### PR TITLE
test(bananass-utils-console): create unit tests for `theme.js`

### DIFF
--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -8,7 +8,7 @@
     "./theme": "./src/theme.js"
   },
   "scripts": {
-    "test": "true"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/packages/bananass-utils-console/src/theme.js
+++ b/packages/bananass-utils-console/src/theme.js
@@ -65,19 +65,6 @@ module.exports.success = (str, showIcon = true) =>
 module.exports.error = (str, showIcon = true) => format(str, showIcon, red, errorIcon);
 
 /**
- * Returns a blue-colored info message prefixed with an icon.
- *
- * @param {string} str The info message to format.
- * @param {boolean} showIcon Whether to show the icon.
- * @returns {string} Returns a blue-colored info message prefixed with an icon.
- *
- * @example
- * console.log(info('Informational message.'));
- * // Output: (icon?) Informational message. (displayed in blue text in the terminal.)
- */
-module.exports.info = (str, showIcon = true) => format(str, showIcon, blue, infoIcon);
-
-/**
  * Returns a yellow-colored warning message prefixed with an icon.
  *
  * @param {string} str The warning message to format.
@@ -90,6 +77,19 @@ module.exports.info = (str, showIcon = true) => format(str, showIcon, blue, info
  */
 module.exports.warning = (str, showIcon = true) =>
   format(str, showIcon, yellow, warningIcon);
+
+/**
+ * Returns a blue-colored info message prefixed with an icon.
+ *
+ * @param {string} str The info message to format.
+ * @param {boolean} showIcon Whether to show the icon.
+ * @returns {string} Returns a blue-colored info message prefixed with an icon.
+ *
+ * @example
+ * console.log(info('Informational message.'));
+ * // Output: (icon?) Informational message. (displayed in blue text in the terminal.)
+ */
+module.exports.info = (str, showIcon = true) => format(str, showIcon, blue, infoIcon);
 
 /**
  * Returns a yellow-colored error message prefixed with an icon.

--- a/packages/bananass-utils-console/src/theme.js
+++ b/packages/bananass-utils-console/src/theme.js
@@ -41,7 +41,7 @@ const format = (str, showIcon, color, icon) =>
  * Returns a green-colored success message prefixed with an icon.
  *
  * @param {string} str The success message to format.
- * @param {boolean} showIcon Whether to show the icon.
+ * @param {boolean} showIcon Whether to show the icon. Defaults to `true`.
  * @returns {string} Returns a green-colored success message prefixed with an icon.
  *
  * @example
@@ -55,7 +55,7 @@ module.exports.success = (str, showIcon = true) =>
  * Returns a red-colored error message prefixed with an icon.
  *
  * @param {string} str The error message to format.
- * @param {boolean} showIcon Whether to show the icon.
+ * @param {boolean} showIcon Whether to show the icon. Defaults to `true`.
  * @returns {string} Returns a red-colored error message prefixed with an icon.
  *
  * @example
@@ -68,7 +68,7 @@ module.exports.error = (str, showIcon = true) => format(str, showIcon, red, erro
  * Returns a yellow-colored warning message prefixed with an icon.
  *
  * @param {string} str The warning message to format.
- * @param {boolean} showIcon Whether to show the icon.
+ * @param {boolean} showIcon Whether to show the icon. Defaults to `true`.
  * @returns {string} Returns a yellow-colored warning message prefixed with an icon.
  *
  * @example
@@ -82,7 +82,7 @@ module.exports.warning = (str, showIcon = true) =>
  * Returns a blue-colored info message prefixed with an icon.
  *
  * @param {string} str The info message to format.
- * @param {boolean} showIcon Whether to show the icon.
+ * @param {boolean} showIcon Whether to show the icon. Defaults to `true`.
  * @returns {string} Returns a blue-colored info message prefixed with an icon.
  *
  * @example
@@ -95,7 +95,7 @@ module.exports.info = (str, showIcon = true) => format(str, showIcon, blue, info
  * Returns a yellow-colored error message prefixed with an icon.
  *
  * @param {string} str The bananass message to format.
- * @param {boolean} showIcon Whether to show the icon.
+ * @param {boolean} showIcon Whether to show the icon. Defaults to `true`.
  * @returns Returns a yellow-colored error message prefixed with an icon.
  *
  * @example

--- a/packages/bananass-utils-console/src/theme.test.js
+++ b/packages/bananass-utils-console/src/theme.test.js
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Test for `theme.js`.
+ */
+
+// --------------------------------------------------------------------------------
+// Require
+// --------------------------------------------------------------------------------
+
+const { strictEqual } = require('node:assert');
+const { describe, it } = require('node:test');
+
+const { green, red, yellow, blue } = require('ansi-colors');
+
+const {
+  successIcon,
+  errorIcon,
+  warningIcon,
+  infoIcon,
+  bananassIcon,
+} = require('./icons');
+const { success, error, warning, info, bananass } = require('./theme');
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('theme.js', () => {
+  describe('success message formatting', () => {
+    const message = 'Operation successful.';
+
+    it('with a icon', () => {
+      strictEqual(success(message), green(`${successIcon} ${message}`));
+    });
+    it('without a icon', () => {
+      strictEqual(success(message, false), green(message));
+    });
+  });
+
+  describe('error message formatting', () => {
+    const message = 'Something went wrong.';
+
+    it('with a icon', () => {
+      strictEqual(error(message), red(`${errorIcon} ${message}`));
+    });
+    it('without a icon', () => {
+      strictEqual(error(message, false), red(message));
+    });
+  });
+
+  describe('warning message formatting', () => {
+    const message = 'This is a warning.';
+
+    it('with a icon', () => {
+      strictEqual(warning(message), yellow(`${warningIcon} ${message}`));
+    });
+    it('without a icon', () => {
+      strictEqual(warning(message, false), yellow(message));
+    });
+  });
+
+  describe('info message formatting', () => {
+    const message = 'Informational message.';
+
+    it('with a icon', () => {
+      strictEqual(info(message), blue(`${infoIcon} ${message}`));
+    });
+    it('without a icon', () => {
+      strictEqual(info(message, false), blue(message));
+    });
+  });
+
+  describe('bananass message formatting', () => {
+    const message = 'Hello, Bananass.';
+
+    it('with a icon', () => {
+      strictEqual(bananass(message), yellow(`${bananassIcon} ${message}`));
+    });
+    it('without a icon', () => {
+      strictEqual(bananass(message, false), yellow(message));
+    });
+  });
+});


### PR DESCRIPTION
This pull request includes several changes to the `bananass-utils-console` package, focusing on improving the `theme.js` file and adding tests. The most important changes include modifying the `test` script in `package.json`, updating the `theme.js` file to set default values for parameters, and adding a comprehensive test suite for `theme.js`.

Changes to `package.json`:

* Modified the `test` script to use `node --test` instead of `true`.

Updates to `theme.js`:

* Updated parameter descriptions to indicate that `showIcon` defaults to `true` in multiple functions. [[1]](diffhunk://#diff-f0bfb1b2c98da1254a13bc8d734f0b69d2d4f6099bc19c2ab9cae42c89d598f5L44-R44) [[2]](diffhunk://#diff-f0bfb1b2c98da1254a13bc8d734f0b69d2d4f6099bc19c2ab9cae42c89d598f5L58-R58) [[3]](diffhunk://#diff-f0bfb1b2c98da1254a13bc8d734f0b69d2d4f6099bc19c2ab9cae42c89d598f5L67-R71)
* Re-added the `info` function with updated parameter descriptions.

Addition of tests:

* Added a new test suite for `theme.js` to verify the formatting of success, error, warning, info, and bananass messages with and without icons.