### PR TITLE
chore: exclude test files from `package.json` `files` array in eslint and prettier configs

### DIFF
--- a/packages/eslint-config-bananass-react/package.json
+++ b/packages/eslint-config-bananass-react/package.json
@@ -10,6 +10,8 @@
   },
   "files": [
     "src",
+    "!src/**/*.test.js",
+    "!src/**/*.spec.js",
     "LICENSE.md",
     "README.md"
   ],

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -10,6 +10,8 @@
   },
   "files": [
     "src",
+    "!src/**/*.test.js",
+    "!src/**/*.spec.js",
     "LICENSE.md",
     "README.md"
   ],

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -9,7 +9,9 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "src/index.js",
+    "src",
+    "!src/**/*.test.js",
+    "!src/**/*.spec.js",
     "LICENSE.md",
     "README.md"
   ],


### PR DESCRIPTION
This pull request includes changes to the `package.json` files of several packages to exclude test and spec files from the published packages. 

Changes to exclude test and spec files:

* [`packages/eslint-config-bananass-react/package.json`](diffhunk://#diff-263baf2bd4636e9041e07fa4d170bdde1545c6a48947ab5ff1f511e289d53356R13-R14): Added exclusions for `src/**/*.test.js` and `src/**/*.spec.js` files.
* [`packages/eslint-config-bananass/package.json`](diffhunk://#diff-e820b85e94fd5b26012547982c44a557398b5c3dc850ac0c4094d184dfd5bcbcR13-R14): Added exclusions for `src/**/*.test.js` and `src/**/*.spec.js` files.
* [`packages/prettier-config-bananass/package.json`](diffhunk://#diff-0fdaf27a6fc3a9c98ce068e2f60dd6fa1d2a82cfc232695581bcae3256c32d76L12-R14): Changed the `files` field to include the entire `src` directory and added exclusions for `src/**/*.test.js` and `src/**/*.spec.js` files.