### PR TITLE
fix: fix broken `editorconfig-checker` by pinning `EC_VERSION` in `lint.yml` workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    env:
+      EC_VERSION: 3.0.3 # Used for `editorconfig-checker`. Pinned to specific version for better security and stability.
+
     steps:
       - name: Set up checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      EC_VERSION: 3.0.3 # Used for `editorconfig-checker`. Pinned to specific version for better security and stability.
+      EC_VERSION: v3.0.3 # Used for `editorconfig-checker`. Pinned to specific version for better security and stability.
 
     steps:
       - name: Set up checkout


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/lint.yml` file to enhance the security and stability of the linting process by pinning the `editorconfig-checker` version.

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R14-R16): Added an environment variable `EC_VERSION` set to `3.0.3` for `editorconfig-checker` to ensure a specific version is used.

Ref: See, https://github.com/editorconfig-checker/editorconfig-checker/issues/409
