### PR TITLE
refactor(bananass): update `configLoader` to use `defaultConfigObject` and improve test cases

### DIFF
--- a/packages/bananass/src/cli/bananass-bug.js
+++ b/packages/bananass/src/cli/bananass-bug.js
@@ -9,7 +9,7 @@
 import logger from 'bananass-utils-console/logger';
 
 import { bug as bugCmd } from '../commands/index.js';
-import { configLoader, defaultConfigObject } from '../core/conf/index.js';
+import { configLoader } from '../core/conf/index.js';
 
 import { bug as bugDesc } from '../core/cli/descriptions.js';
 import {
@@ -63,10 +63,7 @@ export default function bug(program) {
         },
       };
 
-      const { config: configObject } = await configLoader({
-        cliConfigObject,
-        defaultConfigObject,
-      });
+      const { config: configObject } = await configLoader({ cliConfigObject });
 
       logger(configObject.console)
         .debug('command:', command.name())

--- a/packages/bananass/src/cli/bananass-build.js
+++ b/packages/bananass/src/cli/bananass-build.js
@@ -9,7 +9,7 @@
 import logger from 'bananass-utils-console/logger';
 
 import { build as buildCmd } from '../commands/index.js';
-import { configLoader, defaultConfigObject } from '../core/conf/index.js';
+import { configLoader } from '../core/conf/index.js';
 
 import { build as buildDesc } from '../core/cli/descriptions.js';
 import { problems as problemsArg } from '../core/cli/arguments.js';
@@ -71,10 +71,7 @@ export default function build(program) {
         },
       };
 
-      const { config: configObject } = await configLoader({
-        cliConfigObject,
-        defaultConfigObject,
-      });
+      const { config: configObject } = await configLoader({ cliConfigObject });
 
       logger(configObject.console)
         .debug('command:', command.name())

--- a/packages/bananass/src/cli/bananass-discussion.js
+++ b/packages/bananass/src/cli/bananass-discussion.js
@@ -9,7 +9,7 @@
 import logger from 'bananass-utils-console/logger';
 
 import { discussion as discussionCmd } from '../commands/index.js';
-import { configLoader, defaultConfigObject } from '../core/conf/index.js';
+import { configLoader } from '../core/conf/index.js';
 
 import { discussion as discussionDesc } from '../core/cli/descriptions.js';
 import {
@@ -63,10 +63,7 @@ export default function discussion(program) {
         },
       };
 
-      const { config: configObject } = await configLoader({
-        cliConfigObject,
-        defaultConfigObject,
-      });
+      const { config: configObject } = await configLoader({ cliConfigObject });
 
       logger(configObject.console)
         .debug('command:', command.name())

--- a/packages/bananass/src/cli/bananass-home.js
+++ b/packages/bananass/src/cli/bananass-home.js
@@ -9,7 +9,7 @@
 import logger from 'bananass-utils-console/logger';
 
 import { home as homeCmd } from '../commands/index.js';
-import { configLoader, defaultConfigObject } from '../core/conf/index.js';
+import { configLoader } from '../core/conf/index.js';
 
 import { home as homeDesc } from '../core/cli/descriptions.js';
 import {
@@ -60,10 +60,7 @@ export default function home(program) {
         },
       };
 
-      const { config: configObject } = await configLoader({
-        cliConfigObject,
-        defaultConfigObject,
-      });
+      const { config: configObject } = await configLoader({ cliConfigObject });
 
       logger(configObject.console)
         .debug('command:', command.name())

--- a/packages/bananass/src/cli/bananass-info.js
+++ b/packages/bananass/src/cli/bananass-info.js
@@ -9,7 +9,7 @@
 import logger from 'bananass-utils-console/logger';
 
 import { info as infoCmd } from '../commands/index.js';
-import { configLoader, defaultConfigObject } from '../core/conf/index.js';
+import { configLoader } from '../core/conf/index.js';
 
 import { info as infoDesc } from '../core/cli/descriptions.js';
 import {
@@ -57,10 +57,7 @@ export default function info(program) {
         },
       };
 
-      const { config: configObject } = await configLoader({
-        cliConfigObject,
-        defaultConfigObject,
-      });
+      const { config: configObject } = await configLoader({ cliConfigObject });
 
       logger(configObject.console)
         .debug('command:', command.name())

--- a/packages/bananass/src/cli/bananass-open.js
+++ b/packages/bananass/src/cli/bananass-open.js
@@ -9,7 +9,7 @@
 import logger from 'bananass-utils-console/logger';
 
 import { open as openCmd } from '../commands/index.js';
-import { configLoader, defaultConfigObject } from '../core/conf/index.js';
+import { configLoader } from '../core/conf/index.js';
 
 import { open as openDesc } from '../core/cli/descriptions.js';
 import { problems as problemsArg } from '../core/cli/arguments.js';
@@ -62,10 +62,7 @@ export default function open(program) {
         },
       };
 
-      const { config: configObject } = await configLoader({
-        cliConfigObject,
-        defaultConfigObject,
-      });
+      const { config: configObject } = await configLoader({ cliConfigObject });
 
       logger(configObject.console)
         .debug('command:', command.name())

--- a/packages/bananass/src/cli/bananass-repo.js
+++ b/packages/bananass/src/cli/bananass-repo.js
@@ -9,7 +9,7 @@
 import logger from 'bananass-utils-console/logger';
 
 import { repo as repoCmd } from '../commands/index.js';
-import { configLoader, defaultConfigObject } from '../core/conf/index.js';
+import { configLoader } from '../core/conf/index.js';
 
 import { repo as repoDesc } from '../core/cli/descriptions.js';
 import {
@@ -60,10 +60,7 @@ export default function repo(program) {
         },
       };
 
-      const { config: configObject } = await configLoader({
-        cliConfigObject,
-        defaultConfigObject,
-      });
+      const { config: configObject } = await configLoader({ cliConfigObject });
 
       logger(configObject.console)
         .debug('command:', command.name())

--- a/packages/bananass/src/cli/bananass-run.js
+++ b/packages/bananass/src/cli/bananass-run.js
@@ -9,7 +9,7 @@
 import logger from 'bananass-utils-console/logger';
 
 import { run as runCmd } from '../commands/index.js';
-import { configLoader, defaultConfigObject } from '../core/conf/index.js';
+import { configLoader } from '../core/conf/index.js';
 
 import { run as runDesc } from '../core/cli/descriptions.js';
 import { problems as problemsArg } from '../core/cli/arguments.js';
@@ -60,10 +60,7 @@ export default function run(program) {
         },
       };
 
-      const { config: configObject } = await configLoader({
-        cliConfigObject,
-        defaultConfigObject,
-      });
+      const { config: configObject } = await configLoader({ cliConfigObject });
 
       logger(configObject.console)
         .debug('command:', command.name())

--- a/packages/bananass/src/core/conf/config-loader/config-loader.js
+++ b/packages/bananass/src/core/conf/config-loader/config-loader.js
@@ -9,6 +9,7 @@
 
 import { loadConfig } from 'c12';
 
+import dco from '../default-config-object/index.js';
 import { findRootDir } from '../../fs/index.js';
 import { PKG_NAME } from '../../constants.js';
 
@@ -30,17 +31,17 @@ import { PKG_NAME } from '../../constants.js';
  * - Merge priority: CLI config object > Config file config object > Default config object
  *
  * @param {object} configLoaderOptions
- * @param {string} [configLoaderOptions.cwd] Current working directory.
- * @param {ConfigObject} configLoaderOptions.cliConfigObject CLI config object.
- * @param {ConfigObject} configLoaderOptions.defaultConfigObject Default config object.
+ * @param {string} [configLoaderOptions.cwd] Current working directory. (default: `findRootDir()`)
+ * @param {ConfigObject} [configLoaderOptions.cliConfigObject] CLI config object. (default: `{}`)
+ * @param {ConfigObject} [configLoaderOptions.defaultConfigObject] Default config object. (default: `defaultConfigObject`)
  * @returns Merged configuration object.
  * @async
  */
 export default async function configLoader({
   cwd = findRootDir(),
   cliConfigObject = {},
-  defaultConfigObject = {},
-}) {
+  defaultConfigObject = dco,
+} = {}) {
   const config = await loadConfig({
     cwd,
     name: PKG_NAME,

--- a/packages/bananass/src/core/conf/config-loader/config-loader.test.js
+++ b/packages/bananass/src/core/conf/config-loader/config-loader.test.js
@@ -21,7 +21,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const fixturesDir = join(__dirname, 'fixtures');
 
-const configFileObject = {
+const configObject = {
   1: {
     1: 'a',
     2: 'b',
@@ -49,65 +49,73 @@ describe('config-loader.js', () => {
     it('should load `bananass.config.cjs` correctly', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-cjs'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should load `bananass.config.cts` correctly', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-cts'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should load CJS `bananass.config.js` correctly, even if the `type` is not specified in `package.json`', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-js-cjs'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should load ESM `bananass.config.js` correctly, even if the `type` is not specified in `package.json`', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-js-mjs'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should load `bananass.config.mjs` correctly', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-mjs'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should load `bananass.config.mts` correctly', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-mts'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should load `bananass.config.ts` correctly, even if the `type` is not specified in `package.json`', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-ts-cts'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should load `bananass.config.ts` correctly, even if the `type` is not specified in `package.json`', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-ts-mts'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should use default options when no config files are found', async () => {
@@ -157,6 +165,7 @@ describe('config-loader.js', () => {
     it('should override all options when all options are specified', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-cjs'),
+        defaultConfigObject: {},
         cliConfigObject: {
           1: {
             1: 'overrided',
@@ -199,6 +208,7 @@ describe('config-loader.js', () => {
     it('should override some options when some options are specified', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-cjs'),
+        defaultConfigObject: {},
         cliConfigObject: {
           1: {
             1: 'overrided',
@@ -236,6 +246,7 @@ describe('config-loader.js', () => {
     it('should add new properties when unknown config file options are specified', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-cjs'),
+        defaultConfigObject: {},
         cliConfigObject: {
           3: {
             4: 'overrided',
@@ -273,18 +284,20 @@ describe('config-loader.js', () => {
     it('should use the options of config file when no options are specified', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-cjs'),
+        defaultConfigObject: {},
         cliConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
 
     it('should use the options of config file when `cliOptions` is not specified', async () => {
       const { config } = await configLoader({
         cwd: join(fixturesDir, 'bananass-config-cjs'),
+        defaultConfigObject: {},
       });
 
-      deepStrictEqual(config, configFileObject);
+      deepStrictEqual(config, configObject);
     });
   });
 });


### PR DESCRIPTION
This pull request focuses on simplifying the configuration loading process across multiple command files by removing the explicit import and usage of `defaultConfigObject` in favor of using a default parameter within the `configLoader` function. Additionally, the test cases are updated to reflect these changes.

Key changes include:

### Configuration Loading Simplification:
* Removed `defaultConfigObject` import and usage from multiple CLI command files (`bananass-bug.js`, `bananass-build.js`, `bananass-discussion.js`, `bananass-home.js`, `bananass-info.js`, `bananass-open.js`, `bananass-repo.js`, `bananass-run.js`). [[1]](diffhunk://#diff-196f36c2928080b1421ad5f1091b6715ba428f781678296dc43ee5fd1b7f4bd4L12-R12) [[2]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L12-R12) [[3]](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6L12-R12) [[4]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL12-R12) [[5]](diffhunk://#diff-bff245da03f8a2d2d1dc34bee509e9bc4a2eaaa81cf70498e71536284f9267caL12-R12) [[6]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL12-R12) [[7]](diffhunk://#diff-18cad518a6aa21886b7a585bd6846ed203fcbb98516a9191ed3c29e82e30869cL12-R12) [[8]](diffhunk://#diff-b60d6936d484b4fe5468cf7087467bdab42ddc70d1a1466f0301b5d41aa98658L12-R12)
* Updated `configLoader` function in `config-loader.js` to use `defaultConfigObject` as a default parameter instead of requiring it to be passed explicitly. [[1]](diffhunk://#diff-14102365d90891f39640bb88fecd7d7ec7eb7864e3c431fcf3e49b65dc32135aR12) [[2]](diffhunk://#diff-14102365d90891f39640bb88fecd7d7ec7eb7864e3c431fcf3e49b65dc32135aL33-R44)

### Test Case Adjustments:
* Updated test cases in `config-loader.test.js` to align with the new default parameter approach for `defaultConfigObject`. [[1]](diffhunk://#diff-619b4ec5a65af4159d55ed9a5f6bb9362f4996a71e9df9ece4d4145596ae57ebL24-R24) [[2]](diffhunk://#diff-619b4ec5a65af4159d55ed9a5f6bb9362f4996a71e9df9ece4d4145596ae57ebR52-R118) [[3]](diffhunk://#diff-619b4ec5a65af4159d55ed9a5f6bb9362f4996a71e9df9ece4d4145596ae57ebR168) [[4]](diffhunk://#diff-619b4ec5a65af4159d55ed9a5f6bb9362f4996a71e9df9ece4d4145596ae57ebR211) [[5]](diffhunk://#diff-619b4ec5a65af4159d55ed9a5f6bb9362f4996a71e9df9ece4d4145596ae57ebR249) [[6]](diffhunk://#diff-619b4ec5a65af4159d55ed9a5f6bb9362f4996a71e9df9ece4d4145596ae57ebR287-R300)