### PR TITLE
feat(eslint-config-bananass): remove unnecessary `ForOfStatement` warning and add Vitepress config to import warnings

### DIFF
--- a/packages/eslint-config-bananass/src/rules/eslint-suggestions.js
+++ b/packages/eslint-config-bananass/src/rules/eslint-suggestions.js
@@ -849,11 +849,6 @@ module.exports = {
       message:
         'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use `Object.{keys,values,entries}`, and iterate over the resulting array.',
     },
-    {
-      selector: 'ForOfStatement',
-      message:
-        'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
-    },
   ],
 
   /**

--- a/packages/eslint-config-bananass/src/rules/import-helpful-warnings.js
+++ b/packages/eslint-config-bananass/src/rules/import-helpful-warnings.js
@@ -70,6 +70,7 @@ module.exports = {
         '**/karma.conf.js', // karma config
         '**/.eslintrc.js', // eslint config
         '**/eslint.config.{js,mjs,cjs}', // eslint config
+        '**/.vitepress/**/*.{js,mjs,cjs}', // vitepress config
       ],
       optionalDependencies: false,
     },


### PR DESCRIPTION
This pull request includes changes to the ESLint configuration files to improve code quality and add support for VitePress configuration files. The most important changes are:

Improvements to ESLint rules:

* [`packages/eslint-config-bananass/src/rules/eslint-suggestions.js`](diffhunk://#diff-1f40e810e232a16ad4be9fc96b8e5f9c8601d1e880c06207da6297c8f80c51dfL852-L856): Removed the rule that disallowed `ForOfStatement` due to its requirement for regenerator-runtime and preference for array iterations.

Support for additional configuration files:

* [`packages/eslint-config-bananass/src/rules/import-helpful-warnings.js`](diffhunk://#diff-79ecb0b15195b09eb33fa02b122f31c3b379af45d9104d40cad485e5aaa80dd9R73): Added support for VitePress configuration files by including them in the list of files to be linted.