### PR TITLE
fix(eslint-config-bananass): update `react/curly-brace-presence` to follow default options

### DIFF
--- a/packages/eslint-config-bananass/src/rules/import/import-static-analysis.js
+++ b/packages/eslint-config-bananass/src/rules/import/import-static-analysis.js
@@ -114,6 +114,7 @@ module.exports = {
    * Ensure imports point to a file/module that can be resolved.
    *
    * @description This rule doesn't support the `exports` field of `package.json`, which has been the standard since Node.js v12. As it causes false positives, I've disabled it.
+   * @link issue: {@link https://github.com/import-js/eslint-plugin-import/issues/1810}
    * @link issue: {@link https://github.com/import-js/eslint-plugin-import/issues/3088}
    * @link import: {@link https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md}
    * @link airbnb-base: {@link https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb-base/rules/imports.js#L37}

--- a/packages/eslint-config-bananass/src/rules/node/node.js
+++ b/packages/eslint-config-bananass/src/rules/node/node.js
@@ -110,7 +110,7 @@ module.exports = {
   'n/no-missing-import': 'error',
 
   /**
-   * Disallow require() expressions which import non-existence modules.
+   * Disallow `require()` expressions which import non-existence modules.
    *
    * @description This rule is not included in `airbnb-base`.
    * @link n: {@link https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-missing-require.md}

--- a/packages/eslint-config-bananass/src/rules/react/react.js
+++ b/packages/eslint-config-bananass/src/rules/react/react.js
@@ -196,7 +196,7 @@ module.exports = {
     {
       props: 'never',
       children: 'never',
-      propElementValues: 'never',
+      propElementValues: 'ignore',
     },
   ],
 


### PR DESCRIPTION
This pull request includes several changes to the ESLint configuration files in the `packages/eslint-config-bananass` directory. The changes primarily focus on updating rule descriptions and modifying rule settings for better code analysis.

### Updates to rule descriptions:

* [`packages/eslint-config-bananass/src/rules/import/import-static-analysis.js`](diffhunk://#diff-a415fbe05c5cbf8feb435325f7f58bcced3a908ae247260a9b82300b1f1457ffR117): Added a link to an issue in the rule description for better context.
* [`packages/eslint-config-bananass/src/rules/node/node.js`](diffhunk://#diff-c96c91af708b289359a5b68fb41a21628063ede30d509cc8901b9063cacd9309L113-R113): Updated the description to clarify the use of `require()` expressions.

### Modifications to rule settings:

* [`packages/eslint-config-bananass/src/rules/react/react.js`](diffhunk://#diff-d2e14b50ea9ff3e279f30d972b03fd16efe19993bd0d6670de8571d2213515c5L199-R199): Changed the setting for `propElementValues` from 'never' to 'ignore' to adjust the rule's behavior.