### PR TITLE
feat(bananass): add `outDir` option to `build` command

### DIFF
--- a/packages/bananass/src/cli/bananass-build.js
+++ b/packages/bananass/src/cli/bananass-build.js
@@ -10,7 +10,7 @@ import logger from 'bananass-utils-console/logger';
 
 import { build } from '../commands/index.js';
 import { configLoader, defaultConfigObject } from '../core/conf/index.js';
-import { ENTRY_DIR_NAME_ARRAY, OUTPUT_DIR_NAME_ARRAY } from '../core/constants.js';
+import { ENTRY_DIR_NAME_ARRAY } from '../core/constants.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -38,27 +38,21 @@ function toInlineCodeString(arr) {
  * @param {Command} program The `commander` package's `program`.
  */
 export default function bananassBuild(program) {
+  const { clean, debug, outDir, quiet, templateType } = defaultConfigObject.build;
+
   program
     .command('build')
     .description(
-      `build and create bundled files using Webpack from the ${toInlineCodeString(ENTRY_DIR_NAME_ARRAY)} directory and outputs them to the ${toInlineCodeString(OUTPUT_DIR_NAME_ARRAY)} directory`,
+      `build and create bundled files using webpack and babel from the ${toInlineCodeString(ENTRY_DIR_NAME_ARRAY)} directory and outputs them to the \`${outDir}\` directory`,
     )
     .argument('[problems...]', 'baekjoon problem number list', null)
-    .option(
-      '-c, --clean',
-      `clean the output directory before emit (default: ${defaultConfigObject.build.clean})`,
-    ) // DO NOT USE `Default option value` of `commander` package as it overrides the every other options from the config file. Same goes for the other options.
-    .option(
-      '-D, --debug',
-      `enable debug mode (default: ${defaultConfigObject.build.debug})`,
-    )
-    .option(
-      '-q, --quiet',
-      `enable quiet mode (default: ${defaultConfigObject.build.quiet})`,
-    )
+    .option('-c, --clean', `clean the output directory before emit (default: ${clean})`) // DO NOT USE `Default option value` of `commander` package as it overrides the every other options from the config file. Same goes for the other options.
+    .option('-D, --debug', `enable debug mode (default: ${debug})`)
+    .option('-o, --out-dir <dir>', `output directory name (default: ${outDir})`)
+    .option('-q, --quiet', `enable quiet mode (default: ${quiet})`)
     .option(
       '-t, --template-type <type>',
-      `Webpack entry file template type. Select from 'fs' (File System) or 'rl' (Read Line) (default: ${defaultConfigObject.build.templateType})`,
+      `webpack entry file template type. select from \`fs\` (file system) or \`rl\` (read line) (default: ${templateType})`,
     )
     .action(async (problems, options, command) => {
       const cliConfigObject = { build: options };

--- a/packages/bananass/src/commands/bananass-build/webpack.js
+++ b/packages/bananass/src/commands/bananass-build/webpack.js
@@ -16,10 +16,7 @@ import createSpinner from 'bananass-utils-console/spinner';
 import { bananass, success, error } from 'bananass-utils-console/theme';
 import webpack from 'webpack';
 
-import {
-  OUTPUT_DIR_NAME_ARRAY,
-  BAEKJOON_PROBLEM_NUMBER_MIN,
-} from '../../core/constants.js';
+import { BAEKJOON_PROBLEM_NUMBER_MIN } from '../../core/constants.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -44,12 +41,10 @@ export default async function build(problems, { build: options }) {
   // ------------------------------------------------------------------------------
   // Declaration
   // ------------------------------------------------------------------------------
-  const { templateType } = options;
-
-  const webpackEntryFileName = `template-${templateType}.cjs`;
-
+  const webpackEntryFileName = `template-${options.templateType}.cjs`;
   const rootDir = getRootDir();
-  const outputDir = resolve(rootDir, OUTPUT_DIR_NAME_ARRAY[0]);
+  const outDir = resolve(rootDir, options.outDir);
+
   const logger = createLogger(options);
   const spinner = createSpinner({
     color: 'yellow',
@@ -108,7 +103,7 @@ export default async function build(problems, { build: options }) {
      * See {@link https://webpack.js.org/concepts/#output}.
      */
     output: {
-      path: outputDir,
+      path: outDir,
       filename: `${problem}.js`,
       // clean: options.clean, // DO NOT USE THIS OPTION.
     },
@@ -137,7 +132,7 @@ export default async function build(problems, { build: options }) {
     // Secondly, even if we use `webpackConfigs.output.clean` only once with the `map()` method's `index` parameter,
     // it cannot guarantee the build order and may lead to race conditions where files get deleted unpredictably.
     if (options.clean) {
-      rmSync(outputDir, { recursive: true, force: true });
+      rmSync(outDir, { recursive: true, force: true });
     }
 
     await new Promise((res, rej) => {
@@ -155,7 +150,7 @@ export default async function build(problems, { build: options }) {
         spinner.success(success('Bananass build completed successfully.', false)),
       )
       .eol()
-      .log('Output Directory:', outputDir)
+      .log('Output Directory:', outDir)
       .log('Created:', problems.map(problem => `${problem}.js`).join(', '));
   } catch ({ message }) {
     logger.log(() => spinner.error());

--- a/packages/bananass/src/core/conf/default-config-object/default-config-object.js
+++ b/packages/bananass/src/core/conf/default-config-object/default-config-object.js
@@ -6,6 +6,12 @@
 // Typedefs
 // --------------------------------------------------------------------------------
 
+import { DEFAULT_OUT_DIR_NAME } from '../../constants.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
 /**
  * @typedef {import('../../types.js').ConfigObject} ConfigObject
  * @typedef {import('../../types.js').ConfigObjectAddOptions} ConfigObjectAddOptions
@@ -33,6 +39,7 @@ const add = {};
 const build = {
   clean: false,
   debug: false,
+  outDir: DEFAULT_OUT_DIR_NAME,
   quiet: false,
   templateType: 'fs',
 };

--- a/packages/bananass/src/core/constants.js
+++ b/packages/bananass/src/core/constants.js
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { createRequire } from 'node:module';
-import { format, join } from 'node:path';
+import { join } from 'node:path';
 
 // --------------------------------------------------------------------------------
 // Declaration
@@ -34,23 +34,11 @@ export const PKG_NAME = name;
 /** @type string */
 export const PKG_VERSION = version;
 
+export const DEFAULT_OUT_DIR_NAME = `.${name}`;
+
 /* Array */
 // Array constants with `NAME` in their name must not include the extension.
 // Array constants with `BASE` in their name must include the extension.
 export const JS_EXT_ARRAY = Object.freeze(['.js', '.cjs', '.mjs']);
 export const PACKAGE_JSON_FILE_BASE_ARRAY = Object.freeze(['package.json']);
 export const ENTRY_DIR_NAME_ARRAY = Object.freeze([name, join('src', name)]);
-export const OUTPUT_DIR_NAME_ARRAY = Object.freeze([`.${name}`]);
-export const BANANASS_CONFIG_FILE_NAME_ARRAY = Object.freeze([
-  `${name}.config`,
-  `.${name}rc`,
-]);
-export const BANANASS_CONFIG_FILE_BASE_ARRAY = Object.freeze(
-  BANANASS_CONFIG_FILE_NAME_ARRAY.flatMap(configFileName =>
-    JS_EXT_ARRAY.map(ext => format({ name: configFileName, ext })),
-  ),
-);
-export const WEBPACK_ENTRY_FILE_TEMPLATE_TYPE_ARRAY = Object.freeze([
-  'fs', // File System
-  'rl', // Read Line
-]);

--- a/packages/bananass/src/core/types.js
+++ b/packages/bananass/src/core/types.js
@@ -30,6 +30,7 @@
  * @typedef {object} ConfigObjectBuildOptions
  * @property {boolean} clean Clean the output directory before emit.
  * @property {boolean} debug Enable debug mode.
+ * @property {string} outDir Output directory name.
  * @property {boolean} quiet Enable quiet mode.
  * @property {'fs' | 'rl'} templateType Webpack entry file template type. Select from `fs` (File System) or `rl` (Read Line).
  */


### PR DESCRIPTION
This pull request includes changes to the `bananass` package, focusing on improvements to the build configuration and code simplification. The most important changes include removing unused constants, adding a new configuration option for the output directory, and updating related functions to use this new option.

### Build Configuration Improvements:
* [`packages/bananass/src/cli/bananass-build.js`](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L13-R13): Added `outDir` to the build configuration options and updated the command description to reflect this change. Removed unused constants from imports. [[1]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L13-R13) [[2]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776R41-R55)
* [`packages/bananass/src/commands/bananass-build/webpack.js`](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL19-R19): Updated the build function to use `options.outDir` instead of the removed `OUTPUT_DIR_NAME_ARRAY` constant. [[1]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL19-R19) [[2]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL47-R47) [[3]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL111-R106) [[4]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL140-R135) [[5]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL158-R153)

### Code Simplification:
* [`packages/bananass/src/core/constants.js`](diffhunk://#diff-97d6046c52dcaa9f59ecd0bc5a1ed48d3a91d2c8159901b86ba0b4932b532886L10-R10): Removed the `OUTPUT_DIR_NAME_ARRAY` constant and added `DEFAULT_OUT_DIR_NAME`. [[1]](diffhunk://#diff-97d6046c52dcaa9f59ecd0bc5a1ed48d3a91d2c8159901b86ba0b4932b532886L10-R10) [[2]](diffhunk://#diff-97d6046c52dcaa9f59ecd0bc5a1ed48d3a91d2c8159901b86ba0b4932b532886R37-L56)
* [`packages/bananass/src/core/conf/default-config-object/default-config-object.js`](diffhunk://#diff-52a8798a5e892009d2bf6b96aaff12cc552d06b6a08c3338dacfcfb2f15d6b89R9-R14): Added `outDir` to the default build configuration using the new `DEFAULT_OUT_DIR_NAME` constant. [[1]](diffhunk://#diff-52a8798a5e892009d2bf6b96aaff12cc552d06b6a08c3338dacfcfb2f15d6b89R9-R14) [[2]](diffhunk://#diff-52a8798a5e892009d2bf6b96aaff12cc552d06b6a08c3338dacfcfb2f15d6b89R42)
* [`packages/bananass/src/core/types.js`](diffhunk://#diff-0b5f63f76dd8d7069ef461522345f424e381b4ccd8fd1cc3b8683bb57a1f05cdR33): Updated the `ConfigObjectBuildOptions` type to include the `outDir` property.