### PR TITLE
feat(eslint-config-bananass): add new `tsx` configs

### DIFF
--- a/packages/eslint-config-bananass/src/configs/tsx-next.js
+++ b/packages/eslint-config-bananass/src/configs/tsx-next.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Configuration applied when a user configuration extends from `tsx.next`.
+ *
+ * - Values not explicitly defined on the object will use their default values.
+ * - Use the config inspector (`--inspect-config` in the CLI) to test which config objects apply to a specific file.
+ */
+
+// --------------------------------------------------------------------------------
+// Require
+// --------------------------------------------------------------------------------
+
+const { ts, tsx } = require('../files');
+const { globals, parser, parserOptions } = require('../language-options');
+const { react } = require('../settings');
+
+const {
+  importPlugin,
+  nodePlugin,
+  stylisticJsPlugin,
+  jsxA11yPlugin,
+  reactPlugin,
+  reactCompilerPlugin,
+  reactHooksPlugin,
+  nextPlugin,
+  typescriptPlugin,
+} = require('../plugins');
+
+const {
+  eslintRules,
+  importRules,
+  nodeRules,
+  stylisticJsRules,
+  jsxA11yRules,
+  reactRules,
+  reactCompilerRules,
+  reactHooksRules,
+  nextRules,
+  typescriptRules,
+} = require('../rules');
+
+// --------------------------------------------------------------------------------
+// Exports
+// --------------------------------------------------------------------------------
+
+module.exports = {
+  name: 'bananass/tsx-next',
+  files: [...ts, ...tsx],
+  languageOptions: {
+    globals,
+    parser,
+    parserOptions,
+  },
+  plugins: {
+    ...importPlugin,
+    ...nodePlugin,
+    ...stylisticJsPlugin,
+    ...jsxA11yPlugin,
+    ...reactPlugin,
+    ...reactCompilerPlugin,
+    ...reactHooksPlugin,
+    ...nextPlugin,
+    ...typescriptPlugin,
+  },
+  rules: {
+    ...eslintRules,
+    ...importRules,
+    ...nodeRules,
+    ...stylisticJsRules,
+    ...jsxA11yRules,
+    ...reactRules,
+    ...reactCompilerRules,
+    ...reactHooksRules,
+    ...nextRules,
+    ...typescriptRules,
+
+    'react/react-in-jsx-scope': 'off',
+  },
+  settings: {
+    react,
+  },
+};

--- a/packages/eslint-config-bananass/src/configs/tsx-react.js
+++ b/packages/eslint-config-bananass/src/configs/tsx-react.js
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview Configuration applied when a user configuration extends from `tsx.react`.
+ *
+ * - Values not explicitly defined on the object will use their default values.
+ * - Use the config inspector (`--inspect-config` in the CLI) to test which config objects apply to a specific file.
+ */
+
+// --------------------------------------------------------------------------------
+// Require
+// --------------------------------------------------------------------------------
+
+const { ts, tsx } = require('../files');
+const { globals, parser, parserOptions } = require('../language-options');
+const { react } = require('../settings');
+
+const {
+  importPlugin,
+  nodePlugin,
+  stylisticJsPlugin,
+  jsxA11yPlugin,
+  reactPlugin,
+  reactCompilerPlugin,
+  reactHooksPlugin,
+  typescriptPlugin,
+} = require('../plugins');
+
+const {
+  eslintRules,
+  importRules,
+  nodeRules,
+  stylisticJsRules,
+  jsxA11yRules,
+  reactRules,
+  reactCompilerRules,
+  reactHooksRules,
+  typescriptRules,
+} = require('../rules');
+
+// --------------------------------------------------------------------------------
+// Exports
+// --------------------------------------------------------------------------------
+
+module.exports = {
+  name: 'bananass/tsx-react',
+  files: [...ts, ...tsx],
+  languageOptions: {
+    globals,
+    parser,
+    parserOptions,
+  },
+  plugins: {
+    ...importPlugin,
+    ...nodePlugin,
+    ...stylisticJsPlugin,
+    ...jsxA11yPlugin,
+    ...reactPlugin,
+    ...reactCompilerPlugin,
+    ...reactHooksPlugin,
+    ...typescriptPlugin,
+  },
+  rules: {
+    ...eslintRules,
+    ...importRules,
+    ...nodeRules,
+    ...stylisticJsRules,
+    ...jsxA11yRules,
+    ...reactRules,
+    ...reactCompilerRules,
+    ...reactHooksRules,
+    ...typescriptRules,
+  },
+  settings: {
+    react,
+  },
+};

--- a/packages/eslint-config-bananass/src/index.js
+++ b/packages/eslint-config-bananass/src/index.js
@@ -11,6 +11,8 @@ const js = require('./configs/js');
 const jsxReact = require('./configs/jsx-react');
 const jsxNext = require('./configs/jsx-next');
 const ts = require('./configs/ts');
+const tsxReact = require('./configs/tsx-react');
+const tsxNext = require('./configs/tsx-next');
 
 const { name, version } = require('../package.json');
 
@@ -31,8 +33,8 @@ module.exports = {
       next: jsxNext,
     },
     tsx: {
-      react: '...', // TODO
-      next: '...', // TODO
+      react: tsxReact,
+      next: tsxNext,
     },
   },
 };

--- a/packages/eslint-config-bananass/src/rules/react/react.js
+++ b/packages/eslint-config-bananass/src/rules/react/react.js
@@ -234,7 +234,7 @@ module.exports = {
     'error',
     {
       allow: 'as-needed',
-      extensions: ['.jsx'],
+      extensions: ['.jsx', '.tsx'],
       ignoreFilesWithoutCode: true,
     },
   ],

--- a/websites/eslint-config-bananass/config.js
+++ b/websites/eslint-config-bananass/config.js
@@ -5,4 +5,6 @@ module.exports = [
   bananass.configs.jsx.react,
   bananass.configs.jsx.next,
   bananass.configs.ts,
+  bananass.configs.tsx.react,
+  bananass.configs.tsx.next,
 ];


### PR DESCRIPTION
This pull request includes significant updates to the ESLint configuration for TypeScript and React projects. The changes introduce new configurations for `tsx-react` and `tsx-next`, and update existing configurations to support `.tsx` files.

New configurations:

* [`packages/eslint-config-bananass/src/configs/tsx-next.js`](diffhunk://#diff-7e6986b8aa252958b9da97c71d62e00f1895da50f896ceb71305ba34671b403aR1-R81): Added a new configuration for projects using TypeScript and Next.js. This configuration includes relevant plugins and rules.
* [`packages/eslint-config-bananass/src/configs/tsx-react.js`](diffhunk://#diff-1f99df34d53d43dd73a2dbe7af4e50a96ff8a4d5b36cbb7fc8a9296ab0bc22fdR1-R75): Added a new configuration for projects using TypeScript and React. This configuration includes relevant plugins and rules.

Updates to existing configurations:

* [`packages/eslint-config-bananass/src/index.js`](diffhunk://#diff-da6ac4dc852a85b2a5c769cf09235e210f89ee7efbfd4f64929d892bf91a5848R14-R15): Integrated the new `tsx-react` and `tsx-next` configurations into the main export object. [[1]](diffhunk://#diff-da6ac4dc852a85b2a5c769cf09235e210f89ee7efbfd4f64929d892bf91a5848R14-R15) [[2]](diffhunk://#diff-da6ac4dc852a85b2a5c769cf09235e210f89ee7efbfd4f64929d892bf91a5848L34-R37)
* [`packages/eslint-config-bananass/src/rules/react/react.js`](diffhunk://#diff-d2e14b50ea9ff3e279f30d972b03fd16efe19993bd0d6670de8571d2213515c5L237-R237): Updated the React ESLint rules to support `.tsx` file extensions.
* [`websites/eslint-config-bananass/config.js`](diffhunk://#diff-c1f34d5ca272776f85e487187fcf6795c3f6a9a7993cf71e9763e2ece5debefeR8-R9): Added the new `tsx-react` and `tsx-next` configurations to the website configuration.