### PR TITLE
fix(bananass): enable bananass icon display in spinner messages across multiple commands

### DIFF
--- a/packages/bananass/src/commands/bananass-bug/bug.js
+++ b/packages/bananass/src/commands/bananass-bug/bug.js
@@ -55,7 +55,7 @@ export default async function bug(configObject) {
   // CLI Animation
   // ------------------------------------------------------------------------------
 
-  logger.log(() => spinner.start(bananass('Opening in a browser...'))); // TODO: Set `showIcon` true
+  logger.log(() => spinner.start(bananass('Opening in a browser...', true)));
 
   // ------------------------------------------------------------------------------
   // Open

--- a/packages/bananass/src/commands/bananass-build/build.js
+++ b/packages/bananass/src/commands/bananass-build/build.js
@@ -77,7 +77,7 @@ export default async function build(problems, configObject) {
   // ------------------------------------------------------------------------------
 
   // Ensure correct `this` binding for `spinner.start` using arrow function. (Or use `apply`, `call` or `bind` method.)
-  logger.log(() => spinner.start(bananass('Bananass build is running...')));
+  logger.log(() => spinner.start(bananass('Bananass build is running...', true)));
 
   // ------------------------------------------------------------------------------
   // Webpack Configs

--- a/packages/bananass/src/commands/bananass-discussion/discussion.js
+++ b/packages/bananass/src/commands/bananass-discussion/discussion.js
@@ -55,7 +55,7 @@ export default async function repo(configObject) {
   // CLI Animation
   // ------------------------------------------------------------------------------
 
-  logger.log(() => spinner.start(bananass('Opening in a browser...')));
+  logger.log(() => spinner.start(bananass('Opening in a browser...', true)));
 
   // ------------------------------------------------------------------------------
   // Open

--- a/packages/bananass/src/commands/bananass-home/home.js
+++ b/packages/bananass/src/commands/bananass-home/home.js
@@ -55,7 +55,7 @@ export default async function home(configObject) {
   // CLI Animation
   // ------------------------------------------------------------------------------
 
-  logger.log(() => spinner.start(bananass('Opening in a browser...')));
+  logger.log(() => spinner.start(bananass('Opening in a browser...', true)));
 
   // ------------------------------------------------------------------------------
   // Open

--- a/packages/bananass/src/commands/bananass-open/open.js
+++ b/packages/bananass/src/commands/bananass-open/open.js
@@ -58,7 +58,7 @@ export default async function home(problems, configObject) {
   // CLI Animation
   // ------------------------------------------------------------------------------
 
-  logger.log(() => spinner.start(bananass('Opening in a browser...')));
+  logger.log(() => spinner.start(bananass('Opening in a browser...', true)));
 
   // ------------------------------------------------------------------------------
   // Open

--- a/packages/bananass/src/commands/bananass-repo/repo.js
+++ b/packages/bananass/src/commands/bananass-repo/repo.js
@@ -55,7 +55,7 @@ export default async function repo(configObject) {
   // CLI Animation
   // ------------------------------------------------------------------------------
 
-  logger.log(() => spinner.start(bananass('Opening in a browser...')));
+  logger.log(() => spinner.start(bananass('Opening in a browser...', true)));
 
   // ------------------------------------------------------------------------------
   // Open

--- a/packages/bananass/src/commands/bananass-run/run.js
+++ b/packages/bananass/src/commands/bananass-run/run.js
@@ -74,7 +74,7 @@ export default async function run(problems, configObject) {
   // CLI Animation
   // ------------------------------------------------------------------------------
 
-  logger.log(() => spinner.start(bananass('Bananass run is running...')));
+  logger.log(() => spinner.start(bananass('Bananass run is running...', true)));
 
   // ------------------------------------------------------------------------------
   // Resolve Entry Files


### PR DESCRIPTION
This pull request includes changes to multiple command files in the `bananass` package to ensure the `showIcon` parameter is set to `true` when starting the spinner animation. This change provides a consistent user interface experience across different commands.

Changes to spinner animation:

* [`packages/bananass/src/commands/bananass-bug/bug.js`](diffhunk://#diff-c49c2ac0f48f162fb6dd63de6eaaf35f7fc82f0372fc582a3332539634eb576bL58-R58): Set `showIcon` to `true` in the `bananass` function call within the `bug` command.
* [`packages/bananass/src/commands/bananass-build/build.js`](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4L80-R80): Set `showIcon` to `true` in the `bananass` function call within the `build` command.
* [`packages/bananass/src/commands/bananass-discussion/discussion.js`](diffhunk://#diff-03cd972aa107ca0cec83822951b2bd90c5839c4243593c102b24aa17390458a6L58-R58): Set `showIcon` to `true` in the `bananass` function call within the `discussion` command.
* [`packages/bananass/src/commands/bananass-home/home.js`](diffhunk://#diff-51296f54e1d3e1c2abe3893ec66ff745811830d67cd373dcfdbe56986e7df4b8L58-R58): Set `showIcon` to `true` in the `bananass` function call within the `home` command.
* [`packages/bananass/src/commands/bananass-open/open.js`](diffhunk://#diff-6c43147143109854fa17abf461dfdde7e862fc194454f5869fae5dc60631a682L61-R61): Set `showIcon` to `true` in the `bananass` function call within the `open` command.
* [`packages/bananass/src/commands/bananass-repo/repo.js`](diffhunk://#diff-561777915366eed77e0e117f652a202ef5a969d05ae4b8b4f4d3291f03102088L58-R58): Set `showIcon` to `true` in the `bananass` function call within the `repo` command.
* [`packages/bananass/src/commands/bananass-run/run.js`](diffhunk://#diff-e32949e4dff2549ab48c17b6a98d88eff1f009162d34c041087ba9fdd1480ce2L77-R77): Set `showIcon` to `true` in the `bananass` function call within the `run` command.