### PR TITLE
chore(deps-dev): bump `vitepress-plugin-group-icons` from `1.3.6` to `1.3.7`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19229,9 +19229,9 @@
       }
     },
     "node_modules/vitepress-plugin-group-icons": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/vitepress-plugin-group-icons/-/vitepress-plugin-group-icons-1.3.6.tgz",
-      "integrity": "sha512-MzUAuMZ43f51dfBKYowW7yv/A2DxIjtN50d8Dcj31nU9RB6GuYBJ48E/Ze88U0bEn4wlnrjMXFh2j2e0rYmGug==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-group-icons/-/vitepress-plugin-group-icons-1.3.7.tgz",
+      "integrity": "sha512-2pS7KATeAPXTVOiXF0cU9Jh8TiMWuLn7uzQr1RkYG8fmILvUfue60w2WtloOfrAenByzYSQ724A4aQzUCgVfqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20356,7 +20356,7 @@
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^1.6.3",
-        "vitepress-plugin-group-icons": "^1.3.6"
+        "vitepress-plugin-group-icons": "^1.3.7"
       }
     },
     "websites/vitepress/node_modules/is-interactive": {

--- a/websites/vitepress/ko/learn/how-to-parse-input-value.md
+++ b/websites/vitepress/ko/learn/how-to-parse-input-value.md
@@ -272,7 +272,7 @@ const inputParsed = input.trim().split('\n');
 const inputParsed = input.trim().split('\n').map(val => Number(val));
 ```
 
-or
+또는
 
 ```js
 const inputParsed = input.trim().split('\n').map(Number);

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -16,6 +16,6 @@
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^1.6.3",
-    "vitepress-plugin-group-icons": "^1.3.6"
+    "vitepress-plugin-group-icons": "^1.3.7"
   }
 }


### PR DESCRIPTION
This pull request includes minor updates to the Korean documentation and a version bump for a plugin in the `websites/vitepress` package.

Documentation update:

* [`websites/vitepress/ko/learn/how-to-parse-input-value.md`](diffhunk://#diff-23393c5e02c45691527083acfcadef7dc125af1cfcad10f20412864a0a83fbfdL275-R275): Improved the code example by simplifying the `map` function call to directly use `Number` instead of a lambda function.

Dependency update:

* [`websites/vitepress/package.json`](diffhunk://#diff-10ef64608fffd18cd9a3d2a3b2adb3361c324abf4a0040a210720ab259c6acd2L19-R19): Updated the version of `vitepress-plugin-group-icons` from `^1.3.6` to `^1.3.7`.