### PR TITLE
build: update Babel configuration and add TypeScript support

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -65,8 +65,6 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/.prettierrc.js
   - source: ./.textlintrc.js
     dest: ./configs/.textlintrc.js
-  - source: ./babel.config.js
-    dest: ./configs/babel.config.js
   - source: ./CODE_OF_CONDUCT.md
     dest: ./configs/CODE_OF_CONDUCT.md
   - source: ./LICENSE.md

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,12 @@
 module.exports = {
-  presets: ['@babel/preset-env'],
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        modules: false,
+      },
+    ],
+  ],
   ignore: ['**/*.test.js', '**/*.spec.js'],
   minified: true,
   comments: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "nyc": "^17.1.0",
         "prettier": "^3.4.1",
         "textlint": "^14.3.0",
-        "textlint-rule-allowed-uris": "^1.0.6"
+        "textlint-rule-allowed-uris": "^1.0.6",
+        "typescript": "^5.7.2"
       }
     },
     "examples/readline": {
@@ -15475,9 +15476,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16477,6 +16478,9 @@
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       }
     },
     "packages/bananass/node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "nyc": "^17.1.0",
     "prettier": "^3.4.1",
     "textlint": "^14.3.0",
-    "textlint-rule-allowed-uris": "^1.0.6"
+    "textlint-rule-allowed-uris": "^1.0.6",
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/bananass-utils-console/babel.config.cjs
+++ b/packages/bananass-utils-console/babel.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '../../babel.config.js',
+};

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -4,10 +4,22 @@
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {
-    ".": "./build/index.js",
-    "./logger": "./build/logger.js",
-    "./spinner": "./build/spinner.js",
-    "./theme": "./build/theme.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
+    "./logger": {
+      "types": "./build/logger.d.ts",
+      "default": "./build/logger.js"
+    },
+    "./spinner": {
+      "types": "./build/spinner.d.ts",
+      "default": "./build/spinner.js"
+    },
+    "./theme": {
+      "types": "./build/theme.d.ts",
+      "default": "./build/theme.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -41,6 +53,8 @@
     "node": ">=20.18.0"
   },
   "scripts": {
+    "prepublishOnly": "npm run build",
+    "build": "npx babel src -d build && npx tsc && cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
   },
   "dependencies": {

--- a/packages/bananass-utils-console/tsconfig.json
+++ b/packages/bananass-utils-console/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "build"
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+}


### PR DESCRIPTION
This pull request includes several changes focused on updating configuration files, improving TypeScript support, and refining the build and export processes for the `bananass-utils-console` package. Here are the most important changes:

### Configuration Updates:

* Updated `.github/sync-client.yml` to remove the `babel.config.js` synchronization entry.

### TypeScript Support:

* Added TypeScript as a dependency in `package.json`.
* Updated the `exports` field in `packages/bananass-utils-console/package.json` to include TypeScript declaration files.
* Added a `tsconfig.json` file to `packages/bananass-utils-console` to configure TypeScript compilation.

### Build and Export Process:

* Modified `babel.config.js` to prevent module transformation by Babel.
* Added a `babel.config.cjs` file to `packages/bananass-utils-console` to extend the root `babel.config.js`.
* Updated the `scripts` section in `packages/bananass-utils-console/package.json` to include a build script and a `prepublishOnly` script for building before publishing.