### PR TITLE
refactor(eslint-config-bananass)!: migrate to ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3986,9 +3986,9 @@
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-3.1.0.tgz",
-      "integrity": "sha512-lQktsOiCr8S6StG29C5fzXYxLOD6ID1rp4j6TRS+E/qY1xd59Fm7dy5qm9UauJIEoSTlYx6yGsCHYh5UkgXPyg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.2.0.tgz",
+      "integrity": "sha512-MiJr6wvyzMYl/wElmj8Jns8zH7Q1w8XoVtm+WM6yDaTrfxryMyb8n0CMxt82fo42RoLIfxAEtM6tmQVxqhk0/A==",
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^4.2.0",
@@ -3998,7 +3998,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.40.0"
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
@@ -21090,7 +21090,7 @@
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.3.0",
-        "@stylistic/eslint-plugin-js": "^3.1.0",
+        "@stylistic/eslint-plugin-js": "^4.2.0",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
         "@typescript-eslint/parser": "^8.29.1",
         "eslint-plugin-import": "^2.31.0",

--- a/packages/bananass-utils-console/src/spinner/spinner.js
+++ b/packages/bananass-utils-console/src/spinner/spinner.js
@@ -24,7 +24,7 @@ import {
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import('chalk').ForegroundColorName} ForegroundColorName
+ * @typedef {'black'|'red'|'green'|'yellow'|'blue'|'cyan'|'magenta'|'white'|'gray'|'grey'|'blackBright'|'redBright'|'greenBright'|'yellowBright'|'blueBright'|'cyanBright'|'magentaBright'|'whiteBright'} ForegroundColorName
  */
 
 /**

--- a/packages/bananass-utils-console/tsconfig.json
+++ b/packages/bananass-utils-console/tsconfig.json
@@ -7,8 +7,8 @@
     "emitDeclarationOnly": true,
     "outDir": "build",
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "skipLibCheck": true
   },
   "include": ["src/**/*.js", "src/**/*.mjs", "src/**/*.cjs"],

--- a/packages/bananass-utils-vitepress/tsconfig.json
+++ b/packages/bananass-utils-vitepress/tsconfig.json
@@ -7,8 +7,8 @@
     "emitDeclarationOnly": true,
     "outDir": "build",
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "skipLibCheck": true
   },
   "include": ["src/**/*.js", "src/**/*.mjs", "src/**/*.cjs"],

--- a/packages/bananass/tsconfig.json
+++ b/packages/bananass/tsconfig.json
@@ -7,8 +7,8 @@
     "emitDeclarationOnly": true,
     "outDir": "build",
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "skipLibCheck": true
   },
   "include": ["src/**/*.js", "src/**/*.mjs", "src/**/*.cjs"],

--- a/packages/create-bananass/tsconfig.json
+++ b/packages/create-bananass/tsconfig.json
@@ -7,8 +7,8 @@
     "emitDeclarationOnly": true,
     "outDir": "build",
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "skipLibCheck": true
   },
   "include": ["src/**/*.js", "src/**/*.mjs", "src/**/*.cjs"],

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,7 @@
 {
   "name": "eslint-config-bananass",
   "version": "0.1.0-canary.1",
+  "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {
     ".": {
@@ -70,7 +71,7 @@
   },
   "dependencies": {
     "@next/eslint-plugin-next": "^15.3.0",
-    "@stylistic/eslint-plugin-js": "^3.1.0",
+    "@stylistic/eslint-plugin-js": "^4.2.0",
     "@typescript-eslint/eslint-plugin": "^8.29.1",
     "@typescript-eslint/parser": "^8.29.1",
     "eslint-plugin-import": "^2.31.0",

--- a/packages/eslint-config-bananass/src/configs/js.js
+++ b/packages/eslint-config-bananass/src/configs/js.js
@@ -6,21 +6,21 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { js } = require('../files');
-const { globals } = require('../language-options');
-const { importPlugin, nodePlugin, stylisticJsPlugin } = require('../plugins');
-const { eslintRules, importRules, nodeRules, stylisticJsRules } = require('../rules');
-const { node } = require('../settings');
+import { js } from '../files.js';
+import { globals } from '../language-options.js';
+import { importPlugin, nodePlugin, stylisticJsPlugin } from '../plugins.js';
+import { eslintRules, importRules, nodeRules, stylisticJsRules } from '../rules/index.js';
+import { node } from '../settings.js';
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-module.exports = {
+export default {
   name: 'bananass/js',
   files: js,
   languageOptions: {

--- a/packages/eslint-config-bananass/src/configs/jsx-next.js
+++ b/packages/eslint-config-bananass/src/configs/jsx-next.js
@@ -6,14 +6,14 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { js, jsx } = require('../files');
-const { globals, parserOptions } = require('../language-options');
-const { node, react } = require('../settings');
+import { js, jsx } from '../files.js';
+import { globals, parserOptions } from '../language-options.js';
+import { node, react } from '../settings.js';
 
-const {
+import {
   importPlugin,
   nodePlugin,
   stylisticJsPlugin,
@@ -22,9 +22,9 @@ const {
   reactCompilerPlugin,
   reactHooksPlugin,
   nextPlugin,
-} = require('../plugins');
+} from '../plugins.js';
 
-const {
+import {
   eslintRules,
   importRules,
   nodeRules,
@@ -34,14 +34,14 @@ const {
   reactCompilerRules,
   reactHooksRules,
   nextRules,
-} = require('../rules');
+} from '../rules/index.js';
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-module.exports = {
+export default {
   name: 'bananass/jsx-next',
   files: [...js, ...jsx],
   languageOptions: {

--- a/packages/eslint-config-bananass/src/configs/jsx-react.js
+++ b/packages/eslint-config-bananass/src/configs/jsx-react.js
@@ -6,14 +6,14 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { js, jsx } = require('../files');
-const { globals, parserOptions } = require('../language-options');
-const { node, react } = require('../settings');
+import { js, jsx } from '../files.js';
+import { globals, parserOptions } from '../language-options.js';
+import { node, react } from '../settings.js';
 
-const {
+import {
   importPlugin,
   nodePlugin,
   stylisticJsPlugin,
@@ -21,9 +21,9 @@ const {
   reactPlugin,
   reactCompilerPlugin,
   reactHooksPlugin,
-} = require('../plugins');
+} from '../plugins.js';
 
-const {
+import {
   eslintRules,
   importRules,
   nodeRules,
@@ -32,14 +32,14 @@ const {
   reactRules,
   reactCompilerRules,
   reactHooksRules,
-} = require('../rules');
+} from '../rules/index.js';
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-module.exports = {
+export default {
   name: 'bananass/jsx-react',
   files: [...js, ...jsx],
   languageOptions: {

--- a/packages/eslint-config-bananass/src/configs/ts.js
+++ b/packages/eslint-config-bananass/src/configs/ts.js
@@ -9,34 +9,35 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { ts } = require('../files');
-const { globals, parser } = require('../language-options');
-const { node } = require('../settings');
+import { ts } from '../files.js';
+import { globals, parser } from '../language-options.js';
+import { node } from '../settings.js';
 
-const {
+import {
   importPlugin,
   nodePlugin,
   stylisticJsPlugin,
   typescriptPlugin,
-} = require('../plugins');
+} from '../plugins.js';
 
-const {
+import {
   eslintRules,
   importRules,
   nodeRules,
   stylisticJsRules,
   typescriptRules,
-} = require('../rules');
+} from '../rules/index.js';
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-module.exports = {
+// @ts-expect-error -- `typescriptPlugin` makes an error here, but it is a valid config.
+export default {
   name: 'bananass/ts',
   files: ts,
   languageOptions: {

--- a/packages/eslint-config-bananass/src/configs/ts.js
+++ b/packages/eslint-config-bananass/src/configs/ts.js
@@ -36,7 +36,7 @@ import {
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-// @ts-expect-error -- `typescriptPlugin` makes an error here, but it is a valid config.
+// @ts-expect-error -- TODO: `typescriptPlugin` makes an error here, but it is a valid config.
 export default {
   name: 'bananass/ts',
   files: ts,

--- a/packages/eslint-config-bananass/src/configs/tsx-next.js
+++ b/packages/eslint-config-bananass/src/configs/tsx-next.js
@@ -6,14 +6,14 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { ts, tsx } = require('../files');
-const { globals, parser, parserOptions } = require('../language-options');
-const { node, react } = require('../settings');
+import { ts, tsx } from '../files.js';
+import { globals, parser, parserOptions } from '../language-options.js';
+import { node, react } from '../settings.js';
 
-const {
+import {
   importPlugin,
   nodePlugin,
   stylisticJsPlugin,
@@ -23,9 +23,9 @@ const {
   reactHooksPlugin,
   nextPlugin,
   typescriptPlugin,
-} = require('../plugins');
+} from '../plugins.js';
 
-const {
+import {
   eslintRules,
   importRules,
   nodeRules,
@@ -36,14 +36,15 @@ const {
   reactHooksRules,
   nextRules,
   typescriptRules,
-} = require('../rules');
+} from '../rules/index.js';
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-module.exports = {
+// @ts-expect-error -- `typescriptPlugin` makes an error here, but it is a valid config.
+export default {
   name: 'bananass/tsx-next',
   files: [...ts, ...tsx],
   languageOptions: {

--- a/packages/eslint-config-bananass/src/configs/tsx-next.js
+++ b/packages/eslint-config-bananass/src/configs/tsx-next.js
@@ -43,7 +43,7 @@ import {
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-// @ts-expect-error -- `typescriptPlugin` makes an error here, but it is a valid config.
+// @ts-expect-error -- TODO: `typescriptPlugin` makes an error here, but it is a valid config.
 export default {
   name: 'bananass/tsx-next',
   files: [...ts, ...tsx],

--- a/packages/eslint-config-bananass/src/configs/tsx-react.js
+++ b/packages/eslint-config-bananass/src/configs/tsx-react.js
@@ -41,7 +41,7 @@ import {
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-// @ts-expect-error -- `typescriptPlugin` makes an error here, but it is a valid config.
+// @ts-expect-error -- TODO: `typescriptPlugin` makes an error here, but it is a valid config.
 export default {
   name: 'bananass/tsx-react',
   files: [...ts, ...tsx],

--- a/packages/eslint-config-bananass/src/configs/tsx-react.js
+++ b/packages/eslint-config-bananass/src/configs/tsx-react.js
@@ -6,14 +6,14 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { ts, tsx } = require('../files');
-const { globals, parser, parserOptions } = require('../language-options');
-const { node, react } = require('../settings');
+import { ts, tsx } from '../files.js';
+import { globals, parser, parserOptions } from '../language-options.js';
+import { node, react } from '../settings.js';
 
-const {
+import {
   importPlugin,
   nodePlugin,
   stylisticJsPlugin,
@@ -22,9 +22,9 @@ const {
   reactCompilerPlugin,
   reactHooksPlugin,
   typescriptPlugin,
-} = require('../plugins');
+} from '../plugins.js';
 
-const {
+import {
   eslintRules,
   importRules,
   nodeRules,
@@ -34,14 +34,15 @@ const {
   reactCompilerRules,
   reactHooksRules,
   typescriptRules,
-} = require('../rules');
+} from '../rules/index.js';
 
 // --------------------------------------------------------------------------------
 // Exports
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").Linter.Config} */
-module.exports = {
+// @ts-expect-error -- `typescriptPlugin` makes an error here, but it is a valid config.
+export default {
   name: 'bananass/tsx-react',
   files: [...ts, ...tsx],
   languageOptions: {

--- a/packages/eslint-config-bananass/src/files.js
+++ b/packages/eslint-config-bananass/src/files.js
@@ -3,13 +3,13 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports.js = ['**/*.js', '**/*.cjs', '**/*.mjs'];
+export const js = ['**/*.js', '**/*.cjs', '**/*.mjs'];
 
-module.exports.jsx = ['**/*.jsx'];
+export const jsx = ['**/*.jsx'];
 
-module.exports.ts = ['**/*.ts', '**/*.cts', '**/*.mts'];
+export const ts = ['**/*.ts', '**/*.cts', '**/*.mts'];
 
-module.exports.tsx = ['**/*.tsx'];
+export const tsx = ['**/*.tsx'];

--- a/packages/eslint-config-bananass/src/index.js
+++ b/packages/eslint-config-bananass/src/index.js
@@ -1,28 +1,32 @@
 /**
  * @fileoverview Entry file for the `eslint-config-bananass` package.
- * @module eslint-config-bananass
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const js = require('./configs/js');
-const jsxReact = require('./configs/jsx-react');
-const jsxNext = require('./configs/jsx-next');
-const ts = require('./configs/ts');
-const tsxReact = require('./configs/tsx-react');
-const tsxNext = require('./configs/tsx-next');
+import { createRequire } from 'node:module';
 
-// @ts-expect-error -- TODO
-const { name, version } = require('../package.json');
+import js from './configs/js.js';
+import jsxReact from './configs/jsx-react.js';
+import jsxNext from './configs/jsx-next.js';
+import ts from './configs/ts.js';
+import tsxReact from './configs/tsx-react.js';
+import tsxNext from './configs/tsx-next.js';
 
 // --------------------------------------------------------------------------------
-// Exports
+// Helpers
+// --------------------------------------------------------------------------------
+
+const { name, version } = createRequire(import.meta.url)('../package.json');
+
+// --------------------------------------------------------------------------------
+// Export
 // --------------------------------------------------------------------------------
 
 /** @type {import("eslint").ESLint.Plugin} */
-module.exports = {
+export default {
   meta: {
     name,
     version,

--- a/packages/eslint-config-bananass/src/language-options.js
+++ b/packages/eslint-config-bananass/src/language-options.js
@@ -3,30 +3,29 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { browser, builtin, es2025, node, jest, vitest, mocha } = require('globals');
-// @ts-expect-error -- TODO
-const typescriptParser = require('@typescript-eslint/parser');
+import globalsModule from 'globals';
+import typescriptParser from '@typescript-eslint/parser';
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports.globals = {
-  ...browser,
-  ...builtin,
-  ...es2025,
-  ...node,
-  ...jest,
-  ...vitest,
-  ...mocha,
+export const globals = {
+  ...globalsModule.browser,
+  ...globalsModule.builtin,
+  ...globalsModule.es2025,
+  ...globalsModule.node,
+  ...globalsModule.jest,
+  ...globalsModule.vitest,
+  ...globalsModule.mocha,
 };
 
-module.exports.parser = typescriptParser;
+export const parser = typescriptParser;
 
-module.exports.parserOptions = {
+export const parserOptions = {
   ecmaFeatures: {
     jsx: true,
   },

--- a/packages/eslint-config-bananass/src/plugins.js
+++ b/packages/eslint-config-bananass/src/plugins.js
@@ -3,40 +3,40 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const importPlugin = require('eslint-plugin-import');
-const nodePlugin = require('eslint-plugin-n');
-const stylisticJsPlugin = require('@stylistic/eslint-plugin-js');
+import importPluginModule from 'eslint-plugin-import';
+import nodePluginModule from 'eslint-plugin-n';
+import stylisticJsPluginModule from '@stylistic/eslint-plugin-js';
 
-const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
-const reactPlugin = require('eslint-plugin-react');
-const reactCompilerPlugin = require('eslint-plugin-react-compiler');
-const reactHooksPlugin = require('eslint-plugin-react-hooks');
+import jsxA11yPluginModule from 'eslint-plugin-jsx-a11y';
+import reactPluginModule from 'eslint-plugin-react';
+import reactCompilerPluginModule from 'eslint-plugin-react-compiler';
+import reactHooksPluginModule from 'eslint-plugin-react-hooks';
 
-const nextPlugin = require('@next/eslint-plugin-next');
+import nextPluginModule from '@next/eslint-plugin-next';
 
-const typescriptPlugin = require('@typescript-eslint/eslint-plugin');
+import typescriptPluginModule from '@typescript-eslint/eslint-plugin';
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports.importPlugin = { import: importPlugin };
+export const importPlugin = { import: importPluginModule };
 
-module.exports.nodePlugin = { n: nodePlugin };
+export const nodePlugin = { n: nodePluginModule };
 
-module.exports.stylisticJsPlugin = { '@stylistic/js': stylisticJsPlugin };
+export const stylisticJsPlugin = { '@stylistic/js': stylisticJsPluginModule };
 
-module.exports.jsxA11yPlugin = { 'jsx-a11y': jsxA11yPlugin };
+export const jsxA11yPlugin = { 'jsx-a11y': jsxA11yPluginModule };
 
-module.exports.reactPlugin = { react: reactPlugin };
+export const reactPlugin = { react: reactPluginModule };
 
-module.exports.reactCompilerPlugin = { 'react-compiler': reactCompilerPlugin };
+export const reactCompilerPlugin = { 'react-compiler': reactCompilerPluginModule };
 
-module.exports.reactHooksPlugin = { 'react-hooks': reactHooksPlugin };
+export const reactHooksPlugin = { 'react-hooks': reactHooksPluginModule };
 
-module.exports.nextPlugin = { '@next/next': nextPlugin };
+export const nextPlugin = { '@next/next': nextPluginModule };
 
-module.exports.typescriptPlugin = { '@typescript-eslint': typescriptPlugin };
+export const typescriptPlugin = { '@typescript-eslint': typescriptPluginModule };

--- a/packages/eslint-config-bananass/src/rules/eslint/eslint-layout-formatting.js
+++ b/packages/eslint-config-bananass/src/rules/eslint/eslint-layout-formatting.js
@@ -9,10 +9,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Require or disallow Unicode byte order mark (BOM).
    *

--- a/packages/eslint-config-bananass/src/rules/eslint/eslint-possible-problems.js
+++ b/packages/eslint-config-bananass/src/rules/eslint/eslint-possible-problems.js
@@ -12,10 +12,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Enforce `return` statements in callbacks of array methods.
    *

--- a/packages/eslint-config-bananass/src/rules/eslint/eslint-suggestions.js
+++ b/packages/eslint-config-bananass/src/rules/eslint/eslint-suggestions.js
@@ -12,10 +12,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Enforce getter and setter pairs in objects and classes.
    *

--- a/packages/eslint-config-bananass/src/rules/eslint/eslint-suggestions.js
+++ b/packages/eslint-config-bananass/src/rules/eslint/eslint-suggestions.js
@@ -1223,7 +1223,7 @@ module.exports = {
    * @link eslint: {@link https://eslint.org/docs/latest/rules/require-unicode-regexp}
    * @link airbnb-base: {@link https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb-base/rules/best-practices.js#L399}
    */
-  'require-unicode-regexp': ['warn', { requireFlag: 'u' }],
+  'require-unicode-regexp': 'off',
 
   /**
    * Require generator functions to contain `yield`.

--- a/packages/eslint-config-bananass/src/rules/eslint/eslint.test.js
+++ b/packages/eslint-config-bananass/src/rules/eslint/eslint.test.js
@@ -3,18 +3,18 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const eslintLayoutFormatting = require('./eslint-layout-formatting');
-const eslintPossibleProblems = require('./eslint-possible-problems');
-const eslintSuggestions = require('./eslint-suggestions');
+import eslintLayoutFormatting from './eslint-layout-formatting.js';
+import eslintPossibleProblems from './eslint-possible-problems.js';
+import eslintSuggestions from './eslint-suggestions.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = '/';

--- a/packages/eslint-config-bananass/src/rules/eslint/index.js
+++ b/packages/eslint-config-bananass/src/rules/eslint/index.js
@@ -1,8 +1,9 @@
-const eslintLayoutFormatting = require('./eslint-layout-formatting');
-const eslintPossibleProblems = require('./eslint-possible-problems');
-const eslintSuggestions = require('./eslint-suggestions');
+import eslintLayoutFormatting from './eslint-layout-formatting.js';
+import eslintPossibleProblems from './eslint-possible-problems.js';
+import eslintSuggestions from './eslint-suggestions.js';
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   ...eslintLayoutFormatting,
   ...eslintPossibleProblems,
   ...eslintSuggestions,

--- a/packages/eslint-config-bananass/src/rules/import/import-helpful-warnings.js
+++ b/packages/eslint-config-bananass/src/rules/import/import-helpful-warnings.js
@@ -9,10 +9,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Forbid any invalid exports, i.e. re-export of the same name.
    *

--- a/packages/eslint-config-bananass/src/rules/import/import-module-systems.js
+++ b/packages/eslint-config-bananass/src/rules/import/import-module-systems.js
@@ -9,10 +9,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Forbid AMD `require` and `define` calls.
    *

--- a/packages/eslint-config-bananass/src/rules/import/import-static-analysis.js
+++ b/packages/eslint-config-bananass/src/rules/import/import-static-analysis.js
@@ -9,10 +9,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Ensure a default export is present, given a default import.
    *

--- a/packages/eslint-config-bananass/src/rules/import/import-style-guide.js
+++ b/packages/eslint-config-bananass/src/rules/import/import-style-guide.js
@@ -9,10 +9,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Enforce or ban the use of inline type-only markers for named imports.
    *

--- a/packages/eslint-config-bananass/src/rules/import/import.test.js
+++ b/packages/eslint-config-bananass/src/rules/import/import.test.js
@@ -3,19 +3,19 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const importHelpfulWarnings = require('./import-helpful-warnings');
-const importModuleSystems = require('./import-module-systems');
-const importStaticAnalysis = require('./import-static-analysis');
-const importStyleGuide = require('./import-style-guide');
+import importHelpfulWarnings from './import-helpful-warnings.js';
+import importModuleSystems from './import-module-systems.js';
+import importStaticAnalysis from './import-static-analysis.js';
+import importStyleGuide from './import-style-guide.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = 'import/';

--- a/packages/eslint-config-bananass/src/rules/import/index.js
+++ b/packages/eslint-config-bananass/src/rules/import/index.js
@@ -1,9 +1,10 @@
-const importHelpfulWarnings = require('./import-helpful-warnings');
-const importModuleSystems = require('./import-module-systems');
-const importStaticAnalysis = require('./import-static-analysis');
-const importStyleGuide = require('./import-style-guide');
+import importHelpfulWarnings from './import-helpful-warnings.js';
+import importModuleSystems from './import-module-systems.js';
+import importStaticAnalysis from './import-static-analysis.js';
+import importStyleGuide from './import-style-guide.js';
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   ...importHelpfulWarnings,
   ...importModuleSystems,
   ...importStaticAnalysis,

--- a/packages/eslint-config-bananass/src/rules/index.js
+++ b/packages/eslint-config-bananass/src/rules/index.js
@@ -1,15 +1,15 @@
-const eslintRules = require('./eslint');
-const importRules = require('./import');
-const nodeRules = require('./node');
-const stylisticJsRules = require('./stylistic-js');
-const jsxA11yRules = require('./jsx-a11y');
-const reactRules = require('./react');
-const reactCompilerRules = require('./react-compiler');
-const reactHooksRules = require('./react-hooks');
-const nextRules = require('./next');
-const typescriptRules = require('./typescript');
+import eslintRules from './eslint/index.js';
+import importRules from './import/index.js';
+import nodeRules from './node/index.js';
+import stylisticJsRules from './stylistic-js/index.js';
+import jsxA11yRules from './jsx-a11y/index.js';
+import reactRules from './react/index.js';
+import reactCompilerRules from './react-compiler/index.js';
+import reactHooksRules from './react-hooks/index.js';
+import nextRules from './next/index.js';
+import typescriptRules from './typescript/index.js';
 
-module.exports = {
+export {
   eslintRules,
   importRules,
   nodeRules,

--- a/packages/eslint-config-bananass/src/rules/jsx-a11y/index.js
+++ b/packages/eslint-config-bananass/src/rules/jsx-a11y/index.js
@@ -1,3 +1,3 @@
-const jsxA11y = require('./jsx-a11y');
+import jsxA11y from './jsx-a11y.js';
 
-module.exports = jsxA11y;
+export default jsxA11y;

--- a/packages/eslint-config-bananass/src/rules/jsx-a11y/jsx-a11y.js
+++ b/packages/eslint-config-bananass/src/rules/jsx-a11y/jsx-a11y.js
@@ -10,7 +10,12 @@
  * - I've set almost every `'error'` rules to `'warn'` because I don't want to enforce them.
  */
 
-module.exports = {
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Enforce all elements that require alternative text have meaningful information to relay back to end user.
    *

--- a/packages/eslint-config-bananass/src/rules/jsx-a11y/jsx-a11y.test.js
+++ b/packages/eslint-config-bananass/src/rules/jsx-a11y/jsx-a11y.test.js
@@ -3,16 +3,16 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const jsxA11y = require('./jsx-a11y');
+import jsxA11y from './jsx-a11y.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = 'jsx-a11y/';

--- a/packages/eslint-config-bananass/src/rules/next/index.js
+++ b/packages/eslint-config-bananass/src/rules/next/index.js
@@ -1,3 +1,3 @@
-const next = require('./next');
+import next from './next.js';
 
-module.exports = next;
+export default next;

--- a/packages/eslint-config-bananass/src/rules/next/next.js
+++ b/packages/eslint-config-bananass/src/rules/next/next.js
@@ -8,10 +8,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   // warnings
   '@next/next/google-font-display': 'warn',
   '@next/next/google-font-preconnect': 'warn',

--- a/packages/eslint-config-bananass/src/rules/next/next.test.js
+++ b/packages/eslint-config-bananass/src/rules/next/next.test.js
@@ -3,16 +3,16 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const next = require('./next');
+import next from './next.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = '@next/next/';

--- a/packages/eslint-config-bananass/src/rules/node/index.js
+++ b/packages/eslint-config-bananass/src/rules/node/index.js
@@ -1,3 +1,3 @@
-const node = require('./node');
+import node from './node.js';
 
-module.exports = node;
+export default node;

--- a/packages/eslint-config-bananass/src/rules/node/node.js
+++ b/packages/eslint-config-bananass/src/rules/node/node.js
@@ -9,10 +9,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Require `return` statements after callbacks.
    *

--- a/packages/eslint-config-bananass/src/rules/node/node.test.js
+++ b/packages/eslint-config-bananass/src/rules/node/node.test.js
@@ -3,16 +3,16 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const node = require('./node');
+import node from './node.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = 'n/';

--- a/packages/eslint-config-bananass/src/rules/react-compiler/index.js
+++ b/packages/eslint-config-bananass/src/rules/react-compiler/index.js
@@ -1,3 +1,3 @@
-const reactCompiler = require('./react-compiler');
+import reactCompiler from './react-compiler.js';
 
-module.exports = reactCompiler;
+export default reactCompiler;

--- a/packages/eslint-config-bananass/src/rules/react-compiler/react-compiler.js
+++ b/packages/eslint-config-bananass/src/rules/react-compiler/react-compiler.js
@@ -6,10 +6,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Surfaces diagnostics from React Forget.
    */

--- a/packages/eslint-config-bananass/src/rules/react-compiler/react-compiler.test.js
+++ b/packages/eslint-config-bananass/src/rules/react-compiler/react-compiler.test.js
@@ -3,16 +3,16 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const reactCompiler = require('./react-compiler');
+import reactCompiler from './react-compiler.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = 'react-compiler/';

--- a/packages/eslint-config-bananass/src/rules/react-hooks/index.js
+++ b/packages/eslint-config-bananass/src/rules/react-hooks/index.js
@@ -1,3 +1,3 @@
-const reactHooks = require('./react-hooks');
+import reactHooks from './react-hooks.js';
 
-module.exports = reactHooks;
+export default reactHooks;

--- a/packages/eslint-config-bananass/src/rules/react-hooks/react-hooks.js
+++ b/packages/eslint-config-bananass/src/rules/react-hooks/react-hooks.js
@@ -6,10 +6,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Verifies the list of dependencies for Hooks like `useEffect` and similar.
    *

--- a/packages/eslint-config-bananass/src/rules/react-hooks/react-hooks.test.js
+++ b/packages/eslint-config-bananass/src/rules/react-hooks/react-hooks.test.js
@@ -3,16 +3,16 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const reactHooks = require('./react-hooks');
+import reactHooks from './react-hooks.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = 'react-hooks/';

--- a/packages/eslint-config-bananass/src/rules/react/index.js
+++ b/packages/eslint-config-bananass/src/rules/react/index.js
@@ -1,3 +1,3 @@
-const react = require('./react');
+import react from './react.js';
 
-module.exports = react;
+export default react;

--- a/packages/eslint-config-bananass/src/rules/react/react.js
+++ b/packages/eslint-config-bananass/src/rules/react/react.js
@@ -15,10 +15,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Enforces consistent naming for boolean props.
    *

--- a/packages/eslint-config-bananass/src/rules/react/react.test.js
+++ b/packages/eslint-config-bananass/src/rules/react/react.test.js
@@ -3,16 +3,16 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const react = require('./react');
+import react from './react.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = 'react/';

--- a/packages/eslint-config-bananass/src/rules/stylistic-js/index.js
+++ b/packages/eslint-config-bananass/src/rules/stylistic-js/index.js
@@ -1,3 +1,3 @@
-const stylisticJs = require('./stylistic-js');
+import stylisticJs from './stylistic-js.js';
 
-module.exports = stylisticJs;
+export default stylisticJs;

--- a/packages/eslint-config-bananass/src/rules/stylistic-js/stylistic-js.js
+++ b/packages/eslint-config-bananass/src/rules/stylistic-js/stylistic-js.js
@@ -12,10 +12,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Enforce consistency of spacing after the start of a comment `//` or `/*`.
    *

--- a/packages/eslint-config-bananass/src/rules/stylistic-js/stylistic-js.test.js
+++ b/packages/eslint-config-bananass/src/rules/stylistic-js/stylistic-js.test.js
@@ -3,16 +3,16 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const stylisticJs = require('./stylistic-js');
+import stylisticJs from './stylistic-js.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = '@stylistic/js/';

--- a/packages/eslint-config-bananass/src/rules/typescript/index.js
+++ b/packages/eslint-config-bananass/src/rules/typescript/index.js
@@ -1,8 +1,9 @@
-const typescriptExtension = require('./typescript-extension');
-const typescriptRecommended = require('./typescript-recommended');
-const typescriptStylistic = require('./typescript-stylistic');
+import typescriptExtension from './typescript-extension.js';
+import typescriptRecommended from './typescript-recommended.js';
+import typescriptStylistic from './typescript-stylistic.js';
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   ...typescriptExtension,
   ...typescriptRecommended,
   ...typescriptStylistic,

--- a/packages/eslint-config-bananass/src/rules/typescript/typescript-extension.js
+++ b/packages/eslint-config-bananass/src/rules/typescript/typescript-extension.js
@@ -6,10 +6,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * @link https://typescript-eslint.io/rules/class-methods-use-this
    */

--- a/packages/eslint-config-bananass/src/rules/typescript/typescript-recommended.js
+++ b/packages/eslint-config-bananass/src/rules/typescript/typescript-recommended.js
@@ -9,10 +9,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * @link https://typescript-eslint.io/rules/ban-ts-comment
    */

--- a/packages/eslint-config-bananass/src/rules/typescript/typescript-stylistic.js
+++ b/packages/eslint-config-bananass/src/rules/typescript/typescript-stylistic.js
@@ -10,10 +10,11 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * @link https://typescript-eslint.io/rules/adjacent-overload-signatures
    */

--- a/packages/eslint-config-bananass/src/rules/typescript/typescript.test.js
+++ b/packages/eslint-config-bananass/src/rules/typescript/typescript.test.js
@@ -3,18 +3,18 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
+// Import
 // --------------------------------------------------------------------------------
 
-const { strictEqual } = require('node:assert');
-const { describe, it } = require('node:test');
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
 
-const typescriptExtension = require('./typescript-extension');
-const typescriptRecommended = require('./typescript-recommended');
-const typescriptStylistic = require('./typescript-stylistic');
+import typescriptExtension from './typescript-extension.js';
+import typescriptRecommended from './typescript-recommended.js';
+import typescriptStylistic from './typescript-stylistic.js';
 
 // --------------------------------------------------------------------------------
-// Declaration
+// Helper
 // --------------------------------------------------------------------------------
 
 const prefix = '@typescript-eslint/';

--- a/packages/eslint-config-bananass/src/settings.js
+++ b/packages/eslint-config-bananass/src/settings.js
@@ -3,10 +3,10 @@
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports.node = {
+export const node = {
   resolverConfig: {
     // `eslint-plugin-n` uses webpack's `enhanced-resolve` under the hood.
     extensions: [
@@ -27,6 +27,6 @@ module.exports.node = {
   },
 };
 
-module.exports.react = {
+export const react = {
   version: 'detect',
 };

--- a/packages/eslint-config-bananass/tsconfig.json
+++ b/packages/eslint-config-bananass/tsconfig.json
@@ -7,8 +7,8 @@
     "emitDeclarationOnly": true,
     "outDir": "build",
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "skipLibCheck": true
   },
   "include": ["src/**/*.js", "src/**/*.mjs", "src/**/*.cjs"],

--- a/packages/prettier-config-bananass/tsconfig.json
+++ b/packages/prettier-config-bananass/tsconfig.json
@@ -7,8 +7,8 @@
     "emitDeclarationOnly": true,
     "outDir": "build",
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "skipLibCheck": true
   },
   "include": ["src/**/*.js", "src/**/*.mjs", "src/**/*.cjs"],

--- a/websites/eslint-config-bananass/config.js
+++ b/websites/eslint-config-bananass/config.js
@@ -1,7 +1,7 @@
-const bananass = require('eslint-config-bananass');
+import bananass from 'eslint-config-bananass';
 
 /** @type {import("eslint").Linter.Config[]} */
-module.exports = [
+export default [
   bananass.configs.js,
   bananass.configs.jsxReact,
   bananass.configs.jsxNext,

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "websites-eslint-config-bananass",
   "version": "0.1.0-canary.1",
+  "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
     "dev": "npx @eslint/config-inspector --config ./config.js"


### PR DESCRIPTION
This pull request includes several changes to the `bananass` project, focusing on updating TypeScript configurations, converting CommonJS to ES modules, and updating dependencies.

### TypeScript Configuration Updates:
* Updated `module` and `moduleResolution` settings from `ESNext` and `Node` to `NodeNext` and `nodenext` respectively in multiple `tsconfig.json` files.

### Conversion from CommonJS to ES Modules:
* Converted CommonJS `require` statements to ES module `import` statements in various files within the `eslint-config-bananass` package. [[1]](diffhunk://#diff-7d34335be53ca4bc3a3d2f80470310b155e5b7a5074f8d4dc6e1919cac916721L9-R23) [[2]](diffhunk://#diff-ed37bd3604035f4eb1410a22dcd8e5f8a07d6d304b78c9a59425b8ccef30703cL9-R16) [[3]](diffhunk://#diff-b74692fbc583f15ffdfd57efb93fe0c4dea858ad0e7f73f42a8dd806324e8c02L9-R26) [[4]](diffhunk://#diff-69670ae9887ed62b829d596199d8533a95399541f4e151b96c1b7f345c611e8cL12-R40) [[5]](diffhunk://#diff-7e6986b8aa252958b9da97c71d62e00f1895da50f896ceb71305ba34671b403aL9-R16) [[6]](diffhunk://#diff-1f99df34d53d43dd73a2dbe7af4e50a96ff8a4d5b36cbb7fc8a9296ab0bc22fdL9-R16) [[7]](diffhunk://#diff-2f961ebcdd0d389f20b3e05a79b131f49ccf45810fcef665c84ea994f2e242d5L6-R15) [[8]](diffhunk://#diff-da6ac4dc852a85b2a5c769cf09235e210f89ee7efbfd4f64929d892bf91a5848L3-R29) [[9]](diffhunk://#diff-d379aabef12bca9dbfb6a19560c38b4e14a8ab77fee9878dca8eefde57b447eaL6-R28) [[10]](diffhunk://#diff-3e1c30cb9d4fbcf52c8fe8b0c4390c99d1d387121e96e111ca3958dd26302ecaL6-R42) [[11]](diffhunk://#diff-7ab2b5cc1f7a4b1d667a694dd9cbfe3bdd2b36c96091ae4250635ef61a0affc5L12-R16)

### Dependency Updates:
* Updated the version of `@stylistic/eslint-plugin-js` from `^3.1.0` to `^4.2.0` in `eslint-config-bananass/package.json`.

### Minor Changes:
* Added `type: "module"` to `eslint-config-bananass/package.json` to specify the module type.
* Expanded the `ForegroundColorName` typedef in `spinner.js` to include more color options.