### PR TITLE
refactor(bananass): improve documentation and shorten `webpackAsync` function

### DIFF
--- a/packages/bananass/src/commands/bananass-build/template.js
+++ b/packages/bananass/src/commands/bananass-build/template.js
@@ -1,8 +1,8 @@
 /**
  * @fileoverview Entry file for the `webpack.js` file.
  *
- * - The `build` function's `webpackConfig.entry` property references this file.
- * - The global variable `BAEKJOON_PROBLEM_NUMBER_WITH_PATH` is defined via the `build` function's `webpackConfig.plugin`'s `new webpack.DefinePlugin`.
+ * The `build` function's `webpackConfigs.entry` property references this file.
+ * The global variable `BAEKJOON_PROBLEM_NUMBER_WITH_PATH` is defined via the `build` function's `webpackConfigs.plugin`'s `new webpack.DefinePlugin`.
  */
 
 // --------------------------------------------------------------------------------

--- a/packages/bananass/src/commands/bananass-build/webpack.js
+++ b/packages/bananass/src/commands/bananass-build/webpack.js
@@ -115,12 +115,12 @@ module.exports = async function build(problems) {
   }));
 
   // ------------------------------------------------------------------------------
-  // Run Webpack
+  // Webpack Excution
   // ------------------------------------------------------------------------------
 
-  function webpackAsync(configs) {
-    return new Promise((res, rej) => {
-      webpack(configs, (err, stats) => {
+  try {
+    await new Promise((res, rej) => {
+      webpack(webpackConfigs, (err, stats) => {
         if (err || stats.hasErrors()) {
           rej(new Error(err || stats.toString()));
         } else {
@@ -128,20 +128,16 @@ module.exports = async function build(problems) {
         }
       });
     });
-  }
-
-  try {
-    await webpackAsync(webpackConfigs);
 
     spinner.success(success('Bananass build completed successfully.', false));
 
     // TODO: add -d, --debug option.
     log(); // new line.
-    log(`- Output Directory: ${resolve(rootDir, OUTPUT_DIRECTORY_NAME)}`); // TODO: reduce redundency using `outputDir` variable.
-    log(`- Created: ${problems.map(problem => `${problem}.js`).join(', ')}`);
+    log(`> Output Directory: ${resolve(rootDir, OUTPUT_DIRECTORY_NAME)}`); // TODO: reduce redundency using of `outputDir` variable.
+    log(`> Created: ${problems.map(problem => `${problem}.js`).join(', ')}`);
   } catch {
     spinner.error();
 
-    throw new Error(error('`webpackAysnc` function run failed.'));
+    throw new Error(error('Webpack run failed.'));
   }
 };

--- a/packages/bananass/src/utils/fs/getRootDir.js
+++ b/packages/bananass/src/utils/fs/getRootDir.js
@@ -1,3 +1,7 @@
+/**
+ * @fileoverview Find and get the root directory path based on the existence of `package.json`.
+ */
+
 // --------------------------------------------------------------------------------
 // Require
 // --------------------------------------------------------------------------------
@@ -6,11 +10,9 @@ const { execSync } = require('node:child_process');
 const { join, resolve } = require('node:path');
 const { existsSync } = require('node:fs');
 
-const {
-  theme: { error },
-  // TODO: Bug Report
-  // eslint-disable-next-line import/no-unresolved
-} = require('bananass-utils-console');
+// TODO: Bug Report
+// eslint-disable-next-line import/no-unresolved
+const { error } = require('bananass-utils-console/theme');
 
 // --------------------------------------------------------------------------------
 // Exports


### PR DESCRIPTION
This pull request includes several changes to improve the `bananass` package by updating comments, refining the webpack execution process, and enhancing the file structure. The most important changes are summarized below:

### Documentation and Comments:

* [`packages/bananass/src/commands/bananass-build/template.js`](diffhunk://#diff-b5f27b403eb4f40a6a77b31a9d86aef95ef86913afbc8779ba275d54708f17efL4-R5): Updated comments to correct the property name from `webpackConfig` to `webpackConfigs` for accuracy.

### Webpack Execution:

* [`packages/bananass/src/commands/bananass-build/webpack.js`](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL118-R141): Refined the webpack execution process by removing the `webpackAsync` function and directly using a promise within a try-catch block. Improved error handling and log messages for better clarity.

### File Structure and Imports:

* [`packages/bananass/src/utils/fs/getRootDir.js`](diffhunk://#diff-70d43515016ae846a4b9b5be1c4f9e0c10f36efdf0b0be0517dfa571c0a14bf5R1-R4): Added a file overview comment to describe the purpose of the file.
* [`packages/bananass/src/utils/fs/getRootDir.js`](diffhunk://#diff-70d43515016ae846a4b9b5be1c4f9e0c10f36efdf0b0be0517dfa571c0a14bf5L9-R15): Simplified the import statement for `error` from `bananass-utils-console/theme` by removing unnecessary destructuring.