### PR TITLE
test(bananass-utils-console): add tests for `spinner` functionality and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3076,6 +3076,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sigstore/bundle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
@@ -16482,6 +16489,7 @@
         "is-unicode-supported": "^2.1.0"
       },
       "devDependencies": {
+        "get-stream": "^9.0.1",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
@@ -16501,6 +16509,23 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "packages/bananass-utils-console/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/bananass-utils-console/node_modules/is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -16508,6 +16533,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/bananass-utils-console/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -63,6 +63,7 @@
     "is-unicode-supported": "^2.1.0"
   },
   "devDependencies": {
+    "get-stream": "^9.0.1",
     "strip-ansi": "^7.1.0"
   }
 }

--- a/packages/bananass-utils-console/src/spinner.test.js
+++ b/packages/bananass-utils-console/src/spinner.test.js
@@ -1,0 +1,156 @@
+/**
+ * @fileoverview Test for `spinner.js`.
+ */
+
+/* eslint-disable import/extensions, no-param-reassign */ // TODO: Remove this line after developing `eslint-config-bananass` package.
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { strictEqual, match, ok } from 'node:assert';
+import { describe, it } from 'node:test';
+import process from 'node:process';
+import { PassThrough } from 'node:stream'; // TODO: Remove `PassThrough` and replace it with stream mocking.
+
+import getStream from 'get-stream'; // TODO: Remove `get-stream` devdependency and replace it with stream mocking.
+import stripAnsi from 'strip-ansi';
+
+import createSpinner from './spinner.js';
+
+// --------------------------------------------------------------------------------
+// Declaration
+// --------------------------------------------------------------------------------
+
+delete process.env.CI;
+
+const getPassThroughStream = () => {
+  const stream = new PassThrough();
+
+  stream.clearLine = () => {};
+  stream.cursorTo = () => {};
+  stream.moveCursor = () => {};
+
+  return stream;
+};
+
+const runSpinner = async (callback, options = {}) => {
+  const stream = getPassThroughStream();
+  const spinner = createSpinner({
+    stream,
+    text: 'foo',
+    spinner: {
+      frames: ['-'],
+      interval: 10_000,
+    },
+    ...options,
+  });
+
+  spinner.start();
+  callback(spinner);
+  stream.end();
+
+  return stripAnsi(await getStream(stream));
+};
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('spinner.js', () => {
+  it('start and stop spinner', async () => {
+    const output = await runSpinner(spinner => spinner.stop());
+
+    strictEqual(output, '- foo\n');
+  });
+
+  it('spinner.success()', async () => {
+    const output = await runSpinner(spinner => spinner.success());
+
+    match(output, /✓ foo\n$/);
+  });
+
+  it('spinner.error()', async () => {
+    const output = await runSpinner(spinner => spinner.error());
+
+    match(output, /✕ foo\n$/);
+  });
+
+  it('spinner.warning()', async () => {
+    const output = await runSpinner(spinner => spinner.warning());
+
+    match(output, /⚠ foo\n$/);
+  });
+
+  it('spinner.info()', async () => {
+    const output = await runSpinner(spinner => spinner.info());
+
+    match(output, /✦ foo\n$/);
+  });
+
+  it('spinner changes text', async () => {
+    const output = await runSpinner(spinner => {
+      spinner.text = 'bar';
+      spinner.stop();
+    });
+
+    strictEqual(output, '- foo\n- bar\n');
+  });
+
+  it('spinner stops with final text', async () => {
+    const output = await runSpinner(spinner => spinner.stop('final'));
+
+    match(output, /final\n$/);
+  });
+
+  it('spinner with non-TTY stream', () => {
+    const stream = getPassThroughStream();
+    stream.isTTY = false;
+    const spinner = createSpinner({ stream, text: 'foo' });
+
+    spinner.start();
+    spinner.stop('final');
+
+    ok(true);
+  });
+
+  it('spinner starts with custom text', async () => {
+    const output = await runSpinner(spinner => spinner.stop(), { text: 'custom' });
+
+    strictEqual(output, '- custom\n');
+  });
+
+  it('spinner starts and changes text multiple times', async () => {
+    const output = await runSpinner(spinner => {
+      spinner.text = 'bar';
+      spinner.text = 'baz';
+      spinner.stop();
+    });
+
+    strictEqual(output, '- foo\n- bar\n- baz\n');
+  });
+
+  it('spinner handles multiple start/stop cycles', async () => {
+    const output = await runSpinner(spinner => {
+      spinner.stop();
+      spinner.start('bar');
+      spinner.stop();
+      spinner.start('baz');
+      spinner.stop();
+    });
+
+    strictEqual(output, '- foo\n- bar\n- baz\n');
+  });
+
+  it('spinner stops with success symbol and final text', async () => {
+    const output = await runSpinner(spinner => spinner.success('done'));
+
+    match(output, /✓ done\n$/);
+  });
+
+  it('spinner stops with error symbol and final text', async () => {
+    const output = await runSpinner(spinner => spinner.error('failed'));
+
+    match(output, /✕ failed\n$/);
+  });
+});


### PR DESCRIPTION
This pull request introduces a new test file for the `spinner.js` module and adds a new development dependency to the `bananass-utils-console` package. The primary focus is on enhancing the test coverage for the `spinner.js` functionality.

### Enhancements to test coverage:

* [`packages/bananass-utils-console/src/spinner.test.js`](diffhunk://#diff-c07c0032e447775e33efc82ed90e5c25c75d2e9437b5acb548190f9008e8874aR1-R156): Added comprehensive tests for `spinner.js`, including various scenarios such as starting, stopping, and changing the spinner text, as well as handling different spinner states like success, error, warning, and info.

### Dependency updates:

* [`packages/bananass-utils-console/package.json`](diffhunk://#diff-14dc0ab8d918f740c0f0d225fcfbbfdbf6620ab25f1e833d884d3878b35a9a0eR66): Added `get-stream` as a new development dependency to facilitate stream handling in tests.