### PR TITLE
feat(bananass): add `question` and `questions` alias to `bananass discussion` cli command

### DIFF
--- a/packages/bananass/src/cli/bananass-discussion.js
+++ b/packages/bananass/src/cli/bananass-discussion.js
@@ -42,6 +42,8 @@ export default function discussion(program) {
     .alias('discussions')
     .alias('discuss')
     .alias('disc')
+    .alias('question')
+    .alias('questions')
     .description(discussionDesc)
     .option(...browserOpt)
     .option(...secretModeOpt)


### PR DESCRIPTION
This pull request includes an enhancement to the `discussion` function in the `bananass-discussion.js` file. The change adds new aliases to improve user accessibility and command recognition.

Enhancements to command aliases:

* [`packages/bananass/src/cli/bananass-discussion.js`](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6R45-R46): Added new aliases 'question' and 'questions' to the `discussion` function to provide more intuitive command options for users.