### PR TITLE
chore(*): update prettier commands to include `--ignore-unknown` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "run:ex:sb-mts": "npm run bananass:run -w examples/solutions-bananass-mts",
     "fix": "concurrently \"npm:fix:*\"",
     "fix:eslint": "npx eslint --fix",
-    "fix:prettier": "npx prettier . --write",
+    "fix:prettier": "npx prettier . --write --ignore-unknown",
     "lint": "concurrently \"npm:lint:*\"",
     "lint:eslint": "npx eslint",
-    "lint:prettier": "npx prettier . --check",
+    "lint:prettier": "npx prettier . --check --ignore-unknown",
     "lint:editorconfig": "npx editorconfig-checker -config .editorconfig-checker.json",
     "lint:markdownlint": "npx markdownlint **/*.md",
     "lint:textlint": "npx textlint -f pretty-error **/*.md"


### PR DESCRIPTION
This pull request includes a small but important change to the `package.json` file. The change updates the Prettier commands to include the `--ignore-unknown` flag, which helps prevent errors when encountering unknown file types.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L55-R58): Updated `fix:prettier` and `lint:prettier` commands to include the `--ignore-unknown` flag.