### PR TITLE
chore: add `website` workspace and initialize `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "workspaces": [
         "examples/*",
         "packages/*",
-        "tests/*"
+        "tests/*",
+        "website"
       ],
       "devDependencies": {
         "@babel/cli": "^7.25.9",
@@ -16004,6 +16005,10 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/website": {
+      "resolved": "website",
+      "link": true
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -16587,6 +16592,9 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "website": {
+      "version": "0.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "workspaces": [
     "examples/*",
     "packages/*",
-    "tests/*"
+    "tests/*",
+    "website"
   ],
   "scripts": {
     "prepare": "husky",

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "website",
+  "version": "0.0.0",
+  "scripts": {
+    "start": "echo start"
+  }
+}


### PR DESCRIPTION
This pull request includes changes to support the addition of a new `website` workspace. The most important changes include updating the `workspaces` configuration in `package.json` and adding a `package.json` file for the `website` workspace.

Workspace configuration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R7): Added the `website` directory to the list of workspaces.

New workspace setup:

* [`website/package.json`](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76R1-R8): Created a new `package.json` file for the `website` workspace with basic configuration including a `start` script.