### PR TITLE
ci(*): update permissions in `sync-client.yml` to allow read access to contents

### DIFF
--- a/.github/workflows/sync-client.yml
+++ b/.github/workflows/sync-client.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   sync-client:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a small but important change to the GitHub Actions workflow configuration file. The change adds read permissions for contents in the `sync-client` job.

* [`.github/workflows/sync-client.yml`](diffhunk://#diff-254f50149bdf646bb0bb19197c9fa73d054fdb550909072ed57e0b5bcc39a197R7-R9): Added `permissions` section to allow read access to contents.