### PR TITLE
feat(bananass): add `entryDir` option to `build` command

### DIFF
--- a/packages/bananass/src/cli/bananass-build.js
+++ b/packages/bananass/src/cli/bananass-build.js
@@ -10,7 +10,6 @@ import logger from 'bananass-utils-console/logger';
 
 import { build } from '../commands/index.js';
 import { configLoader, defaultConfigObject } from '../core/conf/index.js';
-import { ENTRY_DIR_NAME_ARRAY } from '../core/constants.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -19,14 +18,6 @@ import { ENTRY_DIR_NAME_ARRAY } from '../core/constants.js';
 /**
  * @typedef {import('commander').Command} Command
  */
-
-// --------------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------------
-
-function toInlineCodeString(arr) {
-  return arr.map(elem => `\`${elem}\``).join(', ');
-}
 
 // --------------------------------------------------------------------------------
 // Export
@@ -38,16 +29,18 @@ function toInlineCodeString(arr) {
  * @param {Command} program The `commander` package's `program`.
  */
 export default function bananassBuild(program) {
-  const { clean, debug, outDir, quiet, templateType } = defaultConfigObject.build;
+  const { clean, debug, entryDir, outDir, quiet, templateType } =
+    defaultConfigObject.build;
 
   program
     .command('build')
     .description(
-      `build and create bundled files using webpack and babel from the ${toInlineCodeString(ENTRY_DIR_NAME_ARRAY)} directory and outputs them to the \`${outDir}\` directory`,
+      `build and create bundled files using webpack and babel from the \`${entryDir}\` directory and outputs them to the \`${outDir}\` directory`,
     )
     .argument('[problems...]', 'baekjoon problem number list', null)
     .option('-c, --clean', `clean the output directory before emit (default: ${clean})`) // DO NOT USE `Default option value` of `commander` package as it overrides the every other options from the config file. Same goes for the other options.
     .option('-D, --debug', `enable debug mode (default: ${debug})`)
+    .option('-e, --entry-dir <dir>', `entry directory name (default: ${entryDir})`)
     .option('-o, --out-dir <dir>', `output directory name (default: ${outDir})`)
     .option('-q, --quiet', `enable quiet mode (default: ${quiet})`)
     .option(

--- a/packages/bananass/src/commands/bananass-build/webpack.js
+++ b/packages/bananass/src/commands/bananass-build/webpack.js
@@ -43,6 +43,7 @@ export default async function build(problems, { build: options }) {
   // ------------------------------------------------------------------------------
   const webpackEntryFileName = `template-${options.templateType}.cjs`;
   const rootDir = getRootDir();
+  const entryDir = resolve(rootDir, options.entryDir);
   const outDir = resolve(rootDir, options.outDir);
 
   const logger = createLogger(options);
@@ -113,9 +114,7 @@ export default async function build(problems, { build: options }) {
      */
     plugins: [
       new webpack.DefinePlugin({
-        BAEKJOON_PROBLEM_NUMBER_WITH_PATH: JSON.stringify(
-          resolve(rootDir, 'bananass', problem), // TODO: add `src/bananass` directory.
-        ),
+        BAEKJOON_PROBLEM_NUMBER_WITH_PATH: JSON.stringify(resolve(entryDir, problem)),
       }),
     ],
   }));

--- a/packages/bananass/src/core/conf/default-config-object/default-config-object.js
+++ b/packages/bananass/src/core/conf/default-config-object/default-config-object.js
@@ -3,17 +3,16 @@
  */
 
 // --------------------------------------------------------------------------------
-// Typedefs
+// Import
 // --------------------------------------------------------------------------------
 
-import { DEFAULT_OUT_DIR_NAME } from '../../constants.js';
+import { DEFAULT_ENTRY_DIR_NAME, DEFAULT_OUT_DIR_NAME } from '../../constants.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import('../../types.js').ConfigObject} ConfigObject
  * @typedef {import('../../types.js').ConfigObjectAddOptions} ConfigObjectAddOptions
  * @typedef {import('../../types.js').ConfigObjectBuildOptions} ConfigObjectBuildOptions
  * @typedef {import('../../types.js').ConfigObjectCleanOptions} ConfigObjectCleanOptions
@@ -29,67 +28,48 @@ import { DEFAULT_OUT_DIR_NAME } from '../../constants.js';
  */
 
 // --------------------------------------------------------------------------------
-// Config Object Default Options
+// Export
 // --------------------------------------------------------------------------------
 
 /** @type {ConfigObjectAddOptions} */
-const add = {};
+export const add = {};
 
 /** @type {ConfigObjectBuildOptions} */
-const build = {
+export const build = {
   clean: false,
   debug: false,
+  entryDir: DEFAULT_ENTRY_DIR_NAME,
   outDir: DEFAULT_OUT_DIR_NAME,
   quiet: false,
   templateType: 'fs',
 };
 
 /** @type {ConfigObjectCleanOptions} */
-const clean = {};
+export const clean = {};
 
 /** @type {ConfigObjectInfoOptions} */
-const info = {};
+export const info = {};
 
 /** @type {ConfigObjectInitOptions} */
-const init = {};
+export const init = {};
 
 /** @type {ConfigObjectLintOptions} */
-const lint = {};
+export const lint = {};
 
 /** @type {ConfigObjectLoginOptions} */
-const login = {};
+export const login = {};
 
 /** @type {ConfigObjectOpenOptions} */
-const open = {};
+export const open = {};
 
 /** @type {ConfigObjectRandomOptions} */
-const random = {};
+export const random = {};
 
 /** @type {ConfigObjectRunOptions} */
-const run = {};
+export const run = {};
 
 /** @type {ConfigObjectSubmitOptions} */
-const submit = {};
+export const submit = {};
 
 /** @type {ConfigObjectTestcaseOptions} */
-const testcase = {};
-
-// --------------------------------------------------------------------------------
-// Export
-// --------------------------------------------------------------------------------
-
-/** @type {ConfigObject} */
-export default {
-  add,
-  build,
-  clean,
-  info,
-  init,
-  lint,
-  login,
-  open,
-  random,
-  run,
-  submit,
-  testcase,
-};
+export const testcase = {};

--- a/packages/bananass/src/core/conf/default-config-object/index.js
+++ b/packages/bananass/src/core/conf/default-config-object/index.js
@@ -1,3 +1,1 @@
-import defaultConfig from './default-config-object.js';
-
-export default defaultConfig;
+export * from './default-config-object.js';

--- a/packages/bananass/src/core/conf/index.js
+++ b/packages/bananass/src/core/conf/index.js
@@ -1,4 +1,4 @@
 import configLoader from './config-loader/index.js';
-import defaultConfigObject from './default-config-object/index.js';
+import * as defaultConfigObject from './default-config-object/index.js';
 
 export { configLoader, defaultConfigObject };

--- a/packages/bananass/src/core/constants.js
+++ b/packages/bananass/src/core/constants.js
@@ -7,7 +7,6 @@
 // --------------------------------------------------------------------------------
 
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
 
 // --------------------------------------------------------------------------------
 // Declaration
@@ -34,6 +33,9 @@ export const PKG_NAME = name;
 /** @type string */
 export const PKG_VERSION = version;
 
+/** @type string */
+export const DEFAULT_ENTRY_DIR_NAME = name;
+/** @type string */
 export const DEFAULT_OUT_DIR_NAME = `.${name}`;
 
 /* Array */
@@ -41,4 +43,3 @@ export const DEFAULT_OUT_DIR_NAME = `.${name}`;
 // Array constants with `BASE` in their name must include the extension.
 export const JS_EXT_ARRAY = Object.freeze(['.js', '.cjs', '.mjs']);
 export const PACKAGE_JSON_FILE_BASE_ARRAY = Object.freeze(['package.json']);
-export const ENTRY_DIR_NAME_ARRAY = Object.freeze([name, join('src', name)]);

--- a/packages/bananass/src/core/types.js
+++ b/packages/bananass/src/core/types.js
@@ -30,6 +30,7 @@
  * @typedef {object} ConfigObjectBuildOptions
  * @property {boolean} clean Clean the output directory before emit.
  * @property {boolean} debug Enable debug mode.
+ * @property {string} entryDir Entry directory name.
  * @property {string} outDir Output directory name.
  * @property {boolean} quiet Enable quiet mode.
  * @property {'fs' | 'rl'} templateType Webpack entry file template type. Select from `fs` (File System) or `rl` (Read Line).


### PR DESCRIPTION
This pull request includes several changes to the `bananass` package, primarily focusing on refactoring and adding new configuration options. The most important changes include the addition of an `entryDir` configuration option, refactoring of the `default-config-object`, and removal of unused code.

### Configuration Improvements:
* Added `entryDir` configuration option to the `defaultConfigObject.build` object and updated related files to use this new option. [[1]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L41-R43) [[2]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bR46) [[3]](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bL116-R117) [[4]](diffhunk://#diff-52a8798a5e892009d2bf6b96aaff12cc552d06b6a08c3338dacfcfb2f15d6b89L32-R75) [[5]](diffhunk://#diff-0b5f63f76dd8d7069ef461522345f424e381b4ccd8fd1cc3b8683bb57a1f05cdR33)

### Code Refactoring:
* Refactored `default-config-object` to use named exports instead of a default export. [[1]](diffhunk://#diff-52a8798a5e892009d2bf6b96aaff12cc552d06b6a08c3338dacfcfb2f15d6b89L32-R75) [[2]](diffhunk://#diff-1b26d0592191da623d5c4f920955872fb3da69e943c8d8c63f96405eeffd6cf3L1-R1) [[3]](diffhunk://#diff-1657c2852ae9ab98f9b5fba540bc320c093a2d5759379b27d1735337a3d293e6L2-R2)
* Removed unused `toInlineCodeString` helper function and related import statements from `bananass-build.js`. [[1]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L23-L30) [[2]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L13)

### Constants Update:
* Added `DEFAULT_ENTRY_DIR_NAME` constant and removed `ENTRY_DIR_NAME_ARRAY` constant from `constants.js`.

These changes improve the flexibility and maintainability of the codebase by allowing more configurable options and simplifying the import/export structure.