### PR TITLE
refactor(bananass): simplify and remove unused `ConfigObject` typedef from CLI files

### DIFF
--- a/packages/bananass/src/cli/bananass-bug.js
+++ b/packages/bananass/src/cli/bananass-bug.js
@@ -25,7 +25,6 @@ import {
 
 /**
  * @typedef {import('commander').Command} Command
- * @typedef {import('../core/types.js').ConfigObject} ConfigObject
  */
 
 // --------------------------------------------------------------------------------
@@ -51,24 +50,22 @@ export default function bug(program) {
     .action(async (options, command) => {
       const { browser, secretMode, debug, quiet } = options;
 
-      /** @type {ConfigObject} */
-      const cliConfigObject = {
-        browser: {
-          browser,
-          secretMode,
+      const { config: configObject } = await configLoader({
+        cliConfigObject: {
+          browser: {
+            browser,
+            secretMode,
+          },
+          console: {
+            debug,
+            quiet,
+          },
         },
-        console: {
-          debug,
-          quiet,
-        },
-      };
-
-      const { config: configObject } = await configLoader({ cliConfigObject });
+      });
 
       logger(configObject.console)
         .debug('command:', command.name())
         .debug('cli options:', options)
-        .debug('cli config object:', cliConfigObject)
         .debug('config object:', configObject)
         .eol();
 

--- a/packages/bananass/src/cli/bananass-build.js
+++ b/packages/bananass/src/cli/bananass-build.js
@@ -29,7 +29,6 @@ import {
 
 /**
  * @typedef {import('commander').Command} Command
- * @typedef {import('../core/types.js').ConfigObject} ConfigObject
  */
 
 // --------------------------------------------------------------------------------
@@ -56,28 +55,26 @@ export default function build(program) {
     .action(async (problems, options, command) => {
       const { cwd, entryDir, outDir, debug, quiet, clean, templateType } = options;
 
-      /** @type {ConfigObject} */
-      const cliConfigObject = {
-        cwd,
-        entryDir,
-        outDir,
-        console: {
-          debug,
-          quiet,
+      const { config: configObject } = await configLoader({
+        cliConfigObject: {
+          cwd,
+          entryDir,
+          outDir,
+          console: {
+            debug,
+            quiet,
+          },
+          build: {
+            clean,
+            templateType,
+          },
         },
-        build: {
-          clean,
-          templateType,
-        },
-      };
-
-      const { config: configObject } = await configLoader({ cliConfigObject });
+      });
 
       logger(configObject.console)
         .debug('command:', command.name())
         .debug('problems:', problems)
         .debug('cli options:', options)
-        .debug('cli config object:', cliConfigObject)
         .debug('config object:', configObject)
         .eol();
 

--- a/packages/bananass/src/cli/bananass-discussion.js
+++ b/packages/bananass/src/cli/bananass-discussion.js
@@ -25,7 +25,6 @@ import {
 
 /**
  * @typedef {import('commander').Command} Command
- * @typedef {import('../core/types.js').ConfigObject} ConfigObject
  */
 
 // --------------------------------------------------------------------------------
@@ -51,24 +50,22 @@ export default function discussion(program) {
     .action(async (options, command) => {
       const { browser, secretMode, debug, quiet } = options;
 
-      /** @type {ConfigObject} */
-      const cliConfigObject = {
-        browser: {
-          browser,
-          secretMode,
+      const { config: configObject } = await configLoader({
+        cliConfigObject: {
+          browser: {
+            browser,
+            secretMode,
+          },
+          console: {
+            debug,
+            quiet,
+          },
         },
-        console: {
-          debug,
-          quiet,
-        },
-      };
-
-      const { config: configObject } = await configLoader({ cliConfigObject });
+      });
 
       logger(configObject.console)
         .debug('command:', command.name())
         .debug('cli options:', options)
-        .debug('cli config object:', cliConfigObject)
         .debug('config object:', configObject)
         .eol();
 

--- a/packages/bananass/src/cli/bananass-home.js
+++ b/packages/bananass/src/cli/bananass-home.js
@@ -25,7 +25,6 @@ import {
 
 /**
  * @typedef {import('commander').Command} Command
- * @typedef {import('../core/types.js').ConfigObject} ConfigObject
  */
 
 // --------------------------------------------------------------------------------
@@ -48,24 +47,22 @@ export default function home(program) {
     .action(async (options, command) => {
       const { browser, secretMode, debug, quiet } = options;
 
-      /** @type {ConfigObject} */
-      const cliConfigObject = {
-        browser: {
-          browser,
-          secretMode,
+      const { config: configObject } = await configLoader({
+        cliConfigObject: {
+          browser: {
+            browser,
+            secretMode,
+          },
+          console: {
+            debug,
+            quiet,
+          },
         },
-        console: {
-          debug,
-          quiet,
-        },
-      };
-
-      const { config: configObject } = await configLoader({ cliConfigObject });
+      });
 
       logger(configObject.console)
         .debug('command:', command.name())
         .debug('cli options:', options)
-        .debug('cli config object:', cliConfigObject)
         .debug('config object:', configObject)
         .eol();
 

--- a/packages/bananass/src/cli/bananass-info.js
+++ b/packages/bananass/src/cli/bananass-info.js
@@ -24,7 +24,6 @@ import {
 
 /**
  * @typedef {import('commander').Command} Command
- * @typedef {import('../core/types.js').ConfigObject} ConfigObject
  */
 
 // --------------------------------------------------------------------------------
@@ -46,23 +45,21 @@ export default function info(program) {
     .action(async (options, command) => {
       const { debug, quiet, all } = options;
 
-      /** @type {ConfigObject} */
-      const cliConfigObject = {
-        console: {
-          debug,
-          quiet,
+      const { config: configObject } = await configLoader({
+        cliConfigObject: {
+          console: {
+            debug,
+            quiet,
+          },
+          info: {
+            all,
+          },
         },
-        info: {
-          all,
-        },
-      };
-
-      const { config: configObject } = await configLoader({ cliConfigObject });
+      });
 
       logger(configObject.console)
         .debug('command:', command.name())
         .debug('cli options:', options)
-        .debug('cli config object:', cliConfigObject)
         .debug('config object:', configObject)
         .eol();
 

--- a/packages/bananass/src/cli/bananass-open.js
+++ b/packages/bananass/src/cli/bananass-open.js
@@ -26,7 +26,6 @@ import {
 
 /**
  * @typedef {import('commander').Command} Command
- * @typedef {import('../core/types.js').ConfigObject} ConfigObject
  */
 
 // --------------------------------------------------------------------------------
@@ -50,25 +49,23 @@ export default function open(program) {
     .action(async (problems, options, command) => {
       const { browser, secretMode, debug, quiet } = options;
 
-      /** @type {ConfigObject} */
-      const cliConfigObject = {
-        browser: {
-          browser,
-          secretMode,
+      const { config: configObject } = await configLoader({
+        cliConfigObject: {
+          browser: {
+            browser,
+            secretMode,
+          },
+          console: {
+            debug,
+            quiet,
+          },
         },
-        console: {
-          debug,
-          quiet,
-        },
-      };
-
-      const { config: configObject } = await configLoader({ cliConfigObject });
+      });
 
       logger(configObject.console)
         .debug('command:', command.name())
         .debug('problems:', problems)
         .debug('cli options:', options)
-        .debug('cli config object:', cliConfigObject)
         .debug('config object:', configObject)
         .eol();
 

--- a/packages/bananass/src/cli/bananass-repo.js
+++ b/packages/bananass/src/cli/bananass-repo.js
@@ -25,7 +25,6 @@ import {
 
 /**
  * @typedef {import('commander').Command} Command
- * @typedef {import('../core/types.js').ConfigObject} ConfigObject
  */
 
 // --------------------------------------------------------------------------------
@@ -48,24 +47,22 @@ export default function repo(program) {
     .action(async (options, command) => {
       const { browser, secretMode, debug, quiet } = options;
 
-      /** @type {ConfigObject} */
-      const cliConfigObject = {
-        browser: {
-          browser,
-          secretMode,
+      const { config: configObject } = await configLoader({
+        cliConfigObject: {
+          browser: {
+            browser,
+            secretMode,
+          },
+          console: {
+            debug,
+            quiet,
+          },
         },
-        console: {
-          debug,
-          quiet,
-        },
-      };
-
-      const { config: configObject } = await configLoader({ cliConfigObject });
+      });
 
       logger(configObject.console)
         .debug('command:', command.name())
         .debug('cli options:', options)
-        .debug('cli config object:', cliConfigObject)
         .debug('config object:', configObject)
         .eol();
 

--- a/packages/bananass/src/cli/bananass-run.js
+++ b/packages/bananass/src/cli/bananass-run.js
@@ -26,7 +26,6 @@ import {
 
 /**
  * @typedef {import('commander').Command} Command
- * @typedef {import('../core/types.js').ConfigObject} ConfigObject
  */
 
 // --------------------------------------------------------------------------------
@@ -50,23 +49,21 @@ export default function run(program) {
     .action(async (problems, options, command) => {
       const { cwd, entryDir, debug, quiet } = options;
 
-      /** @type {ConfigObject} */
-      const cliConfigObject = {
-        cwd,
-        entryDir,
-        console: {
-          debug,
-          quiet,
+      const { config: configObject } = await configLoader({
+        cliConfigObject: {
+          cwd,
+          entryDir,
+          console: {
+            debug,
+            quiet,
+          },
         },
-      };
-
-      const { config: configObject } = await configLoader({ cliConfigObject });
+      });
 
       logger(configObject.console)
         .debug('command:', command.name())
         .debug('problems:', problems)
         .debug('cli options:', options)
-        .debug('cli config object:', cliConfigObject)
         .debug('config object:', configObject)
         .eol();
 


### PR DESCRIPTION
This pull request includes changes to multiple files in the `packages/bananass/src/cli` directory to simplify the configuration loading process. The primary change involves removing the `ConfigObject` typedef and directly loading the configuration using `configLoader`.

Changes to configuration loading:

* [`packages/bananass/src/cli/bananass-bug.js`](diffhunk://#diff-196f36c2928080b1421ad5f1091b6715ba428f781678296dc43ee5fd1b7f4bd4L28): Removed `ConfigObject` typedef and refactored configuration loading to use `configLoader` directly. [[1]](diffhunk://#diff-196f36c2928080b1421ad5f1091b6715ba428f781678296dc43ee5fd1b7f4bd4L28) [[2]](diffhunk://#diff-196f36c2928080b1421ad5f1091b6715ba428f781678296dc43ee5fd1b7f4bd4L54-R54) [[3]](diffhunk://#diff-196f36c2928080b1421ad5f1091b6715ba428f781678296dc43ee5fd1b7f4bd4L64-L71)
* [`packages/bananass/src/cli/bananass-build.js`](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L32): Removed `ConfigObject` typedef and refactored configuration loading to use `configLoader` directly. [[1]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L32) [[2]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L59-R59) [[3]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L72-L80)
* [`packages/bananass/src/cli/bananass-discussion.js`](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6L28): Removed `ConfigObject` typedef and refactored configuration loading to use `configLoader` directly. [[1]](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6L28) [[2]](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6L54-R54) [[3]](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6L64-L71)
* [`packages/bananass/src/cli/bananass-home.js`](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL28): Removed `ConfigObject` typedef and refactored configuration loading to use `configLoader` directly. [[1]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL28) [[2]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL51-R51) [[3]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL61-L68)
* [`packages/bananass/src/cli/bananass-info.js`](diffhunk://#diff-bff245da03f8a2d2d1dc34bee509e9bc4a2eaaa81cf70498e71536284f9267caL27): Removed `ConfigObject` typedef and refactored configuration loading to use `configLoader` directly. [[1]](diffhunk://#diff-bff245da03f8a2d2d1dc34bee509e9bc4a2eaaa81cf70498e71536284f9267caL27) [[2]](diffhunk://#diff-bff245da03f8a2d2d1dc34bee509e9bc4a2eaaa81cf70498e71536284f9267caL49-L65)
* [`packages/bananass/src/cli/bananass-open.js`](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL29): Removed `ConfigObject` typedef and refactored configuration loading to use `configLoader` directly. [[1]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL29) [[2]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL53-R53) [[3]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL63-L71)
* [`packages/bananass/src/cli/bananass-repo.js`](diffhunk://#diff-18cad518a6aa21886b7a585bd6846ed203fcbb98516a9191ed3c29e82e30869cL28): Removed `ConfigObject` typedef and refactored configuration loading to use `configLoader` directly. [[1]](diffhunk://#diff-18cad518a6aa21886b7a585bd6846ed203fcbb98516a9191ed3c29e82e30869cL28) [[2]](diffhunk://#diff-18cad518a6aa21886b7a585bd6846ed203fcbb98516a9191ed3c29e82e30869cL51-R51) [[3]](diffhunk://#diff-18cad518a6aa21886b7a585bd6846ed203fcbb98516a9191ed3c29e82e30869cL61-L68)
* [`packages/bananass/src/cli/bananass-run.js`](diffhunk://#diff-b60d6936d484b4fe5468cf7087467bdab42ddc70d1a1466f0301b5d41aa98658L29): Removed `ConfigObject` typedef and refactored configuration loading to use `configLoader` directly. [[1]](diffhunk://#diff-b60d6936d484b4fe5468cf7087467bdab42ddc70d1a1466f0301b5d41aa98658L29) [[2]](diffhunk://#diff-b60d6936d484b4fe5468cf7087467bdab42ddc70d1a1466f0301b5d41aa98658L53-L69)