### PR TITLE
chore: remove `website` package and update workspace configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "workspaces": [
         "examples/*",
         "packages/*",
-        "tests/*",
-        "website"
+        "tests/*"
       ],
       "devDependencies": {
         "@babel/cli": "^7.25.9",
@@ -15283,10 +15282,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
-    "node_modules/website": {
-      "resolved": "website",
-      "link": true
-    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -15869,7 +15864,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "^2.12.1",
+        "@stylistic/eslint-plugin-js": "^2.13.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-n": "^17.15.1",
         "globals": "^15.14.0"
@@ -15911,7 +15906,8 @@
       }
     },
     "website": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "extraneous": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "workspaces": [
     "examples/*",
     "packages/*",
-    "tests/*",
-    "website"
+    "tests/*"
   ],
   "scripts": {
     "prepare": "husky",

--- a/website/package.json
+++ b/website/package.json
@@ -1,8 +1,0 @@
-{
-  "private": true,
-  "name": "website",
-  "version": "0.0.0",
-  "scripts": {
-    "start": "echo start"
-  }
-}


### PR DESCRIPTION
This pull request includes changes to the `package.json` files to clean up the workspace configuration by removing the `website` directory. The most important changes include the removal of the `website` workspace and its associated `package.json` file.

Workspace configuration changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R12): Removed the `website` directory from the list of workspaces.
* [`website/package.json`](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L1-L8): Deleted the `package.json` file for the `website` directory, including its scripts and metadata.