### PR TITLE
refactor(bananass-utils-console): add typedef to `icons/index.js`

### DIFF
--- a/packages/bananass-utils-console/src/icons/index.js
+++ b/packages/bananass-utils-console/src/icons/index.js
@@ -12,15 +12,31 @@ import c from 'ansi-colors';
 import isUnicodeSupported from 'is-unicode-supported';
 
 // --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {object} SpinnerIcon
+ * @property {string[]} frames
+ * @property {number} [interval]
+ */
+
+// --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
+/** @type {string} */
 export const successIcon = c.green.bold(isUnicodeSupported() ? '✓' : 'V');
+/** @type {string} */
 export const errorIcon = c.red.bold(isUnicodeSupported() ? '✕' : 'X');
+/** @type {string} */
 export const warningIcon = c.yellow.bold(isUnicodeSupported() ? '⚠' : '!');
+/** @type {string} */
 export const infoIcon = c.blue.bold(isUnicodeSupported() ? '✦' : 'i');
+/** @type {string} */
 export const bananassIcon = c.yellow(isUnicodeSupported() ? '🍌' : '');
 
+/** @type {SpinnerIcon} */
 export const defaultSpinner = {
   frames: isUnicodeSupported()
     ? ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']


### PR DESCRIPTION
This pull request introduces type definitions and annotations to the `packages/bananass-utils-console/src/icons/index.js` file to improve code readability and maintainability.

Key changes:

* Added a `SpinnerIcon` typedef to define the structure of spinner icons.
* Annotated various icon exports (`successIcon`, `errorIcon`, `warningIcon`, `infoIcon`, `bananassIcon`) with type information to specify that they are strings.
* Annotated `defaultSpinner` with the `SpinnerIcon` type to ensure it adheres to the defined structure.