### PR TITLE
chore(deps): bump `editorconfig-checker` from `6.0.0` to `6.0.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/preset-env": "^7.26.0",
         "c8": "^10.1.3",
         "concurrently": "^9.1.0",
-        "editorconfig-checker": "^6.0.0",
+        "editorconfig-checker": "^6.0.1",
         "eslint": "^8.57.1",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^9.1.0",
@@ -6063,9 +6063,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig-checker": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-6.0.0.tgz",
-      "integrity": "sha512-uyTOwLJzR/k7ugiu7ITjCzkLKBhXeirQZ8hGlUkt1u/hq2Qu1E8EslgFZDN+lxZoQc97eiI87sUFgVILK4P+YQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-6.0.1.tgz",
+      "integrity": "sha512-9qhGMJNBSDx+V2w7u8eh47AOMFe+9KWG6hzEG3nlB/7SATo0O65jOrqWbcutrToZh2ojtaGlLhQ9kVocWxwsrw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.26.0",
     "c8": "^10.1.3",
     "concurrently": "^9.1.0",
-    "editorconfig-checker": "^6.0.0",
+    "editorconfig-checker": "^6.0.1",
     "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file. The change updates the version of the `editorconfig-checker` dependency from `6.0.0` to `6.0.1`.