### PR TITLE
revert: "fix: fix broken `editorconfig-checker` by pinning `EC_VERSION` in `lint.yml` workflow (#58)"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    env:
-      EC_VERSION: v3.0.3 # Used for `editorconfig-checker`. Pinned to specific version for better security and stability.
-
     steps:
       - name: Set up checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit 4c92a0bed2775aa9e9c475a2369b53074d7dbd39.

Bug was fixed in `editorconfig-checker` repository. So it is no longer needed.