### PR TITLE
chore(*): update `lint-staged.config.js` to support TypeScript file extensions

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,6 +3,6 @@ module.exports = {
     'npx prettier --check',
     'npx editorconfig-checker -config .editorconfig-checker.json',
   ],
-  '*.{js,mjs,cjs,jsx}': 'npx eslint',
+  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}': 'npx eslint',
   '*.md': ['npx markdownlint', 'npx textlint -f pretty-error'],
 };


### PR DESCRIPTION
This pull request includes a small change to the `lint-staged.config.js` file. The change extends ESLint to also check TypeScript files.

* [`lint-staged.config.js`](diffhunk://#diff-29c15f0b5d8d1144bd22153c302cde16c2de092d65b122a618cbdb3023336346L6-R6): Updated the file extensions for ESLint to include TypeScript files (`*.ts`, `*.mts`, `*.cts`, `*.tsx`).