### PR TITLE
refactor(bananass): update global variable reference for `BAEKJOON_PROBLEM_NUMBER_WITH_PATH` in build function

### DIFF
--- a/packages/bananass/src/commands/bananass-build/build.js
+++ b/packages/bananass/src/commands/bananass-build/build.js
@@ -116,10 +116,9 @@ export default async function build(problems, configObject) {
             stage: webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
           }),
           new webpack.DefinePlugin({
-            BAEKJOON_PROBLEM_NUMBER_WITH_PATH: JSON.stringify(
+            'globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH': JSON.stringify(
               resolve(resolvedEntryDir, problem),
-            ), // TODO: `globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH`.
-
+            ),
             'globalThis.IS_PROD': JSON.stringify(true), // Same with `process.env.NODE_ENV === 'production'`.
           }),
         ],

--- a/packages/bananass/src/commands/bananass-build/template-fs.cjs
+++ b/packages/bananass/src/commands/bananass-build/template-fs.cjs
@@ -2,7 +2,7 @@
  * @fileoverview Entry file for the `webpack.js` file.
  *
  * The `build` function's `webpackConfigs.entry` property references this file.
- * The global variable `BAEKJOON_PROBLEM_NUMBER_WITH_PATH` is defined via the `build` function's `webpackConfigs.plugin`'s `new webpack.DefinePlugin`.
+ * The global variable `globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH` is defined via the `build` function's `webpackConfigs.plugin`'s `new webpack.DefinePlugin`.
  */
 
 // --------------------------------------------------------------------------------
@@ -11,8 +11,7 @@
 
 const { readFileSync } = require('node:fs');
 
-// dynamic require
-const solutionModule = require(BAEKJOON_PROBLEM_NUMBER_WITH_PATH); // eslint-disable-line
+const solutionModule = require(globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH); // dynamic require
 
 // --------------------------------------------------------------------------------
 // Declaration

--- a/packages/bananass/src/commands/bananass-build/template-rl.cjs
+++ b/packages/bananass/src/commands/bananass-build/template-rl.cjs
@@ -2,7 +2,7 @@
  * @fileoverview Entry file for the `webpack.js` file.
  *
  * The `build` function's `webpackConfigs.entry` property references this file.
- * The global variable `BAEKJOON_PROBLEM_NUMBER_WITH_PATH` is defined via the `build` function's `webpackConfigs.plugin`'s `new webpack.DefinePlugin`.
+ * The global variable `globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH` is defined via the `build` function's `webpackConfigs.plugin`'s `new webpack.DefinePlugin`.
  */
 
 // --------------------------------------------------------------------------------
@@ -13,8 +13,7 @@ const { createInterface } = require('node:readline');
 const { stdin: input, stdout: output } = require('node:process');
 const { EOL } = require('node:os');
 
-// dynamic require
-const solutionModule = require(BAEKJOON_PROBLEM_NUMBER_WITH_PATH); // eslint-disable-line
+const solutionModule = require(globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH); // dynamic require
 
 // --------------------------------------------------------------------------------
 // Declaration


### PR DESCRIPTION
This pull request focuses on updating the `BAEKJOON_PROBLEM_NUMBER_WITH_PATH` global variable to use `globalThis` for better scoping and consistency across the codebase. The changes affect multiple files and ensure that the global variable is correctly referenced throughout the project.

Global variable updates:

* [`packages/bananass/src/commands/bananass-build/build.js`](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4L119-R121): Updated `BAEKJOON_PROBLEM_NUMBER_WITH_PATH` to use `globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH` in the `webpack.DefinePlugin`.
* [`packages/bananass/src/commands/bananass-build/template-fs.cjs`](diffhunk://#diff-10967f3986443f0da26c5ef2346ba9ab9ffa92382931bf0ce5fda46f37808fbcL5-R5): Updated comments and dynamic require statements to use `globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH`. [[1]](diffhunk://#diff-10967f3986443f0da26c5ef2346ba9ab9ffa92382931bf0ce5fda46f37808fbcL5-R5) [[2]](diffhunk://#diff-10967f3986443f0da26c5ef2346ba9ab9ffa92382931bf0ce5fda46f37808fbcL14-R14)
* [`packages/bananass/src/commands/bananass-build/template-rl.cjs`](diffhunk://#diff-ffa2916ce00d102b565d768075e2de5b9206fa13b7fd1348f9a7954e39087f16L5-R5): Updated comments and dynamic require statements to use `globalThis.BAEKJOON_PROBLEM_NUMBER_WITH_PATH`. [[1]](diffhunk://#diff-ffa2916ce00d102b565d768075e2de5b9206fa13b7fd1348f9a7954e39087f16L5-R5) [[2]](diffhunk://#diff-ffa2916ce00d102b565d768075e2de5b9206fa13b7fd1348f9a7954e39087f16L16-R16)