### PR TITLE
refactor(bananass-build): simplify output directory handling and improve logging

### DIFF
--- a/packages/bananass/src/commands/bananass-build/webpack.js
+++ b/packages/bananass/src/commands/bananass-build/webpack.js
@@ -42,6 +42,7 @@ module.exports = async function build(problems, options) {
 
   const WEBPACK_ENTRY_FILE_NAME = 'template.js';
   const rootDir = getRootDir();
+  const outputDir = resolve(rootDir, OUTPUT_DIRECTORY_NAME);
   const logger = createLogger(options);
   const spinner = createSpinner({
     color: 'yellow',
@@ -103,7 +104,7 @@ module.exports = async function build(problems, options) {
      * See {@link https://webpack.js.org/concepts/#output}.
      */
     output: {
-      path: resolve(rootDir, OUTPUT_DIRECTORY_NAME),
+      path: outputDir,
       filename: `${problem}.js`,
       clean: options.clean, // Clean the output directory before emit.
     },
@@ -140,11 +141,11 @@ module.exports = async function build(problems, options) {
         spinner.success(success('Bananass build completed successfully.', false)),
       )
       .eol()
-      .log(`Output Directory: ${resolve(rootDir, OUTPUT_DIRECTORY_NAME)}`) // TODO: reduce redundency using of `outputDir` variable.
-      .log(`Created: ${problems.map(problem => `${problem}.js`).join(', ')}`);
-  } catch {
+      .log('Output Directory:', outputDir)
+      .log('Created:', problems.map(problem => `${problem}.js`).join(', '));
+  } catch ({ message }) {
     logger.log(() => spinner.error());
 
-    throw new Error(error('Webpack run failed.'));
+    throw new Error(error(`Webpack run failed - ${message}`));
   }
 };


### PR DESCRIPTION
This pull request includes changes to the `packages/bananass/src/commands/bananass-build/webpack.js` file to improve code maintainability and error handling. The most important changes include the introduction of the `outputDir` variable to reduce redundancy and the enhancement of error logging.

Code maintainability improvements:

* Introduced the `outputDir` variable to store the resolved output directory path, reducing redundancy in the code. [[1]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bR45) [[2]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL106-R107) [[3]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL143-R149)

Error handling improvements:

* Enhanced error logging by including the error message in the thrown error when the Webpack run fails.