### PR TITLE
chore: add `engines` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "name": "npm-bananass",
   "version": "0.0.0",
   "packageManager": "npm@10.9.2",
+  "engines": {
+    "node": ">=20.18.0"
+  },
   "workspaces": [
     "examples/*",
     "packages/*",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change specifies the required Node.js version for the project.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6-R8): Added an `engines` field to specify that the project requires Node.js version 20.18.0 or higher.