### PR TITLE
build(bananass): delete babel to simplify build process as Bananass only support node >= 20.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20771,7 +20771,7 @@
         "webpack": "^5.97.1"
       },
       "bin": {
-        "bananass": "build/cli.js"
+        "bananass": "src/cli.js"
       },
       "engines": {
         "node": ">=20.18.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "dev:ws:ecbr": "npm run dev -w websites/eslint-config-bananass-react",
     "dev:ws:vp": "npm run dev -w websites/vitepress",
     "start": "npm run start:ws:vp",
-    "start:pkg:b": "npm run start -w packages/bananass",
     "start:ws:vp": "npm run start -w websites/vitepress",
     "fix": "concurrently \"npm:fix:*\"",
     "fix:eslint": "npx eslint --fix",

--- a/packages/bananass/babel.config.cjs
+++ b/packages/bananass/babel.config.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: '../../babel.config.js',
-};

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -6,17 +6,21 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
-      "default": "./build/index.js"
+      "default": "./src/index.js"
     },
     "./package.json": "./package.json"
   },
   "bin": {
-    "bananass": "build/cli.js"
+    "bananass": "src/cli.js"
   },
   "files": [
+    "src",
     "build",
     "LICENSE.md",
-    "README.md"
+    "README.md",
+    "!src/**/*.test.js",
+    "!src/**/*.spec.js",
+    "!**/fixtures/**"
   ],
   "keywords": [
     "bananass",
@@ -42,10 +46,9 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && cp ../../LICENSE.md ../../README.md .",
+    "build": "npx tsc && cp ../../LICENSE.md ../../README.md .",
     "test": "node --test",
-    "dev": "node src/cli.js",
-    "start": "node build/cli.js"
+    "dev": "node src/cli.js"
   },
   "dependencies": {
     "bananass-utils": "^0.0.0",


### PR DESCRIPTION
This pull request includes several changes to the `packages/bananass` package and the overall project configuration. The most important changes involve the removal of the Babel configuration, updates to the `package.json` scripts and exports, and adjustments to the files included in the package.

### Changes to `packages/bananass`:

* [`packages/bananass/babel.config.cjs`](diffhunk://#diff-71c0b4cdbbbd259d8127e792bcb71a898be780767c98686dfcc9fb5ce9a9c026L1-L3): Removed the Babel configuration file as it is no longer needed.
* [`packages/bananass/package.json`](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432L9-R23): Updated the `exports` field to point to the source files instead of the build files, and adjusted the `bin` field to reference the source CLI file.
* [`packages/bananass/package.json`](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432L45-R51): Modified the `build` script to remove Babel and only use TypeScript for building, and updated the `dev` and `start` scripts to use the source CLI file.
* [`packages/bananass/package.json`](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432L9-R23): Added `src` to the `files` array and excluded test and fixture files from the package.

### Changes to project configuration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L43): Removed the `start:pkg:b` script as it is no longer needed.