### PR TITLE
fix(eslint-config-bananass)!: update rule configurations for better linting accuracy

### DIFF
--- a/packages/eslint-config-bananass/src/rules/eslint/eslint-suggestions.js
+++ b/packages/eslint-config-bananass/src/rules/eslint/eslint-suggestions.js
@@ -1048,7 +1048,7 @@ module.exports = {
     'error',
     'always',
     {
-      avoidQuotes: true,
+      avoidQuotes: false,
       ignoreConstructors: false,
     },
   ],
@@ -1223,7 +1223,7 @@ module.exports = {
    * @link eslint: {@link https://eslint.org/docs/latest/rules/require-unicode-regexp}
    * @link airbnb-base: {@link https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb-base/rules/best-practices.js#L399}
    */
-  'require-unicode-regexp': 'off',
+  'require-unicode-regexp': ['warn', { requireFlag: 'u' }],
 
   /**
    * Require generator functions to contain `yield`.

--- a/packages/eslint-config-bananass/src/rules/react/react.js
+++ b/packages/eslint-config-bananass/src/rules/react/react.js
@@ -813,12 +813,11 @@ module.exports = {
   /**
    * Disallow missing React when using JSX.
    *
-   * @link I've set this rule to `'warn'`.
    * @link https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
    * @link https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb/rules/react.js#L230
    * @link https://github.com/vercel/next.js/blob/v15.1.4/packages/eslint-config-next/index.js#L65
    */
-  'react/react-in-jsx-scope': 'warn',
+  'react/react-in-jsx-scope': 'error',
 
   /**
    * Enforce a `defaultProps` definition for every prop that is not a required prop.


### PR DESCRIPTION
This pull request includes updates to the ESLint configuration rules in the `packages/eslint-config-bananass` package. The changes focus on modifying rule settings for better code quality and consistency.

### ESLint rule updates:

* [`packages/eslint-config-bananass/src/rules/eslint/eslint-suggestions.js`](diffhunk://#diff-1f441d9b82dbdd31cd2b0b9d9d6c30b2d66b91dfed4e1f4703da5ef1e295430cL1051-R1051): Changed the `avoidQuotes` option to `false` in the `quote-props` rule to enforce consistent property quoting.
* [`packages/eslint-config-bananass/src/rules/eslint/eslint-suggestions.js`](diffhunk://#diff-1f441d9b82dbdd31cd2b0b9d9d6c30b2d66b91dfed4e1f4703da5ef1e295430cL1226-R1226): Updated the `require-unicode-regexp` rule to `'warn'` with a `{ requireFlag: 'u' }` option to encourage the use of Unicode flag in regular expressions.

### React rule updates:

* [`packages/eslint-config-bananass/src/rules/react/react.js`](diffhunk://#diff-d2e14b50ea9ff3e279f30d972b03fd16efe19993bd0d6670de8571d2213515c5L816-R820): Changed the `react/react-in-jsx-scope` rule from `'warn'` to `'error'` to enforce the presence of React when using JSX.