### PR TITLE
refactor(bananass): simplify command function names for consistency

### DIFF
--- a/packages/bananass/src/cli.js
+++ b/packages/bananass/src/cli.js
@@ -11,19 +11,19 @@
 import { program } from 'commander';
 import {
   global,
-  bananassAdd,
-  bananassBuild,
-  bananassClean,
-  bananassHome,
-  bananassInfo,
-  bananassInit,
-  bananassLint,
-  bananassLogin,
-  bananassOpen,
-  bananassRandom,
-  bananassRun,
-  bananassSubmit,
-  bananassTestcase,
+  add,
+  build,
+  clean,
+  home,
+  info,
+  init,
+  lint,
+  login,
+  open,
+  random,
+  run,
+  submit,
+  testcase,
 } from './cli/index.js';
 
 // --------------------------------------------------------------------------------
@@ -31,19 +31,19 @@ import {
 // --------------------------------------------------------------------------------
 
 global(program);
-bananassAdd(program);
-bananassBuild(program);
-bananassClean(program);
-bananassHome(program);
-bananassInfo(program);
-bananassInit(program);
-bananassLint(program);
-bananassLogin(program);
-bananassOpen(program);
-bananassRandom(program);
-bananassRun(program);
-bananassSubmit(program);
-bananassTestcase(program);
+add(program);
+build(program);
+clean(program);
+home(program);
+info(program);
+init(program);
+lint(program);
+login(program);
+open(program);
+random(program);
+run(program);
+submit(program);
+testcase(program);
 
 // --------------------------------------------------------------------------------
 // Parse `commander`

--- a/packages/bananass/src/cli/bananass-add.js
+++ b/packages/bananass/src/cli/bananass-add.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassAdd(program) {
+export default function add(program) {
   program.command('add').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-build.js
+++ b/packages/bananass/src/cli/bananass-build.js
@@ -8,7 +8,7 @@
 
 import logger from 'bananass-utils-console/logger';
 
-import { build } from '../commands/index.js';
+import { build as buildCmd } from '../commands/index.js';
 import { configLoader, defaultConfigObject } from '../core/conf/index.js';
 
 import { build as buildDesc } from '../core/cli/descriptions.js';
@@ -41,7 +41,7 @@ import {
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassBuild(program) {
+export default function build(program) {
   program
     .command('build')
     .description(buildDesc)
@@ -84,6 +84,6 @@ export default function bananassBuild(program) {
         .debug('config object:', configObject)
         .eol();
 
-      await build(problems, configObject);
+      await buildCmd(problems, configObject);
     });
 }

--- a/packages/bananass/src/cli/bananass-clean.js
+++ b/packages/bananass/src/cli/bananass-clean.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassClean(program) {
+export default function clean(program) {
   program.command('clean').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-home.js
+++ b/packages/bananass/src/cli/bananass-home.js
@@ -8,7 +8,7 @@
 
 import logger from 'bananass-utils-console/logger';
 
-import { home } from '../commands/index.js';
+import { home as homeCmd } from '../commands/index.js';
 import { configLoader, defaultConfigObject } from '../core/conf/index.js';
 
 import { home as homeDesc } from '../core/cli/descriptions.js';
@@ -37,7 +37,7 @@ import {
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassHome(program) {
+export default function home(program) {
   program
     .command('home')
     .description(homeDesc)
@@ -72,6 +72,6 @@ export default function bananassHome(program) {
         .debug('config object:', configObject)
         .eol();
 
-      await home(configObject);
+      await homeCmd(configObject);
     });
 }

--- a/packages/bananass/src/cli/bananass-info.js
+++ b/packages/bananass/src/cli/bananass-info.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassInfo(program) {
+export default function info(program) {
   program.command('info').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-init.js
+++ b/packages/bananass/src/cli/bananass-init.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassInit(program) {
+export default function init(program) {
   program.command('init').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-lint.js
+++ b/packages/bananass/src/cli/bananass-lint.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassLint(program) {
+export default function lint(program) {
   program.command('lint').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-login.js
+++ b/packages/bananass/src/cli/bananass-login.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassLogin(program) {
+export default function login(program) {
   program.command('login').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-open.js
+++ b/packages/bananass/src/cli/bananass-open.js
@@ -8,7 +8,7 @@
 
 import logger from 'bananass-utils-console/logger';
 
-import { open } from '../commands/index.js';
+import { open as openCmd } from '../commands/index.js';
 import { configLoader, defaultConfigObject } from '../core/conf/index.js';
 
 import { open as openDesc } from '../core/cli/descriptions.js';
@@ -38,7 +38,7 @@ import {
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassOpen(program) {
+export default function open(program) {
   program
     .command('open')
     .description(openDesc)
@@ -75,6 +75,6 @@ export default function bananassOpen(program) {
         .debug('config object:', configObject)
         .eol();
 
-      await open(problems, configObject);
+      await openCmd(problems, configObject);
     });
 }

--- a/packages/bananass/src/cli/bananass-random.js
+++ b/packages/bananass/src/cli/bananass-random.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassRandom(program) {
+export default function random(program) {
   program.command('random').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-run.js
+++ b/packages/bananass/src/cli/bananass-run.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassRun(program) {
+export default function run(program) {
   program.command('run').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-submit.js
+++ b/packages/bananass/src/cli/bananass-submit.js
@@ -25,6 +25,6 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassSubmit(program) {
+export default function submit(program) {
   program.command('submit').description(warning('TODO: Working in progress...🚧', false));
 }

--- a/packages/bananass/src/cli/bananass-testcase.js
+++ b/packages/bananass/src/cli/bananass-testcase.js
@@ -25,7 +25,7 @@ import { warning } from 'bananass-utils-console/theme';
  *
  * @param {Command} program The `commander` package's `program`.
  */
-export default function bananassTestcase(program) {
+export default function testcase(program) {
   program
     .command('testcase')
     .description(warning('TODO: Working in progress...🚧', false));

--- a/packages/bananass/src/cli/index.js
+++ b/packages/bananass/src/cli/index.js
@@ -1,31 +1,31 @@
 import global from './global.js';
-import bananassAdd from './bananass-add.js';
-import bananassBuild from './bananass-build.js';
-import bananassClean from './bananass-clean.js';
-import bananassHome from './bananass-home.js';
-import bananassInfo from './bananass-info.js';
-import bananassInit from './bananass-init.js';
-import bananassLint from './bananass-lint.js';
-import bananassLogin from './bananass-login.js';
-import bananassOpen from './bananass-open.js';
-import bananassRandom from './bananass-random.js';
-import bananassRun from './bananass-run.js';
-import bananassSubmit from './bananass-submit.js';
-import bananassTestcase from './bananass-testcase.js';
+import add from './bananass-add.js';
+import build from './bananass-build.js';
+import clean from './bananass-clean.js';
+import home from './bananass-home.js';
+import info from './bananass-info.js';
+import init from './bananass-init.js';
+import lint from './bananass-lint.js';
+import login from './bananass-login.js';
+import open from './bananass-open.js';
+import random from './bananass-random.js';
+import run from './bananass-run.js';
+import submit from './bananass-submit.js';
+import testcase from './bananass-testcase.js';
 
 export {
   global,
-  bananassAdd,
-  bananassBuild,
-  bananassClean,
-  bananassHome,
-  bananassInfo,
-  bananassInit,
-  bananassLint,
-  bananassLogin,
-  bananassOpen,
-  bananassRandom,
-  bananassRun,
-  bananassSubmit,
-  bananassTestcase,
+  add,
+  build,
+  clean,
+  home,
+  info,
+  init,
+  lint,
+  login,
+  open,
+  random,
+  run,
+  submit,
+  testcase,
 };


### PR DESCRIPTION
This pull request includes significant refactoring of the `bananass` CLI commands to simplify and standardize the naming conventions. The changes primarily involve renaming functions and imports to use shorter, more concise names.

Refactoring and simplification:

* [`packages/bananass/src/cli.js`](diffhunk://#diff-6544fc29ddb1c7332552c44ae9262c59f8067412edbd9d71bbfe3edd7472813dL14-R46): Renamed all command functions to shorter names (e.g., `bananassAdd` to `add`).
* [`packages/bananass/src/cli/index.js`](diffhunk://#diff-c9e0cfc980e6dc61abd041c44f2a2caafdfff35f9554d653ff592f72b8d30aceL2-R30): Updated imports and exports to reflect the new shorter command function names.

Individual command files:

* [`packages/bananass/src/cli/bananass-add.js`](diffhunk://#diff-7ffec22a0ec92721fc993bfc6e2a84921061a2af373ea0616ad30beb086e4ec6L28-R28): Renamed `bananassAdd` function to `add`.
* [`packages/bananass/src/cli/bananass-build.js`](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L11-R11): Renamed `bananassBuild` function to `build` and updated internal references to `buildCmd`. [[1]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L11-R11) [[2]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L44-R44) [[3]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L87-R87)
* [`packages/bananass/src/cli/bananass-clean.js`](diffhunk://#diff-4098441887f304e953c4fbb71bb4722ecd20b601da6388db70c0b912c4f775cbL28-R28): Renamed `bananassClean` function to `clean`.
* [`packages/bananass/src/cli/bananass-home.js`](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL11-R11): Renamed `bananassHome` function to `home` and updated internal references to `homeCmd`. [[1]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL11-R11) [[2]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL40-R40) [[3]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL75-R75)
* [`packages/bananass/src/cli/bananass-info.js`](diffhunk://#diff-bff245da03f8a2d2d1dc34bee509e9bc4a2eaaa81cf70498e71536284f9267caL28-R28): Renamed `bananassInfo` function to `info`.
* [`packages/bananass/src/cli/bananass-init.js`](diffhunk://#diff-d5d14738d16e31af06da7a5cb8fb63577d13c52712b2d3428186cf70328a0ed1L28-R28): Renamed `bananassInit` function to `init`.
* [`packages/bananass/src/cli/bananass-lint.js`](diffhunk://#diff-a5d8a9e06f32b0ff0b266a32af4efc57b670308bd39d3b9a671624ee1cf6a12bL28-R28): Renamed `bananassLint` function to `lint`.
* [`packages/bananass/src/cli/bananass-login.js`](diffhunk://#diff-a3766741b1280e4c5fd966fa079d8dfe45c2015024400fac2911123805b7bfe9L28-R28): Renamed `bananassLogin` function to `login`.
* [`packages/bananass/src/cli/bananass-open.js`](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL11-R11): Renamed `bananassOpen` function to `open` and updated internal references to `openCmd`. [[1]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL11-R11) [[2]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL41-R41) [[3]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL78-R78)
* [`packages/bananass/src/cli/bananass-random.js`](diffhunk://#diff-7f1b0cf716eabeb2fbb581a2909fcc3385774abab71e6bf271775986bf83f203L28-R28): Renamed `bananassRandom` function to `random`.
* [`packages/bananass/src/cli/bananass-run.js`](diffhunk://#diff-b60d6936d484b4fe5468cf7087467bdab42ddc70d1a1466f0301b5d41aa98658L28-R28): Renamed `bananassRun` function to `run`.
* [`packages/bananass/src/cli/bananass-submit.js`](diffhunk://#diff-dbd28d7982676e2657a1cae96931ff4fc6b6aaa77f6f0ac058f75dcd0558c690L28-R28): Renamed `bananassSubmit` function to `submit`.
* [`packages/bananass/src/cli/bananass-testcase.js`](diffhunk://#diff-da389dfc283857d3298ae48d2c39b3fa87d8ec735ac6942edf113eccb099ed74L28-R28): Renamed `bananassTestcase` function to `testcase`.