### PR TITLE
test(eslint-config-bananass): restructure test descriptions for clarity and consistency

### DIFF
--- a/packages/eslint-config-bananass/src/rules/eslint/eslint.test.js
+++ b/packages/eslint-config-bananass/src/rules/eslint/eslint.test.js
@@ -23,22 +23,24 @@ const prefix = '/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must not include \`${prefix}\`.`, () => {
-  it('eslint-layout-formatting.js', () => {
-    Object.keys(eslintLayoutFormatting).forEach(key => {
-      strictEqual(key.includes(prefix), false);
+describe('eslint', () => {
+  describe(`All key values must not include \`${prefix}\`.`, () => {
+    it('eslint-layout-formatting.js', () => {
+      Object.keys(eslintLayoutFormatting).forEach(key => {
+        strictEqual(key.includes(prefix), false);
+      });
     });
-  });
 
-  it('eslint-possible-problems.js', () => {
-    Object.keys(eslintPossibleProblems).forEach(key => {
-      strictEqual(key.includes(prefix), false);
+    it('eslint-possible-problems.js', () => {
+      Object.keys(eslintPossibleProblems).forEach(key => {
+        strictEqual(key.includes(prefix), false);
+      });
     });
-  });
 
-  it('eslint-suggestions.js', () => {
-    Object.keys(eslintSuggestions).forEach(key => {
-      strictEqual(key.includes(prefix), false);
+    it('eslint-suggestions.js', () => {
+      Object.keys(eslintSuggestions).forEach(key => {
+        strictEqual(key.includes(prefix), false);
+      });
     });
   });
 });

--- a/packages/eslint-config-bananass/src/rules/import/import.test.js
+++ b/packages/eslint-config-bananass/src/rules/import/import.test.js
@@ -24,28 +24,30 @@ const prefix = 'import/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must start with \`${prefix}\`.`, () => {
-  it('import-helpful-warnings.js', () => {
-    Object.keys(importHelpfulWarnings).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+describe('import', () => {
+  describe(`All key values must start with \`${prefix}\`.`, () => {
+    it('import-helpful-warnings.js', () => {
+      Object.keys(importHelpfulWarnings).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
-  });
 
-  it('import-module-systems.js', () => {
-    Object.keys(importModuleSystems).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+    it('import-module-systems.js', () => {
+      Object.keys(importModuleSystems).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
-  });
 
-  it('import-static-analysis.js', () => {
-    Object.keys(importStaticAnalysis).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+    it('import-static-analysis.js', () => {
+      Object.keys(importStaticAnalysis).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
-  });
 
-  it('import-style-guide.js', () => {
-    Object.keys(importStyleGuide).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+    it('import-style-guide.js', () => {
+      Object.keys(importStyleGuide).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
   });
 });

--- a/packages/eslint-config-bananass/src/rules/jsx-a11y/jsx-a11y.test.js
+++ b/packages/eslint-config-bananass/src/rules/jsx-a11y/jsx-a11y.test.js
@@ -21,10 +21,12 @@ const prefix = 'jsx-a11y/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must start with \`${prefix}\`.`, () => {
-  it('jsx-a11y.js', () => {
-    Object.keys(jsxA11y).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+describe('jsx-a11y', () => {
+  describe(`All key values must start with \`${prefix}\`.`, () => {
+    it('jsx-a11y.js', () => {
+      Object.keys(jsxA11y).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
   });
 });

--- a/packages/eslint-config-bananass/src/rules/next/next.test.js
+++ b/packages/eslint-config-bananass/src/rules/next/next.test.js
@@ -21,10 +21,12 @@ const prefix = '@next/next/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must start with \`${prefix}\`.`, () => {
-  it('next.js', () => {
-    Object.keys(next).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+describe('next', () => {
+  describe(`All key values must start with \`${prefix}\`.`, () => {
+    it('next.js', () => {
+      Object.keys(next).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
   });
 });

--- a/packages/eslint-config-bananass/src/rules/node/node.test.js
+++ b/packages/eslint-config-bananass/src/rules/node/node.test.js
@@ -21,10 +21,12 @@ const prefix = 'n/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must start with \`${prefix}\`.`, () => {
-  it('node.js', () => {
-    Object.keys(node).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+describe('node', () => {
+  describe(`All key values must start with \`${prefix}\`.`, () => {
+    it('node.js', () => {
+      Object.keys(node).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
   });
 });

--- a/packages/eslint-config-bananass/src/rules/react-compiler/react-compiler.test.js
+++ b/packages/eslint-config-bananass/src/rules/react-compiler/react-compiler.test.js
@@ -21,10 +21,12 @@ const prefix = 'react-compiler/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must start with \`${prefix}\`.`, () => {
-  it('react-compiler.js', () => {
-    Object.keys(reactCompiler).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+describe('react-compiler', () => {
+  describe(`All key values must start with \`${prefix}\`.`, () => {
+    it('react-compiler.js', () => {
+      Object.keys(reactCompiler).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
   });
 });

--- a/packages/eslint-config-bananass/src/rules/react-hooks/react-hooks.test.js
+++ b/packages/eslint-config-bananass/src/rules/react-hooks/react-hooks.test.js
@@ -21,10 +21,12 @@ const prefix = 'react-hooks/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must start with \`${prefix}\`.`, () => {
-  it('react-hooks.js', () => {
-    Object.keys(reactHooks).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+describe('react-hooks', () => {
+  describe(`All key values must start with \`${prefix}\`.`, () => {
+    it('react-hooks.js', () => {
+      Object.keys(reactHooks).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
   });
 });

--- a/packages/eslint-config-bananass/src/rules/react/react.test.js
+++ b/packages/eslint-config-bananass/src/rules/react/react.test.js
@@ -21,10 +21,12 @@ const prefix = 'react/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must start with \`${prefix}\`.`, () => {
-  it('react.js', () => {
-    Object.keys(react).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+describe('react', () => {
+  describe(`All key values must start with \`${prefix}\`.`, () => {
+    it('react.js', () => {
+      Object.keys(react).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
   });
 });

--- a/packages/eslint-config-bananass/src/rules/stylistic-js/stylistic-js.test.js
+++ b/packages/eslint-config-bananass/src/rules/stylistic-js/stylistic-js.test.js
@@ -21,10 +21,12 @@ const prefix = '@stylistic/js/';
 // Test
 // --------------------------------------------------------------------------------
 
-describe(`All key values must start with \`${prefix}\`.`, () => {
-  it('stylistic-js.js', () => {
-    Object.keys(stylisticJs).forEach(key => {
-      strictEqual(key.startsWith(prefix), true);
+describe('stylistic-js', () => {
+  describe(`All key values must start with \`${prefix}\`.`, () => {
+    it('stylistic-js.js', () => {
+      Object.keys(stylisticJs).forEach(key => {
+        strictEqual(key.startsWith(prefix), true);
+      });
     });
   });
 });


### PR DESCRIPTION
This pull request adds test descriptions to several test files in the `packages/eslint-config-bananass` directory to improve the readability and organization of the tests. The most important changes include the addition of `describe` blocks to group related tests together.

Test organization improvements:

* [`packages/eslint-config-bananass/src/rules/eslint/eslint.test.js`](diffhunk://#diff-c060423761a34eda8493c1e0d772676fa13210a10ddc0a601bffa94ef5b3cd63R26): Added `describe('eslint', () => { ... })` block to group ESLint-related tests. [[1]](diffhunk://#diff-c060423761a34eda8493c1e0d772676fa13210a10ddc0a601bffa94ef5b3cd63R26) [[2]](diffhunk://#diff-c060423761a34eda8493c1e0d772676fa13210a10ddc0a601bffa94ef5b3cd63R46)
* [`packages/eslint-config-bananass/src/rules/import/import.test.js`](diffhunk://#diff-58c37bdad72eb91ded62622dcffd64ae126ad6980b5f852180b75f6cad4b7229R27): Added `describe('import', () => { ... })` block to group import-related tests. [[1]](diffhunk://#diff-58c37bdad72eb91ded62622dcffd64ae126ad6980b5f852180b75f6cad4b7229R27) [[2]](diffhunk://#diff-58c37bdad72eb91ded62622dcffd64ae126ad6980b5f852180b75f6cad4b7229R53)
* [`packages/eslint-config-bananass/src/rules/jsx-a11y/jsx-a11y.test.js`](diffhunk://#diff-aa28f6b6f1931016583638b4e4f5bc6be8526483ee119bb8f525277c37006d0fR24-R32): Added `describe('jsx-a11y', () => { ... })` block to group JSX accessibility-related tests.
* [`packages/eslint-config-bananass/src/rules/next/next.test.js`](diffhunk://#diff-edebcf570cd8714838f57f4334154b49124d0705442ecb02b94511c60ed381c9R24-R32): Added `describe('next', () => { ... })` block to group Next.js-related tests.
* [`packages/eslint-config-bananass/src/rules/node/node.test.js`](diffhunk://#diff-1820851ff06f5f7b87aa91fa71be4e25521f051b4a521abc71b88d5590b1c17eR24-R32): Added `describe('node', () => { ... })` block to group Node.js-related tests.

Similar changes were made to the following files to group tests by their respective categories:

* `packages/eslint-config-bananass/src/rules/react-compiler/react-compiler.test.js`
* `packages/eslint-config-bananass/src/rules/react-hooks/react-hooks.test.js`
* `packages/eslint-config-bananass/src/rules/react/react.test.js`
* `packages/eslint-config-bananass/src/rules/stylistic-js/stylistic-js.test.js`