### PR TITLE
fix(eslint-config-bananass): enforce JSX usage in `no-unused-expressions` rule

### DIFF
--- a/packages/eslint-config-bananass/src/rules/eslint-suggestions.js
+++ b/packages/eslint-config-bananass/src/rules/eslint-suggestions.js
@@ -953,7 +953,7 @@ module.exports = {
    * @link eslint: {@link https://eslint.org/docs/latest/rules/no-unused-expressions}
    * @link airbnb-base: {@link https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb-base/rules/best-practices.js#L329-L333}
    */
-  'no-unused-expressions': 'error',
+  'no-unused-expressions': ['error', { enforceForJSX: true }],
 
   /**
    * Disallow unused labels.

--- a/packages/eslint-config-bananass/src/rules/import.test.js
+++ b/packages/eslint-config-bananass/src/rules/import.test.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `import-helpful-warnings.js`, `import-module-systems.js`, `import-static-analysis.js`, and `import-style-guide.js`.
+ * @fileoverview Test for `import-helpful-warnings.js`, `import-module-systems.js`, `import-static-analysis.js`, `import-style-guide.js`.
  */
 
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request includes updates to the ESLint configuration in the `packages/eslint-config-bananass` directory. The most important changes involve modifying the rule for unused expressions and a minor documentation update in the test file.

ESLint rule modification:

* [`packages/eslint-config-bananass/src/rules/eslint-suggestions.js`](diffhunk://#diff-1f40e810e232a16ad4be9fc96b8e5f9c8601d1e880c06207da6297c8f80c51dfL956-R956): Changed the `no-unused-expressions` rule to enforce checks for JSX expressions.

Documentation update:

* [`packages/eslint-config-bananass/src/rules/import.test.js`](diffhunk://#diff-d9bb1e9956c01e11d0b97a58cbb82ddeddb8f93cfb33197200fde583f374b1fcL2-R2): Corrected the file overview comment to remove unnecessary whitespace.