### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.0` to `v0.1.0-canary.1` (`prerelease`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "scripts": {
     "bananass:build": "npx bananass build",
     "bananass:run": "npx bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.0"
+    "bananass": "^0.1.0-canary.1"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "scripts": {
     "bananass:build": "npx bananass build",
     "bananass:run": "npx bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.0"
+    "bananass": "^0.1.0-canary.1"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "scripts": {
     "bananass:build": "npx bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.0"
+    "bananass": "^0.1.0-canary.1"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "scripts": {
     "bananass:build": "npx bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.0"
+    "bananass": "^0.1.0-canary.1"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.0"
+  "version": "0.1.0-canary.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "workspaces": [
         ".",
         "examples/*",
@@ -20,14 +20,14 @@
         "concurrently": "^9.1.0",
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.24.0",
-        "eslint-config-bananass": "^0.1.0-canary.0",
+        "eslint-config-bananass": "^0.1.0-canary.1",
         "eslint-plugin-mark": "^0.1.0-canary.1",
         "husky": "^9.1.7",
         "lerna": "^8.2.2",
         "lint-staged": "^15.5.0",
         "markdownlint-cli": "^0.44.0",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.0",
+        "prettier-config-bananass": "^0.1.0-canary.1",
         "shx": "^0.4.0",
         "textlint": "^14.6.0",
         "textlint-rule-allowed-uris": "^1.0.9",
@@ -39,7 +39,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.1.0-canary.0"
+      "version": "0.1.0-canary.1"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -51,30 +51,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.0"
+        "bananass": "^0.1.0-canary.1"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.0"
+        "bananass": "^0.1.0-canary.1"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.0"
+        "bananass": "^0.1.0-canary.1"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.0"
+        "bananass": "^0.1.0-canary.1"
       }
     },
     "examples/solutions-readline": {
@@ -84,7 +84,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.1.0-canary.0"
+      "version": "0.1.0-canary.1"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -93,7 +93,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.1.0-canary.0"
+      "version": "0.1.0-canary.1"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -20854,10 +20854,10 @@
       }
     },
     "packages/bananass": {
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.1.0-canary.0",
+        "bananass-utils-console": "^0.1.0-canary.1",
         "c12": "^3.0.3",
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
@@ -20889,7 +20889,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -20937,7 +20937,7 @@
       }
     },
     "packages/bananass-utils-vitepress": {
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -21013,10 +21013,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.1.0-canary.0",
+        "bananass-utils-console": "^0.1.0-canary.1",
         "commander": "^13.1.0",
         "consola": "^3.4.2"
       },
@@ -21029,13 +21029,13 @@
     },
     "packages/create-bananass/templates/javascript": {
       "name": "create-bananass-javascript",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.0",
+        "bananass": "^0.1.0-canary.1",
         "eslint": "^9.24.0",
-        "eslint-config-bananass": "^0.1.0-canary.0",
+        "eslint-config-bananass": "^0.1.0-canary.1",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.0"
+        "prettier-config-bananass": "^0.1.0-canary.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -21043,14 +21043,14 @@
     },
     "packages/create-bananass/templates/typescript": {
       "name": "create-bananass-typescript",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.0",
+        "bananass": "^0.1.0-canary.1",
         "eslint": "^9.24.0",
-        "eslint-config-bananass": "^0.1.0-canary.0",
+        "eslint-config-bananass": "^0.1.0-canary.1",
         "jiti": "^2.4.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.0"
+        "prettier-config-bananass": "^0.1.0-canary.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -21065,7 +21065,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.3.0",
@@ -21100,7 +21100,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -21176,10 +21176,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
         "@eslint/config-inspector": "^1.0.2",
-        "eslint-config-bananass": "^0.1.0-canary.0"
+        "eslint-config-bananass": "^0.1.0-canary.1"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -21193,11 +21193,11 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
-        "bananass": "^0.1.0-canary.0",
-        "bananass-utils-vitepress": "^0.1.0-canary.0",
+        "bananass": "^0.1.0-canary.1",
+        "bananass-utils-vitepress": "^0.1.0-canary.1",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
@@ -65,14 +65,14 @@
     "concurrently": "^9.1.0",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.24.0",
-    "eslint-config-bananass": "^0.1.0-canary.0",
+    "eslint-config-bananass": "^0.1.0-canary.1",
     "eslint-plugin-mark": "^0.1.0-canary.1",
     "husky": "^9.1.7",
     "lerna": "^8.2.2",
     "lint-staged": "^15.5.0",
     "markdownlint-cli": "^0.44.0",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.0",
+    "prettier-config-bananass": "^0.1.0-canary.1",
     "shx": "^0.4.0",
     "textlint": "^14.6.0",
     "textlint-rule-allowed-uris": "^1.0.9",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass-utils-vitepress/package.json
+++ b/packages/bananass-utils-vitepress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-vitepress",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "description": "VitePress Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -75,7 +75,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.1.0-canary.0",
+    "bananass-utils-console": "^0.1.0-canary.1",
     "c12": "^3.0.3",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript.🍌",
   "bin": {
@@ -48,7 +48,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.1.0-canary.0",
+    "bananass-utils-console": "^0.1.0-canary.1",
     "commander": "^13.1.0",
     "consola": "^3.4.2"
   }

--- a/packages/create-bananass/templates/javascript/package.json
+++ b/packages/create-bananass/templates/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "engines": {
     "node": ">=20.18.0"
   },
@@ -9,10 +9,10 @@
     "build": "echo build"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.0",
+    "bananass": "^0.1.0-canary.1",
     "eslint": "^9.24.0",
-    "eslint-config-bananass": "^0.1.0-canary.0",
+    "eslint-config-bananass": "^0.1.0-canary.1",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.0"
+    "prettier-config-bananass": "^0.1.0-canary.1"
   }
 }

--- a/packages/create-bananass/templates/typescript/package.json
+++ b/packages/create-bananass/templates/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "engines": {
     "node": ">=20.18.0"
   },
@@ -9,11 +9,11 @@
     "build": "echo build"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.0",
+    "bananass": "^0.1.0-canary.1",
     "eslint": "^9.24.0",
-    "eslint-config-bananass": "^0.1.0-canary.0",
+    "eslint-config-bananass": "^0.1.0-canary.1",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.0"
+    "prettier-config-bananass": "^0.1.0-canary.1"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {
     ".": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {
     ".": {

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
     "dev": "npx @eslint/config-inspector --config ./config.js"
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.0.2",
-    "eslint-config-bananass": "^0.1.0-canary.0"
+    "eslint-config-bananass": "^0.1.0-canary.1"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",
-    "bananass": "^0.1.0-canary.0",
-    "bananass-utils-vitepress": "^0.1.0-canary.0",
+    "bananass": "^0.1.0-canary.1",
+    "bananass-utils-vitepress": "^0.1.0-canary.1",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.1`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.0` to `v0.1.0-canary.1` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/14430009239) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 1c76690       |
| Old Version | `v0.1.0-canary.0`  |
| New Version | `v0.1.0-canary.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* refactor(bananass)!: refactor, rename and delete unnecessary files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/155
* feat(eslint-config-bananass)!: remove `eslint-config-bananass-react` and move them to `eslint-config-bananass` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/181
* refactor(bananass-utils-vitepress)!: restructure directories and add tests by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/197
* feat(bananass-utils-console)!: add type support for `spinner` and update default color by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/203
* refactor(bananass-utils-console)!: update `icons` and `theme` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/204
* fix(eslint-config-bananass)!: update rule configurations for better linting accuracy by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/318
* feat(eslint-config-bananass)!: add type support and rename configs by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/320
### :sparkles: Features
* feat: `packages/bananass` and `build` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/15
* feat: create `bananass-utils-console` package by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/17
* feat: create `logger.js` and add debug and quiet mode by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/26
* feat(bananass): add option to clean output directory before emit by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/27
* feat(bananass-utils): create `bananass-utils` package by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/39
* feat(prettier-config-bananass): introduce `prettier-config-bananass` package by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/57
* feat(packages): introduce `eslint-config-bananass` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/6
* feat(eslint-config-bananass): add tests for rules by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/67
* feat(eslint-config-bananass-react): create `eslint-config-bananass-react` package by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/70
* feat(eslint-config-bananass-react): add `eslint-plugin-react` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/79
* feat(website): introduce website prototype using docusaurus by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/80
* feat(website-eslint-config-bananass): introduce `website-eslint-config-bananass` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/87
* feat(website-eslint-config-bananass-react): introduce `website-eslint-config-bananass-react` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/88
* feat: new website prototype using vitpress by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/93
* feat: update `package.json` exports to include `package.json` file by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/94
* feat(bananass-utils-console): add `typesVersions` to `package.json` for improved type definitions by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/95
* feat(bananass-utils-vitepress): create `bananass-utils-vitepress` and refactor `websites/vitepress` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/112
* feat(eslint-config-bananass): remove unnecessary `ForOfStatement` warning and add Vitepress config to import warnings by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/115
* feat(bananass): refactor build command and add options by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/96
* feat(bananass): `build` command support `fs` template by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/118
* feat(bananass): add `outDir` option to `build` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/119
* feat(bananass): add `entryDir` option to `build` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/120
* feat!(bananass): change `problems` argument from optional to required in `build` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/125
* feat(bananass): add TypeScript and ESM support for `build` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/138
* feat(bananass): add webpack banner plugin with generated file information by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/139
* feat(bananass): support runtime type validation using `superstruct` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/143
* feat(bananass): add shorthand command `b` for CLI by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/144
* feat(bananass): create `home` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/151
* feat(bananass): create new command `open` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/156
* feat(bananass): create new `repo` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/161
* feat(bananass): create new `discussion` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/164
* feat(bananass): create new `bug` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/166
* feat(bananass): create new `info` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/167
* feat(bananass): add new `run` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/172
* feat(eslint-config-bananass): restructure folder hierarchy by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/179
* feat(eslint-config-bananass): add `jsx-a11y` rules by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/182
* feat(eslint-config-bananass): add new `next` rulesets and refactor utilities by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/186
* feat(eslint-config-bananass): add new `ts` config by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/192
* feat(eslint-config-bananass): add new `tsx` configs by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/194
* feat(bananass): add new missing types `bug`, `discussion`, `home` and `repo` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/212
* feat(*): create new package `create-bananass` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/214
* feat(bananass): add `input` and `output` type, structs and add tests by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/226
* feat(bananass): add `question` and `questions` alias to `bananass discussion` cli command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/261
* feat(prettier-config-bananass): add type support by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/319
### :bug: Bug Fixes
* fix(bananass-build): correct `clean` option behavior by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/29
* fix: fix broken `editorconfig-checker` by pinning `EC_VERSION` in `lint.yml` workflow by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/58
* fix(eslint-config-bananass): support additional file extensions in `import/no-extraneous-dependencies` rule by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/65
* fix(eslint-config-bananass): enforce JSX usage in `no-unused-expressions` rule by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/68
* fix(bananass): correct `logger` calls in cli to use `configObject.console` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/165
* fix(eslint-config-bananass): update `react/curly-brace-presence` to follow default options by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/185
* fix(eslint-config-bananass): update some rule's error level by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/187
* fix(bananass): enable bananass icon display in spinner messages across multiple commands by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/215
* fix(bananass): update `Solution` and `Testcase` types to allow optional input parameters by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/220
* fix(bananass): incorrect bundling in javascript-ESM causing unexpected build results by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/252
* fix(eslint-config-bananass): update `no-missing-import` rule to ignore type imports and add `eslint.config.mjs` to `sync-client.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/270
* fix(eslint-config-bananass): add `.d.ts`, `.d.mts` and `.d.cts` to `node.resolverConfig.extensions` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/298
### :hammer_and_wrench: Builds
* build: update Babel configuration and add TypeScript support by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/33
* build(bananass): delete babel to simplify build process as Bananass only support node >= 20.18.0 by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/117
* build: replace `cp` with `shx cp` in build scripts for cross-platform compatibility by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/127
* build(*): remove Babel configuration files and dependencies by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/178
### :toolbox: Chores
* chore(examples): create `examples/readline` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/12
* chore(examples): create `examples/solutions-readline` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/13
* chore(examples): create `solutions/bananass` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/14
* chore: create `packages/bananass-dataset` directory by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/16
* chore: update npm script naming convention for consistency by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/19
* chore(sync-client): add `.textlintrc.js` to configuration sync by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/25
* chore: create `.gitattributes` for consistent EOL handling by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/31
* chore: add `website` workspace and initialize `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/38
* chore: update `.markdownlintignore` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/40
* chore: replace `nyc` with `c8` for coverage reporting in `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/42
* chore(examples-solutions-readline-esm): add examples for ESM solutions with readline by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/43
* chore: update `.vscode/extensions.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/44
* chore: add `packageManager` field to `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/53
* chore: add `engines` field to `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/59
* chore: add engines field and update `peerDependencies` in `package-lock.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/61
* chore(deps-dev): bump `editorconfig-checker` from `6.0.0` to `6.0.1` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/63
* chore(dependabot): update configuration to include groups, assignees, and reviewers by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/71
* chore: remove `website` package and update workspace configuration by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/74
* chore: update ESLint configuration to use `eslint-config-bananass` and adjust ignored paths by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/75
* chore: rename `create-bananass-app` to `create-bananass` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/85
* chore: restructure website directory and update package configurations for Docusaurus by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/86
* chore: rename `website` directory to `websites` and update related configurations by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/89
* chore: create `ISSUE_TEMPLATE/config.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/92
* chore: update homepage URL in `package.json` files to new site by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/97
* chore: enhance `package.json` scripts for `dev`, `start`, `build` and `test` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/105
* chore: update `.editorconfig-checker.json` to remove excluded files and tidy up `docs/archived.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/106
* chore: add Vercel ignore command script and update configuration for multiple websites by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/107
* chore: exclude test files from `package.json` `files` array in eslint and prettier configs by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/113
* chore(*): update `dependabot.yml`'s `commit-message` configuration to include `prefix` and `scope` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/129
* chore(npm-bananass): update workspace configuration and adjust test/build commands to ignore `npm-bananass` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/135
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/168
* chore(*): update `dependabot.yml` and delete `bananass-dataset` directory by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/173
* chore(*): add `publishConfig` with `provenance` set to `true` in `package.json` files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/176
* chore(*): remove `.spec.js` files from ignore and exclude lists in configuration files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/177
* chore(*): update `publish-package` script to use 'next' pre-dist tag by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/216
* chore(sync-server): update `publish.yml` and `.prettierignore` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/218
* chore(*): update `lint-staged.config.js` to support TypeScript file extensions by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/249
* chore(*): add TypeScript type annotations to ESLint configuration files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/251
* chore(*): add problem number `2558` to the examples by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/253
* chore(*): fix typos in `vercel.json` and `en/index.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/258
* chore(websites-vitepress): add `@codecov/vite-plugin` and update related configs for bundle analysis by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/259
* chore(sync-server): update `eslint.config.mjs` and `lint-staged.config.js` to support markdown by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/271
* chore(sync-server): update `FUNDING.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/283
* chore(*): update `tsconfig.json` to include patterns to support `.mjs` and `.cjs` files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/285
* chore(*): update prettier commands to include `--ignore-unknown` option by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/294
* chore(sync-server): update root level configuration files and fix typos by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/295
* chore(*): rename root level config file extensions to `.mjs` or `.cjs` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/299
### :arrows_counterclockwise: Continuous Integrations
* ci(sync-client): add `lint-staged.config.js` to `sync-client.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/30
* ci: add `concurrency` settings to GitHub Actions `labeler.yml` workflow by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/114
* ci(*): create `pull-request.yml` and update `labeler` logics by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/126
* ci(*): update `pull-request.yml` workflow to include `synchronize` event by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/128
* ci(*): update `pull-request.yml` labeler condition to include `synchronize` event by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/133
* ci(*): update `pull-request.yml` concurrency group and update `sync-client.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/134
* ci(*): drop `bump.yml` and create new `version-monorepo.yml` workflow by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/217
* ci(*): add permissions to read contents in `lint.yml` and `test.yml` workflows by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/243
* ci(*): update permissions for `pull-request` workflow to allow write access by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/245
* ci(*): update permissions in `sync-client.yml` to allow read access to contents by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/246
* ci(*): create `release.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/277
* ci(*): fix `publish.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/322
### :memo: Documentation
* docs(examples): rename and update documentation by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/46
* docs: update documentation by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/11
* docs: update comments in internal modules by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/116
* docs(*): update documentations and refactor `websites-vitepress` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/250
* docs(websites-vitepress): create `how-to-parse-input-value.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/262
* docs(websites-vitepress): create `solving-problems-without-bananass-framework.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/268
### :recycle: Code Refactoring
* refactor(examples-readline): update documentation by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/20
* refactor(examples-solutions-readline): update documentation by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/21
* refactor(bananass-utils-console): restructure and organize modules by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/22
* refactor(bananass): improve documentation and shorten `webpackAsync` function by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/24
* refactor(bananass-build): simplify output directory handling and improve logging by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/28
* refactor(bananass-utils-console): transition from CJS to ESM by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/32
* refactor(bananass-utils-console): delete `utils` directory and replace it with dependencies by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/35
* refactor(bananass-utils-console): add typedef to `icons/index.js` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/37
* refactor(bananass): migrate from CJS to ESM by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/41
* refactor(examples-solutions-bananass): refactor functions and update dependency by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/45
* refactor(prettier-config-bananass): add peerDependencies, prepublish script, type support by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/60
* refactor(*-config-bananass): update `peerDependencies` to use caret versioning for eslint and prettier by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/66
* refactor: remove unnecessary ESLint disable comments across multiple files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/76
* refactor(bananass): create bananass home dummy command files and delete unnecessary things by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/123
* refactor(bananass): delete `bananass-utils` package and move files to `bananass` core accordingly by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/140
* refactor(bananass): delete unused `find-existing-path.js` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/141
* refactor(bananass): add `"checkJs": true` option for `tsconfig.json` to validate js and delete unused `validate-config.js` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/142
* refactor(bananass): imporve types, structs and config object by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/150
* refactor(bananass-utils-console): improve types and JSDoc by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/152
* refactor(bananass): simplify command function names for consistency by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/157
* refactor(bananass-utils-console): restructure directories by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/198
* refactor(bananass-utils-console): replace `ansi-colors` with `chalk` in package and source files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/199
* refactor(bananass): remove `init` command and related configurations by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/208
* refactor(bananass): remove spinner color configuration and improve error logging by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/211
* refactor(bananass): update global variable reference for `BAEKJOON_PROBLEM_NUMBER_WITH_PATH` in build function by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/213
* refactor(*): refactor examples and create more examples by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/219
* refactor(bananass): refactor `find-root-dir.js` to improve error messages and update test file overview by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/236
* refactor(bananass): update `configLoader` to use `defaultConfigObject` and improve test cases by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/237
* refactor(bananass): simplify and remove unused `ConfigObject` typedef from CLI files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/238
* refactor(bananass): refactor and enhance `configloader` to validate supported file extensions by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/242
* refactor(create-bananass): add `.gitattributes` for consistent EOL handling in JavaScript and TypeScript templates by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/263
* refactor(bananass): update TypeScript error handling (`@ts-*`) and add `URL_NPM` constant by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/291
### :test_tube: Tests
* test(bananass-utils-console): create unit tests for `theme.js` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/23
* test(bananass-utils-console): create `logger.test.js` and update `logger.js` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/34
* test(bananass-utils-console): add tests for `spinner` functionality and update dependencies by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/36
* test(eslint-config-bananass-react): add tests for `react`, `react-hooks`, and `react-compiler` rules by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/90
* test(examples-solutions-bananass): create `tests/commands.test.sh` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/124
* test(eslint-config-bananass): restructure test descriptions for clarity and consistency by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/193
* test(bananass-utils-console): drop unnecessary devdependencies and add more testcases to `spinner` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/200
* test(bananass): enhance `config-loader` tests for default parameters and error handling by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/244
* test(bananass): add default values and tests for `commands`  by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/247
### :arrow_up: Dependency Updates
* chore(deps-dev): bump textlint from 14.3.0 to 14.4.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/7
* chore(deps-dev): bump @babel/cli from 7.25.9 to 7.26.4 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/9
* chore(deps-dev): bump prettier from 3.4.1 to 3.4.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/10
* chore(deps-dev): bump lint-staged from 15.2.10 to 15.2.11 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/18
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.0.6 to 1.0.7 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/47
* chore(deps-dev): bump concurrently from 9.1.0 to 9.1.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/49
* chore(deps): bump commander from 12.1.0 to 13.0.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/51
* chore(deps-dev): bump lint-staged from 15.2.11 to 15.3.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/50
* chore(deps-dev): bump concurrently from 9.1.1 to 9.1.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/54
* chore(deps-dev): bump textlint from 14.4.0 to 14.4.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/55
* chore(deps-dev): bump typescript from 5.7.2 to 5.7.3 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/62
* chore(deps): bump @stylistic/eslint-plugin-js from 2.12.1 to 2.13.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/69
* chore(deps-dev): bump eslint from 9.17.0 to 9.18.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/72
* chore(deps): update @stylistic/eslint-plugin-js requirement from ^2.12.1 to ^2.13.0 in /packages/eslint-config-bananass by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/73
* chore(deps-dev): bump lint-staged from 15.3.0 to 15.4.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/78
* chore(deps): update prism-react-renderer requirement from ^2.3.0 to ^2.4.1 in /website by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/82
* chore(deps): update @mdx-js/react requirement from ^3.0.0 to ^3.1.0 in /website by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/83
* chore(deps): update clsx requirement from ^2.0.0 to ^2.1.1 in /website by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/84
* chore(deps-dev): bump the babel group across 1 directory with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/98
* chore(deps-dev): bump eslint from 9.18.0 to 9.19.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/101
* chore(deps): bump commander from 13.0.0 to 13.1.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/102
* chore(deps-dev): bump lint-staged from 15.4.1 to 15.4.3 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/99
* chore(deps): bump eslint-plugin-react-compiler from 19.0.0-beta-e552027-20250112 to 19.0.0-beta-27714ef-20250124 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/100
* chore(deps-dev): update vitepress requirement from ^1.6.1 to ^1.6.3 in /websites/vitepress by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/111
* chore(deps-dev): bump markdownlint-cli from 0.43.0 to 0.44.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/108
* chore(deps): bump @stylistic/eslint-plugin-js from 2.13.0 to 3.0.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/109
* chore(deps): bump eslint-plugin-react-compiler from 19.0.0-beta-27714ef-20250124 to 19.0.0-beta-714736e-20250131 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/121
* chore(deps-dev): bump eslint from 9.19.0 to 9.20.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/130
* chore(deps): bump @stylistic/eslint-plugin-js from 3.0.1 to 3.1.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/131
* chore(deps-dev): bump the babel group across 1 directory with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/136
* chore(deps-dev): bump prettier from 3.4.2 to 3.5.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/137
* chore(deps): bump c12 from 2.0.1 to 2.0.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/145
* chore(deps): bump esbuild-loader from 4.2.2 to 4.3.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/146
* chore(deps-dev): bump eslint from 9.20.0 to 9.20.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/147
* chore(deps): bump globals from 15.14.0 to 15.15.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/153
* chore(deps-dev): bump prettier from 3.5.0 to 3.5.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/158
* chore(deps): bump webpack from 5.97.1 to 5.98.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/159
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.3.5 to 1.3.6 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/170
* chore(deps-dev): bump the babel group across 1 directory with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/169
* chore(deps-dev): bump lerna from 8.1.9 to 8.2.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/180
* chore(deps): bump globals from 15.15.0 to 16.0.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/183
* chore(deps-dev): bump prettier from 3.5.1 to 3.5.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/189
* chore(deps): bump c12 from 2.0.2 to 2.0.4 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/188
* chore(deps-dev): bump eslint from 9.20.1 to 9.21.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/190
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/195
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.0.7 to 1.0.8 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/196
* chore(deps): bump c12 from 2.0.4 to 3.0.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/201
* chore(deps): bump c12 from 3.0.1 to 3.0.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/206
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/205
* chore(deps-dev): bump @eslint/config-inspector from 1.0.0 to 1.0.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/209
* chore(deps): bump eslint-plugin-react-hooks from 5.1.0 to 5.2.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/222
* chore(deps): bump eslint-plugin-n from 17.15.1 to 17.16.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/223
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/228
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/229
* chore(deps): bump eslint-plugin-n from 17.16.1 to 17.16.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/230
* chore(deps-dev): bump prettier from 3.5.2 to 3.5.3 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/232
* chore(deps-dev): bump typescript from 5.7.3 to 5.8.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/231
* chore(deps-dev): bump @eslint/config-inspector from 1.0.1 to 1.0.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/239
* chore(deps-dev): bump lerna from 8.2.0 to 8.2.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/240
* chore(deps): bump axios from 1.7.7 to 1.8.2 in the npm_and_yarn group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/248
* chore(deps-dev): bump eslint from 9.21.0 to 9.22.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/255
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/264
* chore(deps-dev): bump `vitepress-plugin-group-icons` from `1.3.6` to `1.3.7` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/265
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/266
* chore(deps-dev): bump textlint from 14.4.2 to 14.5.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/267
* chore(deps-dev): bump lint-staged from 15.4.3 to 15.5.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/269
* chore(deps-dev): bump shx from 0.3.4 to 0.4.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/272
* chore(deps): bump consola from 3.4.0 to 3.4.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/275
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/274
* chore(deps): bump consola from 3.4.1 to 3.4.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/278
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.0.8 to 1.0.9  by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/279
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.3.7 to 1.3.8 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/280
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/284
* chore(deps-dev): bump eslint from 9.22.0 to 9.23.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/287
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/290
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/289
* chore(deps): bump eslint-plugin-n from 17.16.2 to 17.17.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/292
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/296
* chore(deps-dev): bump textlint from 14.5.0 to 14.6.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/297
* chore(deps): bump c12 from 3.0.2 to 3.0.3 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/300
* chore(deps): bump eslint-plugin-react from 7.37.4 to 7.37.5 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/301
* chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/304
* chore(deps-dev): bump typescript from 5.8.2 to 5.8.3 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/305
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/308
* chore(deps): bump webpack from 5.98.0 to 5.99.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/309
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/311
* chore(deps): bump webpack from 5.99.1 to 5.99.5 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/312
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/314
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.3.8 to 1.4.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/315
* chore(deps-dev): bump lerna from 8.2.1 to 8.2.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/317

## New Contributors
* @lumirlumir made their first contribution in https://github.com/lumirlumir/npm-bananass/pull/1
* @dependabot made their first contribution in https://github.com/lumirlumir/npm-bananass/pull/7

**Full Changelog**: https://github.com/lumirlumir/npm-bananass/commits/v0.1.0-canary.1