### PR TITLE
test(bananass-utils-console): create `logger.test.js` and update `logger.js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16479,8 +16479,40 @@
       "dependencies": {
         "ansi-colors": "^4.1.3"
       },
+      "devDependencies": {
+        "strip-ansi": "^7.1.0"
+      },
       "engines": {
         "node": ">=20.18.0"
+      }
+    },
+    "packages/bananass-utils-console/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/bananass-utils-console/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/bananass/node_modules/commander": {

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -59,5 +59,8 @@
   },
   "dependencies": {
     "ansi-colors": "^4.1.3"
+  },
+  "devDependencies": {
+    "strip-ansi": "^7.1.0"
   }
 }

--- a/packages/bananass-utils-console/src/logger.js
+++ b/packages/bananass-utils-console/src/logger.js
@@ -81,7 +81,15 @@ class Logger {
    * - `quiet === false && debug === true`: output O
    * - `quiet === false && debug === false`: output X
    */
-  debug(textOrCallback, ...args) {
+  debug(...params) {
+    const textOrCallback =
+      typeof params[0] !== 'undefined'
+        ? params[0]
+        : params.length > 0
+          ? undefined
+          : this.#undeclaredValue;
+    const args = params.slice(1);
+
     this.#lastMethodCalled = 'debug';
 
     if (this.#quiet) return this;
@@ -90,12 +98,10 @@ class Logger {
     if (typeof textOrCallback === 'function') {
       textOrCallback(...args);
     } else {
-      const text = textOrCallback ?? '';
-
       console.log(
-        ...[this.#textPrefix, text, ...args].map(arg =>
-          typeof arg === 'string' ? c.gray(arg) : arg,
-        ),
+        ...[this.#textPrefix, textOrCallback, ...args]
+          .filter(arg => arg !== this.#undeclaredValue)
+          .map(arg => (typeof arg === 'string' ? c.gray(arg) : arg)),
       );
     }
 

--- a/packages/bananass-utils-console/src/logger.js
+++ b/packages/bananass-utils-console/src/logger.js
@@ -10,7 +10,7 @@
 // --------------------------------------------------------------------------------
 
 import { log } from 'node:console';
-import { gray } from 'ansi-colors';
+import c from 'ansi-colors';
 
 // --------------------------------------------------------------------------------
 // Class
@@ -78,7 +78,7 @@ class Logger {
 
       log(
         ...[this.#textPrefix, text, ...args].map(arg =>
-          typeof arg === 'string' ? gray(arg) : arg,
+          typeof arg === 'string' ? c.gray(arg) : arg,
         ),
       );
     }

--- a/packages/bananass-utils-console/src/logger.js
+++ b/packages/bananass-utils-console/src/logger.js
@@ -3,13 +3,12 @@
  * @module bananass-utils-console/logger
  */
 
-/* eslint-disable lines-between-class-members */ // TODO: Remove this line after developing `eslint-config-bananass` package.
+/* eslint-disable lines-between-class-members, no-console */ // TODO: Remove this line after developing `eslint-config-bananass` package.
 
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
 
-import { log } from 'node:console';
 import c from 'ansi-colors';
 
 // --------------------------------------------------------------------------------
@@ -52,7 +51,7 @@ class Logger {
     } else {
       const text = textOrCallback ?? '';
 
-      log(...[this.#textPrefix, text, ...args]);
+      console.log(...[this.#textPrefix, text, ...args]);
     }
 
     return this;
@@ -76,7 +75,7 @@ class Logger {
     } else {
       const text = textOrCallback ?? '';
 
-      log(
+      console.log(
         ...[this.#textPrefix, text, ...args].map(arg =>
           typeof arg === 'string' ? c.gray(arg) : arg,
         ),

--- a/packages/bananass-utils-console/src/logger.js
+++ b/packages/bananass-utils-console/src/logger.js
@@ -123,20 +123,8 @@ class Logger {
     return this;
   }
 
-  get textPrefix() {
-    return this.#textPrefix;
-  }
-
-  set textPrefix(text = '>') {
-    this.#textPrefix = text;
-  }
-
   get lastMethodCalled() {
     return this.#lastMethodCalled;
-  }
-
-  set lastMethodCalled(method = 'log') {
-    this.#lastMethodCalled = method;
   }
 }
 

--- a/packages/bananass-utils-console/src/logger.js
+++ b/packages/bananass-utils-console/src/logger.js
@@ -110,7 +110,7 @@ class Logger {
 
   eol() {
     const prevTextPrefix = this.#textPrefix;
-    this.#textPrefix = '';
+    this.#textPrefix = this.#undeclaredValue;
 
     if (this.#lastMethodCalled === 'log') {
       this.log();

--- a/packages/bananass-utils-console/src/logger.test.js
+++ b/packages/bananass-utils-console/src/logger.test.js
@@ -225,6 +225,7 @@ describe('logger.js', () => {
       });
     });
   });
+
   describe('`debug` method', () => {
     // lastMethodCalled
     it("when `debug` method is called, `#lastMethodCalled` should be set to `'debug'`", () => {
@@ -407,6 +408,7 @@ describe('logger.js', () => {
       });
     });
   });
+
   describe('`eol` method', () => {
     it('when `eol` method is called', () => {
       createLogger().eol();

--- a/packages/bananass-utils-console/src/logger.test.js
+++ b/packages/bananass-utils-console/src/logger.test.js
@@ -22,7 +22,7 @@ class ConsoleLogMock {
 
   constructor() {
     mock.method(console, 'log', (...args) => {
-      this.#output += `${args.join(' ')}\n`;
+      this.#output += `${args.map(arg => String(arg)).join(' ')}\n`;
     }); // Mock `console.log` method.
   }
 
@@ -46,44 +46,97 @@ afterEach(() => {
 });
 
 describe('logger.js', () => {
-  describe('default behavior', () => {
-    it('', () => {
-      createLogger().log('Test message');
+  describe('`log` method`', () => {
+    describe('when first argument is not a function', () => {
+      // basic
+      it('when no argument is passed to log method', () => {
+        createLogger().log();
 
-      strictEqual(consoleLogMock.output, '> Test message\n');
+        strictEqual(consoleLogMock.output, '>\n');
+      });
+      it('when only one argment is passed to log method', () => {
+        createLogger().log('a');
+
+        strictEqual(consoleLogMock.output, '> a\n');
+      });
+      it('when two argments are passed to log method', () => {
+        createLogger().log('a', 'b');
+
+        strictEqual(consoleLogMock.output, '> a b\n');
+      });
+      it('when three argments are passed to log method', () => {
+        createLogger().log('a', 'b', 'c');
+
+        strictEqual(consoleLogMock.output, '> a b c\n');
+      });
+
+      // method chaning
+      it('when method chaning is used', () => {
+        createLogger().log('a').log('b');
+
+        strictEqual(consoleLogMock.output, '> a\n> b\n');
+      });
+      it('when method chaning is used multiple times', () => {
+        createLogger().log('a').log('b').log('c').log('d');
+
+        strictEqual(consoleLogMock.output, '> a\n> b\n> c\n> d\n');
+      });
+
+      // edge cases
+      it('when first argument is `null`', () => {
+        createLogger().log(null);
+
+        strictEqual(consoleLogMock.output, '> null\n');
+      });
+      it('when first and second arguments are `null`', () => {
+        createLogger().log(null, null);
+
+        strictEqual(consoleLogMock.output, '> null null\n');
+      });
+      it('when first argument is `undefined`', () => {
+        createLogger().log(undefined);
+
+        strictEqual(consoleLogMock.output, '> undefined\n');
+      });
+      it('when first and second arguments are `undefined`', () => {
+        createLogger().log(undefined, undefined);
+
+        strictEqual(consoleLogMock.output, '> undefined undefined\n');
+      });
     });
-    it('', () => {
-      createLogger().log('Test message 1').log('Test message 2');
 
-      strictEqual(consoleLogMock.output, '> Test message 1\n> Test message 2\n');
-    });
-    it('', () => {
-      createLogger()
-        .log('Test message 1')
-        .log('Test message 2')
-        .log()
-        .log('Test message 3');
+    describe('options', () => {
+      // textPrefix
+      it('when `textPrefix` option is `false` and no argument is passed to log method', () => {
+        createLogger({ textPrefix: false }).log(); // Same with `console.log()`.
 
-      strictEqual(
-        consoleLogMock.output,
-        '> Test message 1\n> Test message 2\n> \n> Test message 3\n',
-      );
+        strictEqual(consoleLogMock.output, '\n');
+      });
+      it('when `textPrefix` option is `false` and only one argment is passed to log method', () => {
+        createLogger({ textPrefix: false }).log('a'); // Same with `console.log('a')`.
+
+        strictEqual(consoleLogMock.output, 'a\n');
+      });
+      it("when `textPrefix` option is `'logger>'` and no argument is passed to log method", () => {
+        createLogger({ textPrefix: 'logger>' }).log(); // Same with `console.log('logger>')`.
+
+        strictEqual(consoleLogMock.output, 'logger>\n');
+      });
+      it("when `textPrefix` option is `'logger>'` and only one argment is passed to log method", () => {
+        createLogger({ textPrefix: 'logger>' }).log('a'); // Same with `console.log('logger>', 'a')`.
+
+        strictEqual(consoleLogMock.output, 'logger> a\n');
+      });
+      it('when `textPrefix` option is an empty string and no argument is passed to log method', () => {
+        createLogger({ textPrefix: '' }).log(); // Same with `console.log('')`.
+
+        strictEqual(consoleLogMock.output, '\n');
+      });
+      it('when `textPrefix` option is an empty string and only one argment is passed to log method', () => {
+        createLogger({ textPrefix: '' }).log('a'); // Same with `console.log('', 'a')`.
+
+        strictEqual(consoleLogMock.output, ' a\n');
+      });
     });
   });
-
-  // describe('options', () => {
-  //   describe('debug', () => {});
-  //   describe('quiet', () => {});
-  //   describe('textPrefix', () => {});
-  // });
-  // it('quiet가 false일 때 log 메소드가 메시지를 출력합니다.', () => {
-  //   logger = createLogger({ quiet: false });
-  //   logger.log('테스트 메시지');
-  //   strictEqual(outputData.trim(), '> 테스트 메시지');
-  // });
-  // it('quiet가 true일 때 log 메소드가 메시지를 출력하지 않습니다.', () => {
-  //   logger = createLogger({ quiet: true });
-  //   logger.log('테스트 메시지');
-  //   strictEqual(outputData.trim(), '');
-  // });
 });

--- a/packages/bananass-utils-console/src/logger.test.js
+++ b/packages/bananass-utils-console/src/logger.test.js
@@ -407,4 +407,21 @@ describe('logger.js', () => {
       });
     });
   });
+  describe('`eol` method', () => {
+    it('when `eol` method is called', () => {
+      createLogger().eol();
+
+      strictEqual(consoleLogMock.output, '\n');
+    });
+    it('when `eol` method is called after `log` method', () => {
+      createLogger().log('a').eol();
+
+      strictEqual(consoleLogMock.output, '> a\n\n');
+    });
+    it('when `eol` method is called after `debug` method', () => {
+      createLogger({ debug: true }).debug('a').eol();
+
+      strictEqual(stripAnsi(consoleLogMock.output), '> a\n\n');
+    });
+  });
 });

--- a/packages/bananass-utils-console/src/logger.test.js
+++ b/packages/bananass-utils-console/src/logger.test.js
@@ -46,7 +46,55 @@ afterEach(() => {
 });
 
 describe('logger.js', () => {
-  describe('`log` method`', () => {
+  describe('`log` method', () => {
+    // lastMethodCalled
+    it("when `log` method is called, `#lastMethodCalled` should be set to `'log'`", () => {
+      strictEqual('log', createLogger().log().lastMethodCalled);
+    });
+
+    describe('when first argument is a function', () => {
+      // basic
+      it('when a callback function is passed to log method without any arguments', () => {
+        const mockFn = mock.fn();
+
+        createLogger().log(mockFn);
+
+        strictEqual(mockFn.mock.callCount(), 1);
+      });
+      it('when a callback function is passed to log method with one argument', () => {
+        const mockFn = mock.fn(a => console.log(a));
+
+        createLogger().log(mockFn, 'a');
+
+        strictEqual(mockFn.mock.callCount(), 1);
+        strictEqual(consoleLogMock.output, 'a\n');
+      });
+      it('when a callback function is passed to log method with multiple arguments', () => {
+        const mockFn = mock.fn((a, b, c) => console.log(a, b, c));
+
+        createLogger().log(mockFn, 'a', 'b', 'c');
+
+        strictEqual(mockFn.mock.callCount(), 1);
+        strictEqual(consoleLogMock.output, 'a b c\n');
+      });
+
+      // method chaining
+      it('when method chaining is used a single time', () => {
+        const mockFn = mock.fn();
+
+        createLogger().log(mockFn).log(mockFn);
+
+        strictEqual(mockFn.mock.callCount(), 2);
+      });
+      it('when method chaining is used multiple times', () => {
+        const mockFn = mock.fn();
+
+        createLogger().log(mockFn).log(mockFn).log(mockFn).log(mockFn);
+
+        strictEqual(mockFn.mock.callCount(), 4);
+      });
+    });
+
     describe('when first argument is not a function', () => {
       // basic
       it('when no argument is passed to log method', () => {
@@ -70,13 +118,13 @@ describe('logger.js', () => {
         strictEqual(consoleLogMock.output, '> a b c\n');
       });
 
-      // method chaning
-      it('when method chaning is used', () => {
+      // method chaining
+      it('when method chaining is used a single time', () => {
         createLogger().log('a').log('b');
 
         strictEqual(consoleLogMock.output, '> a\n> b\n');
       });
-      it('when method chaning is used multiple times', () => {
+      it('when method chaining is used multiple times', () => {
         createLogger().log('a').log('b').log('c').log('d');
 
         strictEqual(consoleLogMock.output, '> a\n> b\n> c\n> d\n');
@@ -106,7 +154,43 @@ describe('logger.js', () => {
     });
 
     describe('options', () => {
+      // quiet
+      it('when `quiet` option is `true` and callback is passed', () => {
+        const mockFn = mock.fn();
+
+        createLogger({ quiet: true }).log(mockFn).log(mockFn);
+
+        strictEqual(mockFn.mock.callCount(), 0);
+      });
+      it('when `quiet` option is `true` and text is passed', () => {
+        createLogger({ quiet: true }).log('a');
+
+        strictEqual(consoleLogMock.output, '');
+      });
+      it('when `quiet` option is `false` and callback is passed', () => {
+        const mockFn = mock.fn();
+
+        createLogger({ quiet: false }).log(mockFn).log(mockFn);
+
+        strictEqual(mockFn.mock.callCount(), 2);
+      });
+      it('when `quiet` option is `false` and text is passed', () => {
+        createLogger({ quiet: false }).log('a');
+
+        strictEqual(consoleLogMock.output, '> a\n');
+      });
+
       // textPrefix
+      it('when `textPrefix` option is `true` and no argument is passed to log method', () => {
+        createLogger({ textPrefix: true }).log();
+
+        strictEqual(consoleLogMock.output, '>\n');
+      });
+      it('when `textPrefix` option is `true` and only one argment is passed to log method', () => {
+        createLogger({ textPrefix: true }).log('a');
+
+        strictEqual(consoleLogMock.output, '> a\n');
+      });
       it('when `textPrefix` option is `false` and no argument is passed to log method', () => {
         createLogger({ textPrefix: false }).log(); // Same with `console.log()`.
 

--- a/packages/bananass-utils-console/src/logger.test.js
+++ b/packages/bananass-utils-console/src/logger.test.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Test for `logger.js`.
+ */
+
+/* eslint-disable import/extensions, no-console */ // TODO: Remove this line after developing `eslint-config-bananass` package.
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { strictEqual } from 'node:assert';
+import { describe, it, mock, afterEach } from 'node:test';
+
+import createLogger from './logger.js';
+
+// --------------------------------------------------------------------------------
+// Mock
+// --------------------------------------------------------------------------------
+
+class ConsoleLogMock {
+  #output = '';
+
+  constructor() {
+    mock.method(console, 'log', (...args) => {
+      this.#output += `${args.join(' ')}\n`;
+    }); // Mock `console.log` method.
+  }
+
+  reset() {
+    this.#output = '';
+  }
+
+  get output() {
+    return this.#output;
+  }
+}
+
+const consoleLogMock = new ConsoleLogMock();
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+afterEach(() => {
+  consoleLogMock.reset();
+});
+
+describe('logger.js', () => {
+  describe('default behavior', () => {
+    it('', () => {
+      createLogger().log('Test message');
+
+      strictEqual(consoleLogMock.output, '> Test message\n');
+    });
+    it('', () => {
+      createLogger().log('Test message 1').log('Test message 2');
+
+      strictEqual(consoleLogMock.output, '> Test message 1\n> Test message 2\n');
+    });
+    it('', () => {
+      createLogger()
+        .log('Test message 1')
+        .log('Test message 2')
+        .log()
+        .log('Test message 3');
+
+      strictEqual(
+        consoleLogMock.output,
+        '> Test message 1\n> Test message 2\n> \n> Test message 3\n',
+      );
+    });
+  });
+
+  // describe('options', () => {
+  //   describe('debug', () => {});
+  //   describe('quiet', () => {});
+  //   describe('textPrefix', () => {});
+  // });
+  // it('quiet가 false일 때 log 메소드가 메시지를 출력합니다.', () => {
+  //   logger = createLogger({ quiet: false });
+  //   logger.log('테스트 메시지');
+  //   strictEqual(outputData.trim(), '> 테스트 메시지');
+  // });
+  // it('quiet가 true일 때 log 메소드가 메시지를 출력하지 않습니다.', () => {
+  //   logger = createLogger({ quiet: true });
+  //   logger.log('테스트 메시지');
+  //   strictEqual(outputData.trim(), '');
+  // });
+});


### PR DESCRIPTION
This pull request includes several changes to the `bananass-utils-console` package, focusing on updating dependencies, modifying the `Logger` class, and improving the handling of text prefixes and logging methods.

### Dependency Updates:
* [`packages/bananass-utils-console/package.json`](diffhunk://#diff-14dc0ab8d918f740c0f0d225fcfbbfdbf6620ab25f1e833d884d3878b35a9a0eR62-R64): Added `strip-ansi` as a development dependency.

### Logger Class Enhancements:
* `packages/bananass-utils-console/src/logger.js`:
  * Updated ESLint disable comments to include additional rules.
  * Replaced `log` import with `ansi-colors` import.
  * Introduced `#textPrefixDefault` and `#undeclaredValue` private fields.
  * Refactored `log` and `debug` methods to handle parameters more flexibly and use `console.log` directly. [[1]](diffhunk://#diff-ca61110b96c84d07f62507411be0440c90521177060be76fd4fddcaeb122cd33L45-R71) [[2]](diffhunk://#diff-ca61110b96c84d07f62507411be0440c90521177060be76fd4fddcaeb122cd33L68-R92) [[3]](diffhunk://#diff-ca61110b96c84d07f62507411be0440c90521177060be76fd4fddcaeb122cd33L77-R104)
  * Modified `eol` method to reset `#textPrefix` to `#undeclaredValue`.
  * Removed getter and setter for `textPrefix` and `lastMethodCalled`.
  * Added JSDoc comment for `createLogger` function.