### PR TITLE
ci(*): update permissions for `pull-request` workflow to allow write access

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize]
 
+permissions:
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
This pull request includes a small but important change to the GitHub Actions workflow configuration file `.github/workflows/pull-request.yml`. The change grants write permissions to pull requests.

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0R7-R9): Added `permissions` section to grant write access to pull requests.