### PR TITLE
fix(eslint-config-bananass): enhance JSDoc template and update types in `index.js`

### DIFF
--- a/packages/eslint-config-bananass/src/index.js
+++ b/packages/eslint-config-bananass/src/index.js
@@ -20,7 +20,7 @@ import tsxNext from './configs/tsx-next.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {Object} PackageJson
+ * @typedef {object} PackageJson
  * @property {string} name
  * @property {string} version
  */

--- a/packages/eslint-config-bananass/src/index.js
+++ b/packages/eslint-config-bananass/src/index.js
@@ -16,9 +16,20 @@ import tsxReact from './configs/tsx-react.js';
 import tsxNext from './configs/tsx-next.js';
 
 // --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} PackageJson
+ * @property {string} name
+ * @property {string} version
+ */
+
+// --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
 
+/** @type {PackageJson} */
 const { name, version } = createRequire(import.meta.url)('../package.json');
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-config-bananass/templates/jsdoc.md
+++ b/packages/eslint-config-bananass/templates/jsdoc.md
@@ -14,10 +14,11 @@ Every file under `eslint-config-bananass/src/rules` directory should follow the 
  */
 
 // --------------------------------------------------------------------------------
-// Exports
+// Export
 // --------------------------------------------------------------------------------
 
-module.exports = {
+/** @type {import("eslint").Linter.RulesRecord} */
+export default {
   /**
    * Descriptions from the official documentation.
    *


### PR DESCRIPTION
This pull request introduces type definitions and improves code clarity by adding JSDoc annotations and switching to ES module syntax for exports in the `eslint-config-bananass` package.

### Type Definitions and Documentation:

* Added a `PackageJson` typedef to define the structure of `package.json` files, including `name` and `version` properties. This typedef is used to annotate the `name` and `version` variables. (`packages/eslint-config-bananass/src/index.js`, [packages/eslint-config-bananass/src/index.jsR18-R32](diffhunk://#diff-da6ac4dc852a85b2a5c769cf09235e210f89ee7efbfd4f64929d892bf91a5848R18-R32))

### Codebase Modernization:

* Replaced `module.exports` with `export default` for ES module syntax and added a JSDoc type annotation (`Linter.RulesRecord`) to the exported object for better type safety. (`packages/eslint-config-bananass/templates/jsdoc.md`, [packages/eslint-config-bananass/templates/jsdoc.mdL17-R21](diffhunk://#diff-6aa56387685189c797cbb8ca2bae19470ce98c6be4e69e2090d890b0c93a3534L17-R21))