### PR TITLE
feat(bananass): add webpack banner plugin with generated file information

### DIFF
--- a/packages/bananass/src/commands/bananass-build/webpack.js
+++ b/packages/bananass/src/commands/bananass-build/webpack.js
@@ -18,6 +18,7 @@ import webpack from 'webpack';
 
 import {
   BAEKJOON_PROBLEM_NUMBER_MIN,
+  WEBPACK_BANNER,
   SUPPORTED_SOLUTION_FILE_EXTENSIONS,
 } from '../../core/constants.js';
 
@@ -123,6 +124,11 @@ export default async function build(problems, { build: options }) {
      * @see https://webpack.js.org/concepts/#plugins
      */
     plugins: [
+      new webpack.BannerPlugin({
+        banner: WEBPACK_BANNER,
+        raw: true,
+        stage: webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+      }),
       new webpack.DefinePlugin({
         BAEKJOON_PROBLEM_NUMBER_WITH_PATH: JSON.stringify(resolve(entryDir, problem)),
       }),

--- a/packages/bananass/src/core/constants.js
+++ b/packages/bananass/src/core/constants.js
@@ -17,13 +17,15 @@ const { description, homepage, name, version } = createRequire(import.meta.url)(
 );
 
 // --------------------------------------------------------------------------------
-// Export
+// Export `number`
 // --------------------------------------------------------------------------------
 
-/* Number */
 export const BAEKJOON_PROBLEM_NUMBER_MIN = 1_000;
 
-/* String */
+// --------------------------------------------------------------------------------
+// Export `string`
+// --------------------------------------------------------------------------------
+
 /** @type {string} */
 export const PKG_DESCRIPTION = description;
 /** @type {string} */
@@ -32,13 +34,33 @@ export const PKG_HOMEPAGE = homepage;
 export const PKG_NAME = name;
 /** @type {string} */
 export const PKG_VERSION = version;
+/** @type {string} */
+export const PKG_GITHUB_REPOSITORY = 'https://github.com/lumirlumir/npm-bananass';
 
 /** @type {string} */
 export const DEFAULT_ENTRY_DIR_NAME = name;
 /** @type {string} */
 export const DEFAULT_OUT_DIR_NAME = `.${name}`;
 
-/* Array */
+/** @type {string} */
+export const WEBPACK_BANNER = `
+/**
+ * This file was generated using the Baekjoon Framework for JavaScript 'Bananass🍌'
+ *
+ * Bananass Homepage: ${PKG_HOMEPAGE}
+ * Bananass GitHub Repository: ${PKG_GITHUB_REPOSITORY}
+ *
+ * Released under the MIT License
+ * Copyright © 2024-${new Date().getFullYear()} 루밀LuMir(lumirlumir)
+ *
+ * DO NOT DELETE THIS COMMENT
+ */
+`.trim();
+
+// --------------------------------------------------------------------------------
+// Export `string[]`
+// --------------------------------------------------------------------------------
+
 export const SUPPORTED_SOLUTION_FILE_EXTENSIONS = [
   '.js',
   '.mjs',


### PR DESCRIPTION
This pull request includes changes to the `packages/bananass` module to enhance the build process and improve code documentation. The most important changes include the addition of a Webpack banner plugin, the introduction of a new constant for the Webpack banner, and the reorganization of exports in the `constants.js` file.

### Enhancements to the build process:

* [`packages/bananass/src/commands/bananass-build/webpack.js`](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bR127-R131): Added the Webpack BannerPlugin to include a banner in the generated files.

### Improvements to code documentation and organization:

* [`packages/bananass/src/core/constants.js`](diffhunk://#diff-97d6046c52dcaa9f59ecd0bc5a1ed48d3a91d2c8159901b86ba0b4932b532886R37-R63): Introduced a new constant `WEBPACK_BANNER` for the Webpack banner content.
* [`packages/bananass/src/core/constants.js`](diffhunk://#diff-97d6046c52dcaa9f59ecd0bc5a1ed48d3a91d2c8159901b86ba0b4932b532886L20-R28): Reorganized export comments for better clarity and added type annotations for string constants.

### Import adjustments:

* [`packages/bananass/src/commands/bananass-build/webpack.js`](diffhunk://#diff-0ce95c8c9e2a9153c60042f1f9db2f62324e019f7980eb2e8ee8a5001fd6e34bR21): Added `WEBPACK_BANNER` to the import statements.