### PR TITLE
ci(*): update `pull-request.yml` labeler condition to include `synchronize` event

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -142,7 +142,7 @@ jobs:
       scope: ${{ steps.lint-pull-request-title.outputs.scope }}
 
   labeler:
-    if: github.event.action == 'opened' || github.event.changes.title
+    if: github.event.action == 'opened' || github.event.changes.title || github.event.action == 'synchronize'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/pull-request.yml` file. The change updates the condition for the `labeler` job to also trigger when the pull request action is synchronized.

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L145-R145): Updated the `if` condition for the `labeler` job to include `github.event.action == 'synchronize'`.