### PR TITLE
refactor: remove unnecessary ESLint disable comments across multiple files

### DIFF
--- a/examples/solutions-readline-cjs/src/1000.js
+++ b/examples/solutions-readline-cjs/src/1000.js
@@ -27,7 +27,6 @@ let inputFile = '';
 rl.on('line', line => {
   inputFile += `${line}${EOL}`;
 }).on('close', () => {
-  // eslint-disable-next-line no-use-before-define
   solution(inputFile);
 });
 

--- a/examples/solutions-readline-cjs/src/1001.js
+++ b/examples/solutions-readline-cjs/src/1001.js
@@ -27,7 +27,6 @@ let inputFile = '';
 rl.on('line', line => {
   inputFile += `${line}${EOL}`;
 }).on('close', () => {
-  // eslint-disable-next-line no-use-before-define
   solution(inputFile);
 });
 

--- a/examples/solutions-readline-cjs/src/29751.js
+++ b/examples/solutions-readline-cjs/src/29751.js
@@ -27,7 +27,6 @@ let inputFile = '';
 rl.on('line', line => {
   inputFile += `${line}${EOL}`;
 }).on('close', () => {
-  // eslint-disable-next-line no-use-before-define
   solution(inputFile);
 });
 

--- a/examples/solutions-readline-cjs/templates/index.js
+++ b/examples/solutions-readline-cjs/templates/index.js
@@ -28,7 +28,6 @@ let inputFile = '';
 rl.on('line', line => {
   inputFile += `${line}${EOL}`;
 }).on('close', () => {
-  // eslint-disable-next-line no-use-before-define
   solution(inputFile);
 });
 
@@ -36,7 +35,6 @@ rl.on('line', line => {
 // Solution
 // --------------------------------------------------------------------------------
 
-// eslint-disable-next-line no-shadow
 function solution(inputFile) {
   // Write down your solution here.
 }

--- a/examples/solutions-readline-esm/src/1000.js
+++ b/examples/solutions-readline-esm/src/1000.js
@@ -31,7 +31,6 @@ let inputFile = '';
 rl.on('line', line => {
   inputFile += `${line}${EOL}`;
 }).on('close', () => {
-  // eslint-disable-next-line no-use-before-define
   solution(inputFile);
 });
 

--- a/packages/bananass-utils-console/src/icons/index.js
+++ b/packages/bananass-utils-console/src/icons/index.js
@@ -2,8 +2,6 @@
  * @fileoverview Icons used in the console.
  */
 
-/* eslint-disable import/extensions */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils-console/src/index.js
+++ b/packages/bananass-utils-console/src/index.js
@@ -3,8 +3,6 @@
  * @module bananass-utils-console
  */
 
-/* eslint-disable import/extensions */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils-console/src/logger.js
+++ b/packages/bananass-utils-console/src/logger.js
@@ -3,8 +3,6 @@
  * @module bananass-utils-console/logger
  */
 
-/* eslint-disable lines-between-class-members, no-console, no-nested-ternary */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils-console/src/logger.test.js
+++ b/packages/bananass-utils-console/src/logger.test.js
@@ -2,8 +2,6 @@
  * @fileoverview Test for `logger.js`.
  */
 
-/* eslint-disable import/extensions, no-console */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils-console/src/spinner.js
+++ b/packages/bananass-utils-console/src/spinner.js
@@ -4,8 +4,6 @@
  * @see https://github.com/sindresorhus/yocto-spinner `yocto-spinner` package.
  */
 
-/* eslint-disable lines-between-class-members, import/extensions  */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
@@ -140,7 +138,6 @@ class Spinner {
 
     // SIGINT: 128 + 2
     // SIGTERM: 128 + 15
-    // eslint-disable-next-line no-nested-ternary
     const exitCode = signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 1;
     process.exit(exitCode);
   }
@@ -210,7 +207,6 @@ class Spinner {
 
     this.#stream.cursorTo(0);
 
-    // eslint-disable-next-line no-plusplus
     for (let index = 0; index < this.#lines; index++) {
       if (index > 0) {
         this.#stream.moveCursor(0, -1);

--- a/packages/bananass-utils-console/src/spinner.test.js
+++ b/packages/bananass-utils-console/src/spinner.test.js
@@ -2,7 +2,7 @@
  * @fileoverview Test for `spinner.js`.
  */
 
-/* eslint-disable import/extensions, no-param-reassign */ // TODO: Remove this line after developing `eslint-config-bananass` package.
+/* eslint-disable no-param-reassign */
 
 // --------------------------------------------------------------------------------
 // Import

--- a/packages/bananass-utils-console/src/theme.js
+++ b/packages/bananass-utils-console/src/theme.js
@@ -3,8 +3,6 @@
  * @module bananass-utils-console/theme
  */
 
-/* eslint-disable import/extensions */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils-console/src/theme.test.js
+++ b/packages/bananass-utils-console/src/theme.test.js
@@ -2,8 +2,6 @@
  * @fileoverview Test for `theme.js`.
  */
 
-/* eslint-disable import/extensions */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils/src/fs/getRootDir.js
+++ b/packages/bananass-utils/src/fs/getRootDir.js
@@ -10,8 +10,6 @@ import { join, resolve } from 'node:path';
 import cp from 'node:child_process';
 import fs from 'node:fs';
 
-// TODO: Bug Report
-// eslint-disable-next-line import/no-unresolved
 import { error } from 'bananass-utils-console/theme';
 
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils/src/fs/getRootDir.test.js
+++ b/packages/bananass-utils/src/fs/getRootDir.test.js
@@ -2,8 +2,6 @@
  * @fileoverview Test for `getRootDir.js`.
  */
 
-/* eslint-disable import/extensions */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils/src/fs/index.js
+++ b/packages/bananass-utils/src/fs/index.js
@@ -2,8 +2,6 @@
  * @fileoverview Entry file for the `fs` directory.
  */
 
-/* eslint-disable import/extensions, import/prefer-default-export */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils/src/index.js
+++ b/packages/bananass-utils/src/index.js
@@ -3,8 +3,6 @@
  * @module bananass-utils
  */
 
-/* eslint-disable import/extensions, import/prefer-default-export */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass/src/cli.js
+++ b/packages/bananass/src/cli.js
@@ -4,8 +4,6 @@
  * @fileoverview Entry file for the `npx bananass` CLI command. See the `bin.bananass` property in `../package.json`.
  */
 
-/* eslint-disable import/extensions, import/no-unresolved */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass/src/commands/bananass-build/index.js
+++ b/packages/bananass/src/commands/bananass-build/index.js
@@ -2,8 +2,6 @@
  * @fileoverview Entry file for the `bananass-build` directory.
  */
 
-/* eslint-disable import/extensions */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass/src/commands/bananass-build/webpack.js
+++ b/packages/bananass/src/commands/bananass-build/webpack.js
@@ -2,8 +2,6 @@
  * @fileoverview Asynchronously build and create bundled files using Webpack.
  */
 
-/* eslint-disable import/extensions, import/no-unresolved */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------

--- a/packages/bananass/src/commands/index.js
+++ b/packages/bananass/src/commands/index.js
@@ -2,8 +2,6 @@
  * @fileoverview Entry file for the `commands` directory.
  */
 
-/* eslint-disable import/extensions, import/prefer-default-export */ // TODO: Remove this line after developing `eslint-config-bananass` package.
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request includes several changes focused on removing ESLint disable comments across multiple files and ensuring code adheres to ESLint rules. Additionally, there are some minor code cleanups. Below are the most important changes grouped by theme:

### ESLint Disable Comment Removal:

* Removed `eslint-disable-next-line no-use-before-define` comments from `examples/solutions-readline-cjs/src/1000.js`, `examples/solutions-readline-cjs/src/1001.js`, `examples/solutions-readline-cjs/src/29751.js`, and `examples/solutions-readline-cjs/templates/index.js`. [[1]](diffhunk://#diff-46ebdd887a8fc4a557d2808a06b85e0cfd507681b6d4b013de6031c04419bd76L30) [[2]](diffhunk://#diff-55562616839f52730312c3721da85996ea81543dc1b2105c8e555bf632d9dffeL30) [[3]](diffhunk://#diff-8809619fdc4f36450417342013cc590a3659bb764f1b5bf95c63e87bab850f8bL30) [[4]](diffhunk://#diff-5db8c531a7be26c6f7d1e60d3b3efe0164caf1c8a0b3d8f8236a202a4baaf620L31-L39)
* Removed various `eslint-disable` comments from multiple files in `packages/bananass-utils-console` directory. [[1]](diffhunk://#diff-c14edb8e4ab6ed0399ee7474a0b6b2ed5a227761c5e7ea23877f29cb2575324cL5-L6) [[2]](diffhunk://#diff-6fe2564e60a8ff56b34df5b29a471779ab73903124bfc83af28c2cfed6d360bbL6-L7) [[3]](diffhunk://#diff-ca61110b96c84d07f62507411be0440c90521177060be76fd4fddcaeb122cd33L6-L7) [[4]](diffhunk://#diff-78aba1353849ff270a5f07a3ec7606b054d4c7869d8d4531f55eed2f7463f8f5L5-L6) [[5]](diffhunk://#diff-a57af170b8c724600897a5102de4eb2c0a4360d0e34086c8867da06cfc52d6ebL7-L8) [[6]](diffhunk://#diff-f0bfb1b2c98da1254a13bc8d734f0b69d2d4f6099bc19c2ab9cae42c89d598f5L6-L7) [[7]](diffhunk://#diff-afb4d97a13865c03ee89b3c26cad5e431be48766f17debd17f8fb042020839b2L5-L6)
* Removed `eslint-disable` comments from files in `packages/bananass-utils` directory. [[1]](diffhunk://#diff-2d73861b7a48a161b6c7da8bc708a835f7ed4980c32798208f340991861d2bd6L13-L14) [[2]](diffhunk://#diff-c0482ef0af3b1ae543cd63149daad3275a533bcf07ee593e896d1d88e94504e3L5-L6) [[3]](diffhunk://#diff-d309721639755fea30f691711d2b84d859f75dc4f3e0cc4bebdf786c00570d5fL5-L6) [[4]](diffhunk://#diff-63cf995490728ee71e1a41cc3d6e933dbb9598f4d8a66dd0a73545c5cea7c0eeL6-L7)
* Removed `eslint-disable` comments from files in `packages/bananass` directory. [[1]](diffhunk://#diff-6544fc29ddb1c7332552c44ae9262c59f8067412edbd9d71bbfe3edd7472813dL7-L8) [[2]](diffhunk://#diff-90b79afa43cb42d95418d7fb035b8812370e8f979e41e7c1ddd682a4657499e1L5-L6) [[3]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL5-L6)

### Code Cleanup:

* Removed inline ESLint disable comments within `Spinner` class methods in `packages/bananass-utils-console/src/spinner.js`. [[1]](diffhunk://#diff-a57af170b8c724600897a5102de4eb2c0a4360d0e34086c8867da06cfc52d6ebL143) [[2]](diffhunk://#diff-a57af170b8c724600897a5102de4eb2c0a4360d0e34086c8867da06cfc52d6ebL213)
* Updated `packages/bananass-utils-console/src/spinner.test.js` to retain only relevant `eslint-disable` comment.