### PR TITLE
refactor(*-config-bananass): update `peerDependencies` to use caret versioning for eslint and prettier

### DIFF
--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -36,7 +36,7 @@
     "build": "cp ../../LICENSE.md ../../README.md ."
   },
   "peerDependencies": {
-    "eslint": ">=9.0.0"
+    "eslint": "^9.0.0"
   },
   "dependencies": {
     "@stylistic/eslint-plugin-js": "^2.12.1",

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -35,6 +35,6 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "prettier": ">=3.0.0"
+    "prettier": "^3.0.0"
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `peerDependencies` versions in the `eslint-config-bananass` and `prettier-config-bananass` packages to ensure compatibility with specific versions of `eslint` and `prettier`.

* [`packages/eslint-config-bananass/package.json`](diffhunk://#diff-e820b85e94fd5b26012547982c44a557398b5c3dc850ac0c4094d184dfd5bcbcL39-R39): Changed `peerDependencies` version for `eslint` from ">=9.0.0" to "^9.0.0".
* [`packages/prettier-config-bananass/package.json`](diffhunk://#diff-0fdaf27a6fc3a9c98ce068e2f60dd6fa1d2a82cfc232695581bcae3256c32d76L38-R38): Changed `peerDependencies` version for `prettier` from ">=3.0.0" to "^3.0.0".