### PR TITLE
refactor(bananass): update TypeScript error handling (`@ts-*`) and add `URL_NPM` constant

### DIFF
--- a/packages/bananass/src/commands/bananass-run/run.js
+++ b/packages/bananass/src/commands/bananass-run/run.js
@@ -110,7 +110,7 @@ export default async function run(problems, configObject = dco) {
   // ------------------------------------------------------------------------------
 
   try {
-    // @ts-ignore -- TODO: Delete it.
+    // @ts-expect-error -- TODO: Delete it.
     importedModules = await Promise.all(
       resolvedEntryFiles.map(resolvedEntryFile =>
         jiti.import(resolvedEntryFile, { default: true }),

--- a/packages/bananass/src/core/constants.js
+++ b/packages/bananass/src/core/constants.js
@@ -44,6 +44,8 @@ export const PKG_AUTHOR = '루밀LuMir';
 /** @type {string} */
 export const URL_HOMEPAGE = homepage;
 /** @type {string} */
+export const URL_NPM = 'https://www.npmjs.com';
+/** @type {string} */
 export const URL_GITHUB_REPO = 'https://github.com/lumirlumir/npm-bananass';
 /** @type {string} */
 export const URL_GITHUB_ISSUES = `${URL_GITHUB_REPO}/issues`;

--- a/packages/bananass/src/core/structs/solution/solution.js
+++ b/packages/bananass/src/core/structs/solution/solution.js
@@ -25,7 +25,7 @@ import { func, refine } from 'superstruct';
  * `Solution` type struct.
  *
  * @type {SolutionStruct}
- */ // @ts-ignore -- Types cannot be matched, as `superstruct` is unable to infer the input and output types of the function.
+ */ // @ts-expect-error -- Types cannot be matched, as `superstruct` is unable to infer the input and output types of the function.
 const Solution = refine(func(), 'Solution', solution =>
   solution.length <= 1
     ? true

--- a/websites/vitepress/.vitepress/config/en.js
+++ b/websites/vitepress/.vitepress/config/en.js
@@ -9,6 +9,7 @@
 // --------------------------------------------------------------------------------
 
 import {
+  URL_NPM,
   URL_HOMEPAGE,
   URL_GITHUB_REPO,
   BANANASS_PKG_NAMES,
@@ -22,7 +23,6 @@ import { defineConfig } from 'vitepress';
 
 const TITLE = 'Bananass';
 const DESCRIPTION = 'Baekjoon Framework for JavaScript.🍌';
-const NPM_URL = 'https://www.npmjs.com';
 
 const { themeConfig, ...restConfig } = en({
   themeConfigEditLinkPattern: `${URL_GITHUB_REPO}/edit/main/websites/vitepress/:path`,
@@ -81,7 +81,7 @@ export default defineConfig({
         text: 'Packages',
         items: BANANASS_PKG_NAMES.map(pkgName => ({
           text: pkgName,
-          link: `${NPM_URL}/package/${pkgName}`,
+          link: `${URL_NPM}/package/${pkgName}`,
         })),
       },
     ],
@@ -129,7 +129,7 @@ export default defineConfig({
     socialLinks: [
       {
         icon: 'npm',
-        link: `${NPM_URL}/~lumir`,
+        link: `${URL_NPM}/~lumir`,
         ariaLabel: 'npm profile link for LuMir',
       },
       {

--- a/websites/vitepress/.vitepress/config/ko.js
+++ b/websites/vitepress/.vitepress/config/ko.js
@@ -9,6 +9,7 @@
 // --------------------------------------------------------------------------------
 
 import {
+  URL_NPM,
   URL_HOMEPAGE,
   URL_GITHUB_REPO,
   BANANASS_PKG_NAMES,
@@ -22,7 +23,6 @@ import { defineConfig } from 'vitepress';
 
 const TITLE = '바나나';
 const DESCRIPTION = '백준 자바스크립트 프레임워크.🍌';
-const NPM_URL = 'https://www.npmjs.com';
 
 const { themeConfig, ...restConfig } = ko({
   themeConfigEditLinkPattern: `${URL_GITHUB_REPO}/edit/main/websites/vitepress/:path`,
@@ -81,7 +81,7 @@ export default defineConfig({
         text: '패키지',
         items: BANANASS_PKG_NAMES.map(pkgName => ({
           text: pkgName,
-          link: `${NPM_URL}/package/${pkgName}`,
+          link: `${URL_NPM}/package/${pkgName}`,
         })),
       },
     ],
@@ -129,7 +129,7 @@ export default defineConfig({
     socialLinks: [
       {
         icon: 'npm',
-        link: `${NPM_URL}/~lumir`,
+        link: `${URL_NPM}/~lumir`,
         ariaLabel: '루밀LuMir의 npm 프로필 링크',
       },
       {


### PR DESCRIPTION
This pull request includes several changes to improve type handling, update constants, and ensure consistency in URLs across the codebase. The most important changes include replacing `@ts-ignore` with `@ts-expect-error`, adding a new constant for the NPM URL, and updating various configurations to use this new constant.

Improvements to type handling:

* [`packages/bananass/src/commands/bananass-run/run.js`](diffhunk://#diff-e32949e4dff2549ab48c17b6a98d88eff1f009162d34c041087ba9fdd1480ce2L113-R113): Changed `@ts-ignore` to `@ts-expect-error` for better type checking.
* [`packages/bananass/src/core/structs/solution/solution.js`](diffhunk://#diff-1a3d3e2df9dacfb36c9df0d999baf3a817992c8dce1e5b0f5c753b174312f1aeL28-R28): Changed `@ts-ignore` to `@ts-expect-error` for better type checking.

Updates to constants:

* [`packages/bananass/src/core/constants.js`](diffhunk://#diff-97d6046c52dcaa9f59ecd0bc5a1ed48d3a91d2c8159901b86ba0b4932b532886R47-R48): Added a new constant `URL_NPM` to store the NPM URL.

Consistency in URLs:

* [`websites/vitepress/.vitepress/config/en.js`](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beR12): Updated the configuration to use `URL_NPM` instead of a hardcoded NPM URL. [[1]](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beR12) [[2]](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beL25) [[3]](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beL84-R84) [[4]](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beL132-R132)
* [`websites/vitepress/.vitepress/config/ko.js`](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57R12): Updated the configuration to use `URL_NPM` instead of a hardcoded NPM URL. [[1]](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57R12) [[2]](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57L25) [[3]](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57L84-R84) [[4]](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57L132-R132)