### PR TITLE
feat: update `package.json` exports to include `package.json` file

### DIFF
--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -7,7 +7,8 @@
     ".": {
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "bananass": "build/cli.js"

--- a/packages/eslint-config-bananass-react/package.json
+++ b/packages/eslint-config-bananass-react/package.json
@@ -2,7 +2,12 @@
   "name": "eslint-config-bananass-react",
   "version": "0.0.0",
   "description": "ESLint Config for Bananass Framework with React.🍌",
-  "exports": "./src/index.js",
+  "exports": {
+    ".": {
+      "default": "./src/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
     "LICENSE.md",

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -2,7 +2,12 @@
   "name": "eslint-config-bananass",
   "version": "0.0.0",
   "description": "ESLint Config for Bananass Framework.🍌",
-  "exports": "./src/index.js",
+  "exports": {
+    ".": {
+      "default": "./src/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
     "LICENSE.md",

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -2,7 +2,12 @@
   "name": "prettier-config-bananass",
   "version": "0.0.0",
   "description": "Prettier Config for Bananass Framework.🍌",
-  "exports": "./src/index.js",
+  "exports": {
+    ".": {
+      "default": "./src/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "src/index.js",
     "LICENSE.md",


### PR DESCRIPTION
This pull request includes changes to several `package.json` files to improve the handling of package exports. The changes ensure that the `package.json` file itself is also included in the exports.

Changes to `package.json` files:

* [`packages/bananass/package.json`](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432L10-R11): Added `./package.json` to the exports.
* [`packages/eslint-config-bananass-react/package.json`](diffhunk://#diff-263baf2bd4636e9041e07fa4d170bdde1545c6a48947ab5ff1f511e289d53356L5-R10): Modified the exports to include `./package.json` and structured the default export.
* [`packages/eslint-config-bananass/package.json`](diffhunk://#diff-e820b85e94fd5b26012547982c44a557398b5c3dc850ac0c4094d184dfd5bcbcL5-R10): Modified the exports to include `./package.json` and structured the default export.
* [`packages/prettier-config-bananass/package.json`](diffhunk://#diff-0fdaf27a6fc3a9c98ce068e2f60dd6fa1d2a82cfc232695581bcae3256c32d76L5-R10): Modified the exports to include `./package.json` and structured the default export.