### PR TITLE
feat(bananass): add option to clean output directory before emit

### DIFF
--- a/packages/bananass/src/cli.js
+++ b/packages/bananass/src/cli.js
@@ -37,6 +37,7 @@ program
     `build and create bundled files using Webpack from the ${ENTRY_DIRECTORY_NAME_ARRAY.map(dirName => `\`${dirName}\``).join(' or ')} directory and outputs them to the \`${OUTPUT_DIRECTORY_NAME}\` directory`,
   )
   .argument('[problems...]', 'baekjoon problem number list', null)
+  .option('-c, --clean', 'clean the output directory before emit', false)
   .option('-D, --debug', 'enable debug mode', false)
   .option('-q, --quiet', 'enable quiet mode', false)
   .action(async (problems, options, command) => {

--- a/packages/bananass/src/commands/bananass-build/webpack.js
+++ b/packages/bananass/src/commands/bananass-build/webpack.js
@@ -32,6 +32,7 @@ const { getRootDir } = require('../../utils/fs');
  * Asynchronously build and create bundled files using Webpack.
  *
  * @param {string[]} problems Baekjoon problem number list.
+ * @param // TODO
  * @async
  */
 module.exports = async function build(problems, options) {
@@ -104,7 +105,7 @@ module.exports = async function build(problems, options) {
     output: {
       path: resolve(rootDir, OUTPUT_DIRECTORY_NAME),
       filename: `${problem}.js`,
-      // clean: true, // TODO: Clean the output directory before emit.
+      clean: options.clean, // Clean the output directory before emit.
     },
 
     /**


### PR DESCRIPTION
This pull request introduces a new feature to clean the output directory before emitting files and includes some minor documentation updates. The most important changes are:

### New Features:
* Added an option to clean the output directory before emitting files in the `program` of `packages/bananass/src/cli.js`.
* Implemented the `clean` option in the `build` function of `packages/bananass/src/commands/bananass-build/webpack.js`.

### Documentation Updates:
* Added a TODO comment for the new `options` parameter in the `build` function documentation in `packages/bananass/src/commands/bananass-build/webpack.js`.