### PR TITLE
feat(prettier-config-bananass): add type support

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -85,3 +85,5 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/tsconfig.json
   - source: ./packages/create-bananass/tsconfig.json
     dest: ./configs/tsconfig.json
+  - source: ./packages/prettier-config-bananass/tsconfig.json
+    dest: ./configs/tsconfig.json

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -4,15 +4,28 @@
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {
     ".": {
-      "default": "./src/index.js"
+      "default": "./src/index.js",
+      "types": "./build/index.d.ts"
     },
     "./package.json": "./package.json"
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./build/*"
+      ],
+      ".": [
+        "./build/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
-    "!src/**/*.test.js",
+    "build",
     "LICENSE.md",
-    "README.md"
+    "README.md",
+    "!src/**/*.test.js",
+    "!**/fixtures/**"
   ],
   "keywords": [
     "bananass",
@@ -40,7 +53,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "shx cp ../../LICENSE.md ../../README.md .",
+    "build": "npx tsc && shx cp ../../LICENSE.md ../../README.md .",
     "test": "node --test"
   },
   "peerDependencies": {

--- a/packages/prettier-config-bananass/tsconfig.json
+++ b/packages/prettier-config-bananass/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "build",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.js", "src/**/*.mjs", "src/**/*.cjs"],
+  "exclude": ["src/**/*.test.js"]
+}


### PR DESCRIPTION
This pull request includes several changes to the configuration and build process for the `prettier-config-bananass` package. The most important changes include adding TypeScript support, updating the build script, and modifying the synchronization configuration.

### TypeScript Support:

* [`packages/prettier-config-bananass/package.json`](diffhunk://#diff-0fdaf27a6fc3a9c98ce068e2f60dd6fa1d2a82cfc232695581bcae3256c32d76L7-R28): Added TypeScript type definitions and `typesVersions` to the package exports.
* [`packages/prettier-config-bananass/tsconfig.json`](diffhunk://#diff-8f47112bbc5a70fcf4edf6096e3dcd87ebf1fcdde395a04e1a339753a5d84cd6R1-R16): Added a new TypeScript configuration file to generate type declarations and specify compiler options.

### Build Script Update:

* [`packages/prettier-config-bananass/package.json`](diffhunk://#diff-0fdaf27a6fc3a9c98ce068e2f60dd6fa1d2a82cfc232695581bcae3256c32d76L43-R56): Updated the `build` script to include TypeScript compilation using `npx tsc`.

### Synchronization Configuration:

* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1R88-R89): Updated the synchronization configuration to include the new `tsconfig.json` from the `prettier-config-bananass` package.