### PR TITLE
feat!(bananass): change `problems` argument from optional to required in `build` command

### DIFF
--- a/packages/bananass/src/cli/bananass-build.js
+++ b/packages/bananass/src/cli/bananass-build.js
@@ -40,7 +40,7 @@ export default function bananassBuild(program) {
     .description(
       `build and create bundled files using webpack and babel from the \`${entryDir}\` directory and outputs them to the \`${outDir}\` directory`,
     )
-    .argument('[problems...]', 'baekjoon problem number list', null)
+    .argument('<problems...>', 'baekjoon problem number list')
     .option('-c, --clean', `clean the output directory before emit (default: ${clean})`) // DO NOT USE `Default option value` of `commander` package as it overrides the every other options from the config file. Same goes for the other options.
     .option('-D, --debug', `enable debug mode (default: ${debug})`)
     .option('-e, --entry-dir <dir>', `entry directory name (default: ${entryDir})`)


### PR DESCRIPTION
BREAKING CHANGE

This pull request includes a change to the `bananassBuild` function in the `bananass-build.js` file. The change modifies the argument type for the `problems` parameter to be required instead of optional.

* [`packages/bananass/src/cli/bananass-build.js`](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L43-R43): Changed the `problems` argument from optional (`[problems...]`) to required (`<problems...>`).
