### PR TITLE
chore(npm-bananass): update workspace configuration and adjust test/build commands to ignore `npm-bananass`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "npm-bananass",
       "version": "0.0.0",
       "workspaces": [
+        ".",
         "examples/*",
         "packages/*",
         "tests/*",
@@ -15099,6 +15100,10 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/npm-bananass": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/npm-bundled": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=20.18.0"
   },
   "workspaces": [
+    ".",
     "examples/*",
     "packages/*",
     "tests/*",
@@ -16,7 +17,7 @@
     "prepare": "husky",
     "publish-package": "npx lerna publish from-package --pre-dist-tag canary --yes",
     "coverage": "npx c8 --reporter=lcov npm run test",
-    "test": "npx lerna run test",
+    "test": "npx lerna run test --ignore npm-bananass",
     "test:ex:sb": "npm run test -w examples/solutions-bananass",
     "test:pkg:b": "npm run test -w packages/bananass",
     "test:pkg:buc": "npm run test -w packages/bananass-utils-console",
@@ -24,7 +25,7 @@
     "test:pkg:ecb": "npm run test -w packages/eslint-config-bananass",
     "test:pkg:ecbr": "npm run test -w packages/eslint-config-bananass-react",
     "test:pkg:pcb": "npm run test -w packages/prettier-config-bananass",
-    "build": "npx lerna run build",
+    "build": "npx lerna run build --ignore npm-bananass",
     "build:ex:sb": "npm run bananass:build -w examples/solutions-bananass",
     "build:pkg:b": "npm run build -w packages/bananass",
     "build:pkg:buc": "npm run build -w packages/bananass-utils-console",


### PR DESCRIPTION
This pull request includes changes to the `package.json` file to update workspace configuration and modify build and test scripts to exclude a specific package.

Workspace configuration:

* Added the current directory (`"."`) to the list of workspaces.

Script modifications:

* Updated the `test` script to ignore the `npm-bananass` package.
* Updated the `build` script to ignore the `npm-bananass` package.