### PR TITLE
refactor(bananass): refactor `find-root-dir.js` to improve error messages and update test file overview

### DIFF
--- a/packages/bananass/src/core/fs/find-root-dir/find-root-dir.js
+++ b/packages/bananass/src/core/fs/find-root-dir/find-root-dir.js
@@ -7,8 +7,8 @@
 // --------------------------------------------------------------------------------
 
 import { join, resolve } from 'node:path';
-import cp from 'node:child_process';
-import fs from 'node:fs';
+import cp from 'node:child_process'; // DO NOT USE DESTRUCTURING syntax due to `mock` usage in test.
+import fs from 'node:fs'; // DO NOT USE DESTRUCTURING syntax due to `mock` usage in test.
 
 import { error } from 'bananass-utils-console/theme';
 
@@ -42,7 +42,8 @@ export default function findRootDir() {
   } catch ({ message }) {
     throw new Error(
       error(
-        `Git command failed. Ensure Git is installed and you are inside a Git repository - ${message}`,
+        `Git command failed. Ensure Git is installed and you are inside a Git repository\n${message}`,
+        true,
       ),
     );
   }
@@ -50,7 +51,8 @@ export default function findRootDir() {
 
   throw new Error(
     error(
-      `Cannot find root directory. Ensure ${PACKAGE_JSON} exists in the project root.\n> path: ${path}\n> pathFallback: ${pathFallback}`,
+      `Cannot find root directory. Ensure ${PACKAGE_JSON} exists in the project root\n> path: ${path}\n> pathFallback: ${pathFallback}`,
+      true,
     ),
   );
 }

--- a/packages/bananass/src/core/fs/find-root-dir/find-root-dir.test.js
+++ b/packages/bananass/src/core/fs/find-root-dir/find-root-dir.test.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `findRootDir.js`.
+ * @fileoverview Test for `find-root-dir.js`.
  */
 
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request includes several changes to the `find-root-dir` functionality in the `bananass` package. The changes focus on improving error messaging and ensuring compatibility with test mocks.

### Improvements to error messaging:

* [`find-root-dir.js`](diffhunk://#diff-aed2769c5bf3d27e1aa5d4b258ebffc32608a930d0f9f6a9d4c31e6416de2122L45-R55): Enhanced the error messages for Git command failures and missing `PACKAGE_JSON` to improve clarity.

### Compatibility with test mocks:

* [`find-root-dir.js`](diffhunk://#diff-aed2769c5bf3d27e1aa5d4b258ebffc32608a930d0f9f6a9d4c31e6416de2122L10-R11): Added comments to avoid destructuring imports for `child_process` and `fs` due to mock usage in tests.

### Minor corrections:

* [`find-root-dir.test.js`](diffhunk://#diff-66083096c3b9bfd47416706df5b93b42295382b172a5195d7cd2a56a7eb823c3L2-R2): Corrected the file name in the file overview comment.