### PR TITLE
chore: add Vercel ignore command script and update configuration for multiple websites

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -42,6 +42,9 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/.vscode/npm-extensions.json
   - source: ./.vscode/settings.json
     dest: ./configs/.vscode/settings.json
+  # ./scripts
+  - source: ./scripts/vercel-ignore-command.sh
+    dest: ./configs/scripts/vercel-ignore-command.sh
   # ./
   - source: ./.editorconfig
     dest: ./configs/.editorconfig

--- a/scripts/vercel-ignore-command.sh
+++ b/scripts/vercel-ignore-command.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# If the PR is created by `dependabot[bot]` and the branch is not `main`, ignore the build.
+if [ "$VERCEL_GIT_COMMIT_AUTHOR_LOGIN" = "dependabot[bot]" ] && [ "$VERCEL_GIT_COMMIT_REF" != "main" ]; then
+  echo "🛑 Ignoring build for dependabot[bot] PR (branch: $VERCEL_GIT_COMMIT_REF, author: $VERCEL_GIT_COMMIT_AUTHOR_LOGIN)"
+  exit 0 # Return `0` to skip the build.
+fi
+
+# Proceed with the build in other cases.
+echo "✅ Proceeding with the build (branch: $VERCEL_GIT_COMMIT_REF, author: $VERCEL_GIT_COMMIT_AUTHOR_LOGIN)"
+exit 1 # Return `1` to proceed with build.

--- a/websites/eslint-config-bananass-react/vercel.json
+++ b/websites/eslint-config-bananass-react/vercel.json
@@ -1,7 +1,6 @@
 {
   "buildCommand": "npm run build",
-  "cleanUrls": true,
-  "framework": "vitepress",
+  "framework": null,
   "ignoreCommand": "bash  ../../scripts/vercel-ignore-command.sh",
   "installCommand": "npm install --prefix ../..",
   "outputDirectory": "build",

--- a/websites/eslint-config-bananass/vercel.json
+++ b/websites/eslint-config-bananass/vercel.json
@@ -1,7 +1,6 @@
 {
   "buildCommand": "npm run build",
-  "cleanUrls": true,
-  "framework": "vitepress",
+  "framework": null,
   "ignoreCommand": "bash  ../../scripts/vercel-ignore-command.sh",
   "installCommand": "npm install --prefix ../..",
   "outputDirectory": "build",


### PR DESCRIPTION
This pull request includes several changes to improve the build process and configuration for various projects. The most important changes include adding a new script to ignore builds for certain pull requests, updating the Vercel configuration files, and modifying the sync-client configuration.

### Build process improvements:

* Added a new script `vercel-ignore-command.sh` to ignore builds for pull requests created by `dependabot[bot]` if the branch is not `main`. (`scripts/vercel-ignore-command.sh`)

### Configuration updates:

* Updated the Vercel configuration for `eslint-config-bananass-react` to include build, ignore, and install commands, and specified the output directory and regions. (`websites/eslint-config-bananass-react/vercel.json`)
* Updated the Vercel configuration for `eslint-config-bananass` to include build, ignore, and install commands, and specified the output directory and regions. (`websites/eslint-config-bananass/vercel.json`)
* Updated the Vercel configuration for `vitepress` to include build, ignore, and install commands, and specified the output directory and regions. (`websites/vitepress/vercel.json`)

### Sync-client configuration:

* Modified `.github/sync-client.yml` to include the new script in the sync process. (`.github/sync-client.yml`)