### PR TITLE
chore(examples-solutions-readline-esm): add examples for ESM solutions with readline

### DIFF
--- a/examples/solutions-readline-esm/package.json
+++ b/examples/solutions-readline-esm/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "examples-solutions-readline-esm",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start:1000": "node src/1000"
+  }
+}

--- a/examples/solutions-readline-esm/src/1000.js
+++ b/examples/solutions-readline-esm/src/1000.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Baekjoon 1000
+ * @see https://www.acmicpc.net/problem/1000
+ *
+ * This file runs well in the local environment.
+ * However, if you submit this file to Baekjoon, it will result in a 'Runtime Error (Syntax Error)' in Baekjoon's Node.js environment.
+ * This is because Baekjoon does not support ESM modules. so we need to use CJS modules instead.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { createInterface } from 'node:readline';
+import { stdin as input, stdout as output } from 'node:process';
+import { EOL } from 'node:os';
+import { log } from 'node:console';
+
+// --------------------------------------------------------------------------------
+// Declaration
+// --------------------------------------------------------------------------------
+
+const rl = createInterface({ input, output });
+
+let inputFile = '';
+
+// --------------------------------------------------------------------------------
+// Event Listening
+// --------------------------------------------------------------------------------
+
+rl.on('line', line => {
+  inputFile += `${line}${EOL}`;
+}).on('close', () => {
+  // eslint-disable-next-line no-use-before-define
+  solution(inputFile);
+});
+
+// --------------------------------------------------------------------------------
+// Solution
+// --------------------------------------------------------------------------------
+
+// eslint-disable-next-line no-shadow
+function solution(inputFile) {
+  const [a, b] = inputFile
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  log(a + b);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,10 @@
       "name": "examples-solutions-readline",
       "version": "0.0.0"
     },
+    "examples/solutions-readline-esm": {
+      "name": "examples-solutions-readline-esm",
+      "version": "0.0.0"
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -6866,6 +6870,10 @@
     },
     "node_modules/examples-solutions-readline": {
       "resolved": "examples/solutions-readline",
+      "link": true
+    },
+    "node_modules/examples-solutions-readline-esm": {
+      "resolved": "examples/solutions-readline-esm",
       "link": true
     },
     "node_modules/execa": {
@@ -15783,7 +15791,10 @@
         "webpack": "^5.97.1"
       },
       "bin": {
-        "bananass": "src/cli.js"
+        "bananass": "build/cli.js"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       }
     },
     "packages/bananass-utils": {


### PR DESCRIPTION
This pull request introduces a new example solution for the Baekjoon problem 1000 using ESM (ECMAScript Modules) in Node.js. The changes include the addition of a `package.json` file and the implementation of the solution in a new JavaScript file.

### New Example Solution for Baekjoon Problem 1000:

* [`examples/solutions-readline-esm/package.json`](diffhunk://#diff-dfaffaa92838021bc82c5f59c0831a2254b46a25409b25fffcc1f03a100cefa9R1-R9): Added a new `package.json` file to define the project as a module and include a script for running the solution.

* [`examples/solutions-readline-esm/src/1000.js`](diffhunk://#diff-595afe0897143ed9aae3e84be5c7a0649e33a6f2de08c405c87914e9033f6d61R1-R50): Implemented the solution for Baekjoon problem 1000 using ESM syntax, including imports from Node.js built-in modules and handling user input via the `readline` module.