### PR TITLE
chore(dependabot): update configuration to include groups, assignees, and reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,23 +2,46 @@ version: 2
 updates:
   # Maintain dependencies for npm.
   - package-ecosystem: 'npm'
+    assignees:
+      - 'lumirlumir'
     # Specify all directories from the current layer and below recursively, using globstar, for locations of manifest files.
     directories:
       - '**/*'
-    ignore:
-      - dependency-name: 'eslint'
-        versions: ['9']
+    groups:
+      bananass:
+        patterns:
+          - 'eslint-config-bananass'
+          - 'eslint-config-bananass-react'
+          - 'prettier-config-bananass'
+      babel:
+        patterns:
+          - '@babel/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+      next:
+        patterns:
+          - 'next'
+          - '@next/*'
+    reviewers:
+      - 'lumirlumir'
     schedule:
       interval: 'daily'
       time: '10:00'
       timezone: 'Asia/Seoul'
     pull-request-branch-name:
       separator: '-'
+    versioning-strategy: 'increase'
 
   # Maintain dependencies for GitHub Actions.
   - package-ecosystem: 'github-actions'
+    assignees:
+      - 'lumirlumir'
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
+    reviewers:
+      - 'lumirlumir'
     schedule:
       interval: 'weekly'
       day: 'monday'


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yml` file to improve dependency management and assignment. The changes introduce new assignees and reviewers, organize dependencies into groups, and adjust the versioning strategy.

Dependency management improvements:

* Added `assignees` and `reviewers` fields to ensure that 'lumirlumir' is assigned to and reviews the dependency updates for both npm and GitHub Actions.
* Organized npm dependencies into groups (`bananass`, `babel`, `react`, and `next`) to better manage related dependencies.
* Changed the `versioning-strategy` to 'increase' for npm dependencies to ensure a consistent update strategy.