### PR TITLE
fix(bananass): incorrect bundling in javascript-ESM causing unexpected build results

### DIFF
--- a/packages/bananass/src/commands/bananass-build/build.js
+++ b/packages/bananass/src/commands/bananass-build/build.js
@@ -134,6 +134,7 @@ export default async function build(problems, configObject = dco) {
           rules: [
             {
               test: /\.(?:js|mjs|cjs)$/i, // JavaScript
+              include: [/node_modules/, new RegExp(resolvedEntryDir)],
               loader: 'esbuild-loader',
               options: {
                 target: 'node14',

--- a/packages/eslint-config-bananass/src/configs/js.js
+++ b/packages/eslint-config-bananass/src/configs/js.js
@@ -13,6 +13,7 @@ const { js } = require('../files');
 const { globals } = require('../language-options');
 const { importPlugin, nodePlugin, stylisticJsPlugin } = require('../plugins');
 const { eslintRules, importRules, nodeRules, stylisticJsRules } = require('../rules');
+const { node } = require('../settings');
 
 // --------------------------------------------------------------------------------
 // Exports
@@ -34,5 +35,8 @@ module.exports = {
     ...importRules,
     ...nodeRules,
     ...stylisticJsRules,
+  },
+  settings: {
+    node,
   },
 };

--- a/packages/eslint-config-bananass/src/configs/jsx-next.js
+++ b/packages/eslint-config-bananass/src/configs/jsx-next.js
@@ -11,7 +11,7 @@
 
 const { js, jsx } = require('../files');
 const { globals, parserOptions } = require('../language-options');
-const { react } = require('../settings');
+const { node, react } = require('../settings');
 
 const {
   importPlugin,
@@ -71,6 +71,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
   },
   settings: {
+    node,
     react,
   },
 };

--- a/packages/eslint-config-bananass/src/configs/jsx-react.js
+++ b/packages/eslint-config-bananass/src/configs/jsx-react.js
@@ -11,7 +11,7 @@
 
 const { js, jsx } = require('../files');
 const { globals, parserOptions } = require('../language-options');
-const { react } = require('../settings');
+const { node, react } = require('../settings');
 
 const {
   importPlugin,
@@ -65,6 +65,7 @@ module.exports = {
     ...reactHooksRules,
   },
   settings: {
+    node,
     react,
   },
 };

--- a/packages/eslint-config-bananass/src/configs/ts.js
+++ b/packages/eslint-config-bananass/src/configs/ts.js
@@ -14,6 +14,7 @@
 
 const { ts } = require('../files');
 const { globals, parser } = require('../language-options');
+const { node } = require('../settings');
 
 const {
   importPlugin,
@@ -53,5 +54,8 @@ module.exports = {
     ...nodeRules,
     ...stylisticJsRules,
     ...typescriptRules,
+  },
+  settings: {
+    node,
   },
 };

--- a/packages/eslint-config-bananass/src/configs/tsx-next.js
+++ b/packages/eslint-config-bananass/src/configs/tsx-next.js
@@ -11,7 +11,7 @@
 
 const { ts, tsx } = require('../files');
 const { globals, parser, parserOptions } = require('../language-options');
-const { react } = require('../settings');
+const { node, react } = require('../settings');
 
 const {
   importPlugin,
@@ -76,6 +76,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
   },
   settings: {
+    node,
     react,
   },
 };

--- a/packages/eslint-config-bananass/src/configs/tsx-react.js
+++ b/packages/eslint-config-bananass/src/configs/tsx-react.js
@@ -11,7 +11,7 @@
 
 const { ts, tsx } = require('../files');
 const { globals, parser, parserOptions } = require('../language-options');
-const { react } = require('../settings');
+const { node, react } = require('../settings');
 
 const {
   importPlugin,
@@ -70,6 +70,7 @@ module.exports = {
     ...typescriptRules,
   },
   settings: {
+    node,
     react,
   },
 };

--- a/packages/eslint-config-bananass/src/settings.js
+++ b/packages/eslint-config-bananass/src/settings.js
@@ -9,3 +9,11 @@
 module.exports.react = {
   version: 'detect',
 };
+
+module.exports.node = {
+  resolverConfig: {
+    // `eslint-plugin-n` uses webpack's `enhanced-resolve` under the hood.
+    extensions: ['.js', '.mjs', '.cjs', '.jsx', '.ts', '.mts', '.cts', '.tsx', '.json'],
+    mainFiles: ['index'],
+  },
+};

--- a/packages/eslint-config-bananass/src/settings.js
+++ b/packages/eslint-config-bananass/src/settings.js
@@ -6,14 +6,14 @@
 // Exports
 // --------------------------------------------------------------------------------
 
-module.exports.react = {
-  version: 'detect',
-};
-
 module.exports.node = {
   resolverConfig: {
     // `eslint-plugin-n` uses webpack's `enhanced-resolve` under the hood.
     extensions: ['.js', '.mjs', '.cjs', '.jsx', '.ts', '.mts', '.cts', '.tsx', '.json'],
     mainFiles: ['index'],
   },
+};
+
+module.exports.react = {
+  version: 'detect',
 };


### PR DESCRIPTION
This pull request includes changes to the `bananass` package to enhance the build process and update ESLint configurations. The most important changes include adding a new setting for Node.js resolver configuration and updating various ESLint configuration files to include this new setting.

### Build process improvement:

* [`packages/bananass/src/commands/bananass-build/build.js`](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4R137): Added `resolvedEntryDir` to the `include` array for JavaScript files to ensure proper inclusion of node modules.

### ESLint configuration updates:

* [`packages/eslint-config-bananass/src/settings.js`](diffhunk://#diff-f3313674a9f29402cc0fbfc6fa06d9c88b5b8caa48ac94dca0b71f547b85514fR9-R16): Added a new `node` setting with resolver configuration for extensions and main files.
* [`packages/eslint-config-bananass/src/configs/js.js`](diffhunk://#diff-7d34335be53ca4bc3a3d2f80470310b155e5b7a5074f8d4dc6e1919cac916721R16): Included the new `node` setting in the exported configuration. [[1]](diffhunk://#diff-7d34335be53ca4bc3a3d2f80470310b155e5b7a5074f8d4dc6e1919cac916721R16) [[2]](diffhunk://#diff-7d34335be53ca4bc3a3d2f80470310b155e5b7a5074f8d4dc6e1919cac916721R39-R41)
* [`packages/eslint-config-bananass/src/configs/jsx-next.js`](diffhunk://#diff-ed37bd3604035f4eb1410a22dcd8e5f8a07d6d304b78c9a59425b8ccef30703cL14-R14): Updated to include the `node` setting in the exported configuration. [[1]](diffhunk://#diff-ed37bd3604035f4eb1410a22dcd8e5f8a07d6d304b78c9a59425b8ccef30703cL14-R14) [[2]](diffhunk://#diff-ed37bd3604035f4eb1410a22dcd8e5f8a07d6d304b78c9a59425b8ccef30703cR74)
* [`packages/eslint-config-bananass/src/configs/jsx-react.js`](diffhunk://#diff-b74692fbc583f15ffdfd57efb93fe0c4dea858ad0e7f73f42a8dd806324e8c02L14-R14): Added the `node` setting to the exported configuration. [[1]](diffhunk://#diff-b74692fbc583f15ffdfd57efb93fe0c4dea858ad0e7f73f42a8dd806324e8c02L14-R14) [[2]](diffhunk://#diff-b74692fbc583f15ffdfd57efb93fe0c4dea858ad0e7f73f42a8dd806324e8c02R68)
* [`packages/eslint-config-bananass/src/configs/ts.js`](diffhunk://#diff-69670ae9887ed62b829d596199d8533a95399541f4e151b96c1b7f345c611e8cR17): Incorporated the `node` setting into the exported configuration. [[1]](diffhunk://#diff-69670ae9887ed62b829d596199d8533a95399541f4e151b96c1b7f345c611e8cR17) [[2]](diffhunk://#diff-69670ae9887ed62b829d596199d8533a95399541f4e151b96c1b7f345c611e8cR58-R60)
* [`packages/eslint-config-bananass/src/configs/tsx-next.js`](diffhunk://#diff-7e6986b8aa252958b9da97c71d62e00f1895da50f896ceb71305ba34671b403aL14-R14): Included the `node` setting in the exported configuration. [[1]](diffhunk://#diff-7e6986b8aa252958b9da97c71d62e00f1895da50f896ceb71305ba34671b403aL14-R14) [[2]](diffhunk://#diff-7e6986b8aa252958b9da97c71d62e00f1895da50f896ceb71305ba34671b403aR79)
* [`packages/eslint-config-bananass/src/configs/tsx-react.js`](diffhunk://#diff-1f99df34d53d43dd73a2dbe7af4e50a96ff8a4d5b36cbb7fc8a9296ab0bc22fdL14-R14): Updated to include the `node` setting in the exported configuration. [[1]](diffhunk://#diff-1f99df34d53d43dd73a2dbe7af4e50a96ff8a4d5b36cbb7fc8a9296ab0bc22fdL14-R14) [[2]](diffhunk://#diff-1f99df34d53d43dd73a2dbe7af4e50a96ff8a4d5b36cbb7fc8a9296ab0bc22fdR73)