### PR TITLE
build: replace `cp` with `shx cp` in build scripts for cross-platform compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "markdownlint-cli": "^0.44.0",
         "prettier": "^3.4.1",
         "prettier-config-bananass": "^0.0.0",
+        "shx": "^0.3.4",
         "textlint": "^14.3.0",
         "textlint-rule-allowed-uris": "^1.0.6",
         "typescript": "^5.7.2"
@@ -10938,6 +10939,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -16714,6 +16725,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -17485,6 +17508,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/shelljs/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/shiki": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.1.0.tgz",
@@ -17500,6 +17576,23 @@
         "@shikijs/types": "2.1.0",
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "markdownlint-cli": "^0.44.0",
     "prettier": "^3.4.1",
     "prettier-config-bananass": "^0.0.0",
+    "shx": "^0.3.4",
     "textlint": "^14.3.0",
     "textlint-rule-allowed-uris": "^1.0.6",
     "typescript": "^5.7.2"

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && shx cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
   },
   "dependencies": {

--- a/packages/bananass-utils-vitepress/package.json
+++ b/packages/bananass-utils-vitepress/package.json
@@ -74,7 +74,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && shx cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
   }
 }

--- a/packages/bananass-utils/package.json
+++ b/packages/bananass-utils/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && shx cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
   },
   "dependencies": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npx tsc && cp ../../LICENSE.md ../../README.md .",
+    "build": "npx tsc && shx cp ../../LICENSE.md ../../README.md .",
     "test": "node --test",
     "dev": "node src/cli.js"
   },

--- a/packages/eslint-config-bananass-react/package.json
+++ b/packages/eslint-config-bananass-react/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "cp ../../LICENSE.md ../../README.md .",
+    "build": "shx cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
   },
   "peerDependencies": {

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "cp ../../LICENSE.md ../../README.md .",
+    "build": "shx cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
   },
   "peerDependencies": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "cp ../../LICENSE.md ../../README.md .",
+    "build": "shx cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
   },
   "peerDependencies": {


### PR DESCRIPTION
This pull request includes updates to various `package.json` files to standardize the build scripts by using `shx` for copying files. The changes ensure consistency and cross-platform compatibility in the build process.

Standardization of build scripts:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R70): Added `shx` as a dependency.
* [`packages/bananass-utils-console/package.json`](diffhunk://#diff-14dc0ab8d918f740c0f0d225fcfbbfdbf6620ab25f1e833d884d3878b35a9a0eL73-R73): Updated the `build` script to use `shx` for copying `LICENSE.md` and `README.md` files.
* [`packages/bananass-utils-vitepress/package.json`](diffhunk://#diff-e9935f58a17308158af0563ed80b22f02cba32b411c4e1bd2e2acb76593734a9L77-R77): Updated the `build` script to use `shx` for copying `LICENSE.md` and `README.md` files.
* [`packages/bananass-utils/package.json`](diffhunk://#diff-d163ef114bef61820f7f4b4d32b3deb5f15dfc2b5375c030716132c1b4c31c88L45-R45): Updated the `build` script to use `shx` for copying `LICENSE.md` and `README.md` files.
* [`packages/bananass/package.json`](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432L49-R49): Updated the `build` script to use `shx` for copying `LICENSE.md` and `README.md` files.
* [`packages/eslint-config-bananass-react/package.json`](diffhunk://#diff-263baf2bd4636e9041e07fa4d170bdde1545c6a48947ab5ff1f511e289d53356L46-R46): Updated the `build` script to use `shx` for copying `LICENSE.md` and `README.md` files.
* [`packages/eslint-config-bananass/package.json`](diffhunk://#diff-e820b85e94fd5b26012547982c44a557398b5c3dc850ac0c4094d184dfd5bcbcL43-R43): Updated the `build` script to use `shx` for copying `LICENSE.md` and `README.md` files.
* [`packages/prettier-config-bananass/package.json`](diffhunk://#diff-0fdaf27a6fc3a9c98ce068e2f60dd6fa1d2a82cfc232695581bcae3256c32d76L41-R41): Updated the `build` script to use `shx` for copying `LICENSE.md` and `README.md` files.