### PR TITLE
refactor(prettier-config-bananass): add peerDependencies, prepublish script, type support

### DIFF
--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -29,11 +29,12 @@
   "bugs": {
     "url": "https://github.com/lumirlumir/npm-bananass/issues"
   },
-  "engines": {
-    "node": ">=20.18.0"
-  },
   "scripts": {
+    "prepublishOnly": "npm run build",
     "build": "cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
+  },
+  "peerDependencies": {
+    "prettier": ">=3.0.0"
   }
 }

--- a/packages/prettier-config-bananass/src/index.js
+++ b/packages/prettier-config-bananass/src/index.js
@@ -2,13 +2,14 @@
  * @fileoverview Entry file for the `prettier-config-bananass` package.
  * @module prettier-config-bananass
  *
- * All default values are based on `prettier@3`.
+ * All default values are based on `prettier@3`. {@link https://prettier.io/docs/en/options}
  */
 
 // --------------------------------------------------------------------------------
 // Exports
 // --------------------------------------------------------------------------------
 
+/** @type {import("prettier").Config} */
 module.exports = {
   printWidth: 90,
   tabWidth: 2, // Default.


### PR DESCRIPTION
This pull request includes changes to the `prettier-config-bananass` package to update dependencies and improve documentation. The most important changes include adding a `prepublishOnly` script, specifying `peerDependencies`, and enhancing module documentation.

Updates to dependencies and scripts:

* [`packages/prettier-config-bananass/package.json`](diffhunk://#diff-0fdaf27a6fc3a9c98ce068e2f60dd6fa1d2a82cfc232695581bcae3256c32d76L32-R38): Added a `prepublishOnly` script to run the build process before publishing, and specified `prettier` as a peer dependency.

Enhancements to documentation:

* [`packages/prettier-config-bananass/src/index.js`](diffhunk://#diff-5704c175b00dfba9748074a44221d8bdeafc9a341ed6c6107bb94b85ee8394f5L5-R12): Added a link to the Prettier options documentation in the module overview comment and included a type annotation for the Prettier configuration.