### PR TITLE
ci(*): update `pull-request.yml` workflow to include `synchronize` event

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: pull-request
 
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pull-request.yml` file. The change adds the `synchronize` event type to the `pull_request_target` trigger. 

Changes in event types:

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L5-R5): Added `synchronize` to the list of `pull_request_target` event types.