### PR TITLE
fix(eslint-config-bananass): update `no-missing-import` rule to ignore type imports and add `eslint.config.mjs` to `sync-client.yml`

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -70,5 +70,7 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/LICENSE.md
   - source: ./VScode.code-workspace
     dest: ./configs/VScode.code-workspace
+  - source: ./eslint.config.mjs
+    dest: ./configs/eslint.config.mjs
   - source: ./lint-staged.config.js
     dest: ./configs/lint-staged.config.js

--- a/packages/eslint-config-bananass/src/rules/node/node.js
+++ b/packages/eslint-config-bananass/src/rules/node/node.js
@@ -107,7 +107,12 @@ module.exports = {
    * @description This rule is not included in `airbnb-base`.
    * @link n: {@link https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-missing-import.md}
    */
-  'n/no-missing-import': 'error',
+  'n/no-missing-import': [
+    'error',
+    {
+      ignoreTypeImport: true,
+    },
+  ],
 
   /**
    * Disallow `require()` expressions which import non-existence modules.


### PR DESCRIPTION
This pull request includes updates to configuration files and adjustments to ESLint rules. The most important changes are the addition of a new configuration file and an update to an existing ESLint rule.

Configuration updates:

* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1R73-R74): Added `eslint.config.mjs` to the list of files to be synced.

ESLint rule adjustments:

* [`packages/eslint-config-bananass/src/rules/node/node.js`](diffhunk://#diff-c96c91af708b289359a5b68fb41a21628063ede30d509cc8901b9063cacd9309L110-R115): Modified the `n/no-missing-import` rule to ignore type imports by adding an options object.