### PR TITLE
chore: update `.editorconfig-checker.json` to remove excluded files and tidy up `docs/archived.md`

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,3 +1,3 @@
 {
-  "Exclude": ["docs/archived.md"]
+  "Exclude": []
 }

--- a/docs/archived.md
+++ b/docs/archived.md
@@ -84,21 +84,21 @@ git clone https://github.com/lumirlumir/PS_Framework.git
 
 ```bash
 📦PS_Framework
- ┣ 📂.github
- ┃ ┗ 📂workflows
- ┃   ┗ 📜SyntaxCheck.yaml # Git: Github Workflows 설정 파일.
- ┣ 📂.vscode
- ┃ ┗ 📜settings.json # VScode: Editor 설정 파일.
- ┣ 📂Src
- ┃ ┗ 📂* (Baekjoon, Programmers or Etc.)
- ┃   ┣ 📂Blogged # 블로그에 게시된 문제 저장.
- ┃   ┣ 📂Solved # 다 푼 문제 저장.
- ┃   ┗ 📂Unsolved # 아직 풀고있는 문제 저장.
- ┣ 📜.clang-format # C/C++: Convention 설정 파일.
- ┣ 📜.editorconfig # EditorConfig: Covention 설정 파일.
- ┣ 📜.gitignore # Git: Gitignore 설정 파일.
- ┣ 📜README.md # Git: README 파일.
- ┗ 📜VScode.code-workspace # VScode: Workspace 설정 파일.
+┣ 📂.github
+┃ ┗ 📂workflows
+┃   ┗ 📜SyntaxCheck.yaml # Git: Github Workflows 설정 파일.
+┣ 📂.vscode
+┃ ┗ 📜settings.json # VScode: Editor 설정 파일.
+┣ 📂Src
+┃ ┗ 📂* (Baekjoon, Programmers or Etc.)
+┃   ┣ 📂Blogged # 블로그에 게시된 문제 저장.
+┃   ┣ 📂Solved # 다 푼 문제 저장.
+┃   ┗ 📂Unsolved # 아직 풀고있는 문제 저장.
+┣ 📜.clang-format # C/C++: Convention 설정 파일.
+┣ 📜.editorconfig # EditorConfig: Covention 설정 파일.
+┣ 📜.gitignore # Git: Gitignore 설정 파일.
+┣ 📜README.md # Git: README 파일.
+┗ 📜VScode.code-workspace # VScode: Workspace 설정 파일.
 ```
 
 ## 4. Others


### PR DESCRIPTION
This pull request includes a small change to the `.editorconfig-checker.json` file. The change removes the exclusion of the `docs/archived.md` file from the configuration. 

* [`.editorconfig-checker.json`](diffhunk://#diff-ffc189b5d4f8c2eb9a171e067565fbfe9ecba9a5b717d236cbf22497973fc4a3L2-R2): Removed the exclusion of the `docs/archived.md` file from the `Exclude` list.