### PR TITLE
chore(*): update `publish-package` script to use 'next' pre-dist tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "prepare": "husky",
-    "publish-package": "npx lerna publish from-package --pre-dist-tag canary --yes",
+    "publish-package": "npx lerna publish from-package --pre-dist-tag next --yes",
     "coverage": "npx c8 --reporter=lcov npm run test",
     "test": "npx lerna run test --ignore npm-bananass",
     "test:ex:sb": "npm run test -w examples/solutions-bananass",


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to update the publish script. The change modifies the `publish-package` script to use the `next` pre-distribution tag instead of the `canary` tag.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L19-R19): Updated the `publish-package` script to use `next` pre-distribution tag instead of `canary`.