### PR TITLE
chore(*): install `@types/node` and update `lint-staged` configuration

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,8 +1,8 @@
 export default {
   '*': [
-    'npx prettier --check --ignore-unknown',
+    'npx prettier --write --ignore-unknown',
     'npx editorconfig-checker -config .editorconfig-checker.json',
   ],
-  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint',
-  '*.md': ['npx markdownlint', 'npx textlint -f pretty-error'],
+  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint --fix',
+  '*.md': ['npx markdownlint --fix', 'npx textlint -f pretty-error'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "websites/*"
       ],
       "devDependencies": {
+        "@types/node": "^22.14.1",
         "c8": "^10.1.3",
         "concurrently": "^9.1.0",
         "editorconfig-checker": "^6.0.1",
@@ -4420,12 +4421,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -19139,9 +19140,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fix": "concurrently \"npm:fix:*\"",
     "fix:eslint": "npx eslint --fix",
     "fix:prettier": "npx prettier . --write --ignore-unknown",
+    "fix:markdownlint": "npx markdownlint **/*.md --fix",
     "lint": "concurrently \"npm:lint:*\"",
     "lint:eslint": "npx eslint",
     "lint:prettier": "npx prettier . --check --ignore-unknown",
@@ -61,6 +62,7 @@
     "lint:textlint": "npx textlint -f pretty-error **/*.md"
   },
   "devDependencies": {
+    "@types/node": "^22.14.1",
     "c8": "^10.1.3",
     "concurrently": "^9.1.0",
     "editorconfig-checker": "^6.0.1",


### PR DESCRIPTION
This pull request includes updates to the linting and formatting configurations to automate code fixes and adds a new development dependency.

### Linting and Formatting Updates:

* [`lint-staged.config.mjs`](diffhunk://#diff-7de6c7dbbd1b286aac2271abff52aed05b83379c998f2158f357046f9fd06c7dL3-R7): Updated `prettier` and `eslint` commands to automatically fix issues instead of just checking them. Also, added the `--fix` flag to `markdownlint` command.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R56): Added new `fix:markdownlint` script to automatically fix markdown issues.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R65): Added `@types/node` as a development dependency.