### PR TITLE
feat(bananass-utils-console)!: add type support for `spinner` and update default color

### DIFF
--- a/packages/bananass-utils-console/src/icons/icons.js
+++ b/packages/bananass-utils-console/src/icons/icons.js
@@ -14,7 +14,7 @@ import isUnicodeSupported from 'is-unicode-supported';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {object} SpinnerIcon
+ * @typedef {object} SpinnerStyle
  * @property {string[]} frames
  * @property {number} [interval]
  */
@@ -34,7 +34,7 @@ export const infoIcon = c.blue.bold(isUnicodeSupported() ? '✦' : 'i');
 /** @type {string} */
 export const bananassIcon = c.yellow(isUnicodeSupported() ? '🍌' : '');
 
-/** @type {SpinnerIcon} */
+/** @type {SpinnerStyle} */
 export const defaultSpinner = {
   frames: isUnicodeSupported()
     ? ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']


### PR DESCRIPTION
This pull request includes several changes to the `packages/bananass-utils-console` package, focusing on improving the spinner functionality and code documentation. The key changes involve renaming typedefs, adding detailed JSDoc comments, and modifying the spinner's color and behavior.

### Typedef and Documentation Improvements:
* Renamed `SpinnerIcon` to `SpinnerStyle` and updated corresponding typedefs in `icons.js` and `spinner.js`. [[1]](diffhunk://#diff-d3f16eb3ff3fa7e044b861f681f7554eca8a0d838ebe6ef5e26e2adcdb008683L17-R17) [[2]](diffhunk://#diff-d3f16eb3ff3fa7e044b861f681f7554eca8a0d838ebe6ef5e26e2adcdb008683L37-R37) [[3]](diffhunk://#diff-8b2068e270f808f9232fbc4c64ad8c7667268d13530c4dc264e9584a1afbcdebR22-R54)
* Added detailed JSDoc comments for the `Spinner` class methods and properties, including examples and parameter descriptions. [[1]](diffhunk://#diff-8b2068e270f808f9232fbc4c64ad8c7667268d13530c4dc264e9584a1afbcdebR194-R201) [[2]](diffhunk://#diff-8b2068e270f808f9232fbc4c64ad8c7667268d13530c4dc264e9584a1afbcdebR248-R292) [[3]](diffhunk://#diff-8b2068e270f808f9232fbc4c64ad8c7667268d13530c4dc264e9584a1afbcdebR317-R355) [[4]](diffhunk://#diff-8b2068e270f808f9232fbc4c64ad8c7667268d13530c4dc264e9584a1afbcdebR365-R387)

### Code Enhancements:
* Updated the default spinner color from cyan to yellow in the `Spinner` class. [[1]](diffhunk://#diff-8b2068e270f808f9232fbc4c64ad8c7667268d13530c4dc264e9584a1afbcdebR64-R95) [[2]](diffhunk://#diff-8b2068e270f808f9232fbc4c64ad8c7667268d13530c4dc264e9584a1afbcdebL78-R122)
* Removed the unnecessary import of `process` from `node:process` in `spinner.js`.