### PR TITLE
chore(*): update `dependabot.yml`'s `commit-message` configuration to include `prefix` and `scope`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
   - package-ecosystem: 'npm'
     assignees:
       - 'lumirlumir'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
     # Specify all directories from the current layer and below recursively, using globstar, for locations of manifest files.
     directories:
       - '**/*'
@@ -38,6 +41,9 @@ updates:
   - package-ecosystem: 'github-actions'
     assignees:
       - 'lumirlumir'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     reviewers:


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yml` file to enhance commit message configuration for dependency updates.

Improvements to commit message configuration:

* Added `commit-message` configuration with `prefix` set to 'chore' and `include` set to 'scope' for `npm` package ecosystem.
* Added `commit-message` configuration with `prefix` set to 'chore' and `include` set to 'scope' for `github-actions` package ecosystem.