### PR TITLE
chore(*): update `dependabot.yml` and delete `bananass-dataset` directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     groups:
       bananass:
         patterns:
+          - 'bananass-utils-vitepress'
           - 'eslint-config-bananass'
           - 'eslint-config-bananass-react'
           - 'prettier-config-bananass'


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change adds a new pattern to the `bananass` group for dependency updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R16): Added the pattern `'bananass-utils-vitepress'` to the `bananass` group.