### PR TITLE
chore(*): remove `.spec.js` files from ignore and exclude lists in configuration files

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,7 @@ module.exports = {
       },
     ],
   ],
-  ignore: ['**/*.test.js', '**/*.spec.js'],
+  ignore: ['**/*.test.js'],
   minified: true,
   comments: false,
 };

--- a/packages/bananass-utils-console/tsconfig.json
+++ b/packages/bananass-utils-console/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.js"],
-  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+  "exclude": ["src/**/*.test.js"]
 }

--- a/packages/bananass-utils-vitepress/tsconfig.json
+++ b/packages/bananass-utils-vitepress/tsconfig.json
@@ -8,5 +8,5 @@
     "moduleResolution": "Node"
   },
   "include": ["src/**/*.js"],
-  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+  "exclude": ["src/**/*.test.js"]
 }

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -41,7 +41,6 @@
     "LICENSE.md",
     "README.md",
     "!src/**/*.test.js",
-    "!src/**/*.spec.js",
     "!**/fixtures/**"
   ],
   "keywords": [

--- a/packages/bananass/tsconfig.json
+++ b/packages/bananass/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.js"],
-  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+  "exclude": ["src/**/*.test.js"]
 }

--- a/packages/eslint-config-bananass-react/package.json
+++ b/packages/eslint-config-bananass-react/package.json
@@ -11,7 +11,6 @@
   "files": [
     "src",
     "!src/**/*.test.js",
-    "!src/**/*.spec.js",
     "LICENSE.md",
     "README.md"
   ],

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -11,7 +11,6 @@
   "files": [
     "src",
     "!src/**/*.test.js",
-    "!src/**/*.spec.js",
     "LICENSE.md",
     "README.md"
   ],

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -11,7 +11,6 @@
   "files": [
     "src",
     "!src/**/*.test.js",
-    "!src/**/*.spec.js",
     "LICENSE.md",
     "README.md"
   ],


### PR DESCRIPTION
This pull request includes several changes across multiple configuration files to simplify the exclusion patterns for test files by removing references to `*.spec.js` files. The most important changes are as follows:

Changes to ignore/exclude patterns:

* [`babel.config.js`](diffhunk://#diff-09c56b2bf95de2a608a36afef3b6893146a959d6739be0a154dc9c9f02d80f24L10-R10): Updated the `ignore` array to remove `**/*.spec.js` from the list of ignored files.
* [`packages/bananass-utils-console/tsconfig.json`](diffhunk://#diff-00d843065b36c05dd508bb0a94f06c16cc20bb2c4a760080908e336b719d3232L15-R15): Modified the `exclude` array to remove `src/**/*.spec.js` from the list of excluded files.
* [`packages/bananass-utils-vitepress/tsconfig.json`](diffhunk://#diff-16de8031cfd35c972e9f88018f3112664936f6e0fa4ca538d0ee5c7907e8ac40L11-R11): Adjusted the `exclude` array to remove `src/**/*.spec.js` from the list of excluded files.
* [`packages/bananass/package.json`](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432L44): Removed `!src/**/*.spec.js` from the list of files to be included or excluded.
* [`packages/bananass/tsconfig.json`](diffhunk://#diff-00d843065b36c05dd508bb0a94f06c16cc20bb2c4a760080908e336b719d3232L15-R15): Updated the `exclude` array to remove `src/**/*.spec.js` from the list of excluded files.

These changes help streamline the configuration by consistently excluding only `*.test.js` files across various parts of the codebase.