### PR TITLE
chore: update `.markdownlintignore`

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,8 +1,9 @@
 # dependencies
-/node_modules
+node_modules
 
 # production
-/build
+build
+.next
 
 # files
 LICENSE.md


### PR DESCRIPTION
This pull request includes a small change to the `.markdownlintignore` file. The change standardizes the formatting by removing leading slashes from directory names and adds the `.next` directory to the ignore list.