### PR TITLE
feat(bananass): add shorthand command `b` for CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21367,6 +21367,7 @@
         "webpack": "^5.97.1"
       },
       "bin": {
+        "b": "src/cli.js",
         "bananass": "src/cli.js"
       },
       "engines": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -11,6 +11,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
+    "b": "src/cli.js",
     "bananass": "src/cli.js"
   },
   "files": [


### PR DESCRIPTION
This pull request includes a small change to the `packages/bananass/package.json` file. The change adds a new binary entry for `b` that points to `src/cli.js`.

* [`packages/bananass/package.json`](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432R14): Added a new binary entry for `b` that points to `src/cli.js`.