### PR TITLE
fix(bananass): correct `logger` calls in cli to use `configObject.console`

### DIFF
--- a/packages/bananass/src/cli/bananass-build.js
+++ b/packages/bananass/src/cli/bananass-build.js
@@ -76,7 +76,7 @@ export default function build(program) {
         defaultConfigObject,
       });
 
-      logger(options)
+      logger(configObject.console)
         .debug('command:', command.name())
         .debug('problems:', problems)
         .debug('cli options:', options)

--- a/packages/bananass/src/cli/bananass-discussion.js
+++ b/packages/bananass/src/cli/bananass-discussion.js
@@ -68,7 +68,7 @@ export default function discussion(program) {
         defaultConfigObject,
       });
 
-      logger(options)
+      logger(configObject.console)
         .debug('command:', command.name())
         .debug('cli options:', options)
         .debug('cli config object:', cliConfigObject)

--- a/packages/bananass/src/cli/bananass-home.js
+++ b/packages/bananass/src/cli/bananass-home.js
@@ -65,7 +65,7 @@ export default function home(program) {
         defaultConfigObject,
       });
 
-      logger(options)
+      logger(configObject.console)
         .debug('command:', command.name())
         .debug('cli options:', options)
         .debug('cli config object:', cliConfigObject)

--- a/packages/bananass/src/cli/bananass-open.js
+++ b/packages/bananass/src/cli/bananass-open.js
@@ -67,7 +67,7 @@ export default function open(program) {
         defaultConfigObject,
       });
 
-      logger(options)
+      logger(configObject.console)
         .debug('command:', command.name())
         .debug('problems:', problems)
         .debug('cli options:', options)

--- a/packages/bananass/src/cli/bananass-repo.js
+++ b/packages/bananass/src/cli/bananass-repo.js
@@ -65,7 +65,7 @@ export default function repo(program) {
         defaultConfigObject,
       });
 
-      logger(options)
+      logger(configObject.console)
         .debug('command:', command.name())
         .debug('cli options:', options)
         .debug('cli config object:', cliConfigObject)


### PR DESCRIPTION
This pull request makes consistent changes across multiple CLI functions in the `packages/bananass/src/cli` directory. The primary change involves modifying the `logger` function to use `configObject.console` instead of `options`.

Changes to logger function:

* [`packages/bananass/src/cli/bananass-build.js`](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L79-R79): Changed the `logger` function to use `configObject.console`
* [`packages/bananass/src/cli/bananass-discussion.js`](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6L71-R71): Changed the `logger` function to use `configObject.console`
* [`packages/bananass/src/cli/bananass-home.js`](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL68-R68): Changed the `logger` function to use `configObject.console`
* [`packages/bananass/src/cli/bananass-open.js`](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL70-R70): Changed the `logger` function to use `configObject.console`
* [`packages/bananass/src/cli/bananass-repo.js`](diffhunk://#diff-18cad518a6aa21886b7a585bd6846ed203fcbb98516a9191ed3c29e82e30869cL68-R68): Changed the `logger` function to use `configObject.console`