### PR TITLE
chore(sync-client): add `.textlintrc.js` to configuration sync

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -61,6 +61,8 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/.prettierignore
   - source: ./.prettierrc.js
     dest: ./configs/.prettierrc.js
+  - source: ./.textlintrc.js
+    dest: ./configs/.textlintrc.js
   - source: ./babel.config.js
     dest: ./configs/babel.config.js
   - source: ./CODE_OF_CONDUCT.md


### PR DESCRIPTION
This pull request includes a small change to the `.github/sync-client.yml` file. The change adds a new configuration file to be synchronized.

* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1R64-R65): Added synchronization for the `.textlintrc.js` configuration file.