### PR TITLE
feat(bananass-utils-console): add `typesVersions` to `package.json` for improved type definitions

### DIFF
--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -22,6 +22,22 @@
     },
     "./package.json": "./package.json"
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./build/*"
+      ],
+      "logger": [
+        "./build/logger.d.ts"
+      ],
+      "spinner": [
+        "./build/spinner.d.ts"
+      ],
+      "theme": [
+        "./build/theme.d.ts"
+      ]
+    }
+  },
   "files": [
     "build",
     "LICENSE.md",

--- a/packages/bananass-utils-console/tsconfig.json
+++ b/packages/bananass-utils-console/tsconfig.json
@@ -3,7 +3,9 @@
     "allowJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "build"
+    "outDir": "build",
+    "target": "ESNext",
+    "moduleResolution": "Node"
   },
   "include": ["src/**/*.js"],
   "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]

--- a/packages/bananass-utils/tsconfig.json
+++ b/packages/bananass-utils/tsconfig.json
@@ -3,7 +3,9 @@
     "allowJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "build"
+    "outDir": "build",
+    "target": "ESNext",
+    "moduleResolution": "Node"
   },
   "include": ["src/**/*.js"],
   "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]

--- a/packages/bananass/tsconfig.json
+++ b/packages/bananass/tsconfig.json
@@ -3,7 +3,9 @@
     "allowJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "build"
+    "outDir": "build",
+    "target": "ESNext",
+    "moduleResolution": "Node"
   },
   "include": ["src/**/*.js"],
   "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]


### PR DESCRIPTION
This pull request includes changes to the TypeScript configuration and package settings for several packages to improve compatibility and module resolution. The most important changes include adding `typesVersions` to the `package.json` file and updating the `tsconfig.json` files to target `ESNext` and use `Node` module resolution.

Updates to `package.json`:

* [`packages/bananass-utils-console/package.json`](diffhunk://#diff-14dc0ab8d918f740c0f0d225fcfbbfdbf6620ab25f1e833d884d3878b35a9a0eR25-R40): Added `typesVersions` to specify different type definitions for different modules.

Updates to `tsconfig.json`:

* [`packages/bananass-utils-console/tsconfig.json`](diffhunk://#diff-00d843065b36c05dd508bb0a94f06c16cc20bb2c4a760080908e336b719d3232L6-R8): Updated to target `ESNext` and use `Node` module resolution.
* [`packages/bananass-utils/tsconfig.json`](diffhunk://#diff-00d843065b36c05dd508bb0a94f06c16cc20bb2c4a760080908e336b719d3232L6-R8): Updated to target `ESNext` and use `Node` module resolution.
* [`packages/bananass/tsconfig.json`](diffhunk://#diff-00d843065b36c05dd508bb0a94f06c16cc20bb2c4a760080908e336b719d3232L6-R8): Updated to target `ESNext` and use `Node` module resolution.