### PR TITLE
fix(eslint-config-bananass): support additional file extensions in `import/no-extraneous-dependencies` rule

### DIFF
--- a/packages/eslint-config-bananass/src/rules/import-helpful-warnings.js
+++ b/packages/eslint-config-bananass/src/rules/import-helpful-warnings.js
@@ -52,9 +52,9 @@ module.exports = {
         'spec/**', // mocha, rspec-like pattern
         '**/__tests__/**', // jest pattern
         '**/__mocks__/**', // jest pattern
-        'test.{js,jsx}', // repos with a single test file
-        'test-*.{js,jsx}', // repos with multiple top-level test files
-        '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
+        'test.{js,mjs,cjs,jsx}', // repos with a single test file
+        'test-*.{js,mjs,cjs,jsx}', // repos with multiple top-level test files
+        '**/*{.,_}{test,spec}.{js,mjs,cjs,jsx}', // tests where the extension or filename suffix denotes that it is a test
         '**/jest.config.js', // jest config
         '**/jest.setup.js', // jest setup
         '**/vue.config.js', // vue-cli config
@@ -69,6 +69,7 @@ module.exports = {
         '**/protractor.conf.*.js', // protractor config
         '**/karma.conf.js', // karma config
         '**/.eslintrc.js', // eslint config
+        '**/eslint.config.{js,mjs,cjs}', // eslint config
       ],
       optionalDependencies: false,
     },


### PR DESCRIPTION
This pull request includes updates to the ESLint configuration rules in the `import-helpful-warnings.js` file to support additional JavaScript module formats.

Key changes include:

* Updated test file patterns to include `mjs` and `cjs` extensions for better compatibility with different module formats.
* Added a new pattern to recognize ESLint configuration files with `mjs` and `cjs` extensions.