### PR TITLE
test(*): create e2e tests for bananass-build with `cjs` module system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18459,6 +18459,10 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/tests-e2e": {
+      "resolved": "tests/e2e",
+      "link": true
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -21078,6 +21082,13 @@
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
+      }
+    },
+    "tests/e2e": {
+      "name": "tests-e2e",
+      "version": "0.1.0-canary.2",
+      "devDependencies": {
+        "bananass": "^0.1.0-canary.2"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:pkg:buv": "npm run test -w packages/bananass-utils-vitepress",
     "test:pkg:ecb": "npm run test -w packages/eslint-config-bananass",
     "test:pkg:pcb": "npm run test -w packages/prettier-config-bananass",
+    "test:t:e2e": "npm run test -w tests/e2e",
     "build": "npx lerna run build --ignore npm-bananass",
     "build:ex:sb-cjs": "npm run bananass:build -w examples/solutions-bananass-cjs",
     "build:ex:sb-cts": "npm run bananass:build -w examples/solutions-bananass-cts",

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -32,6 +32,18 @@
       ],
       ".": [
         "./build/core/types.d.ts"
+      ],
+      "./commands": [
+        "./build/commands/index.d.ts"
+      ],
+      "./core/structs": [
+        "./build/core/structs/index.d.ts"
+      ],
+      "./core/constants": [
+        "./build/core/constants.d.ts"
+      ],
+      "./core/types": [
+        "./build/core/types.d.ts"
       ]
     }
   },

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./build/core/types.d.ts"
     },
+    "./commands": {
+      "types": "./build/commands/index.d.ts",
+      "default": "./src/commands/index.js"
+    },
     "./core/structs": {
       "types": "./build/core/structs/index.d.ts",
       "default": "./src/core/structs/index.js"

--- a/packages/bananass/src/commands/bananass-build/build.js
+++ b/packages/bananass/src/commands/bananass-build/build.js
@@ -134,7 +134,7 @@ export default async function build(problems, configObject = dco) {
           rules: [
             {
               test: /\.(?:js|mjs|cjs)$/i, // JavaScript
-              include: [/node_modules/, new RegExp(resolvedEntryDir)],
+              include: () => false,
               loader: 'esbuild-loader',
               options: {
                 target: 'node14',

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,1 @@
+.bananass

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -5,6 +5,11 @@
  * They are simply A + B examples used for testing purposes.
  */
 
+// TODO: Add tests for:
+// - templateType: 'rl',
+// - External libraries: local
+// - External libraries: npm
+
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
@@ -24,7 +29,7 @@ import { build } from 'bananass/commands';
 
 const cwd = resolve(import.meta.dirname, './fixtures/cjs');
 const outDir = resolve(cwd, '.bananass');
-const configObject = { cwd, console: { quiet: true } };
+const configObject = { cwd, console: { quiet: true }, build: { templateType: 'fs' } };
 
 /** @param {string} outFile @param {string} input */
 function runOutFile(outFile, input) {

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -69,7 +69,7 @@ describe('cjs', () => {
       strictEqual(result.stdout, '3');
     });
 
-    it('`file.cjs` file should build correctly', async () => {
+    it('`file.cjs` should build correctly', async () => {
       await build(['1002'], configObject);
 
       const outFile = resolve(outDir, '1002.js');
@@ -80,10 +80,21 @@ describe('cjs', () => {
       strictEqual(result.stdout, '3');
     });
 
-    it('`file.mjs` file should build correctly', async () => {
+    it('`file.mjs` with `export default` should build correctly', async () => {
       await build(['1003'], configObject);
 
       const outFile = resolve(outDir, '1003.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
+
+    it('`file.mjs` with `export` should build correctly', async () => {
+      await build(['1004'], configObject);
+
+      const outFile = resolve(outDir, '1004.js');
       const result = runOutFile(outFile, '1 2');
 
       ok(existsSync(outFile));
@@ -126,7 +137,7 @@ describe('cjs', () => {
       strictEqual(result.stdout, '3');
     });
 
-    it('`directory/index.mjs` should build correctly', async () => {
+    it('`directory/index.mjs` with `export default` should build correctly', async () => {
       await build(['2003'], configObject);
 
       const outFile = resolve(outDir, '2003.js');

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -73,9 +73,37 @@ describe('cjs', () => {
       strictEqual(result.status, 0);
       strictEqual(result.stdout, '3');
     });
+
+    it('`.cjs` file should build correctly', async () => {
+      await build(['1002'], {
+        cwd,
+        console: { quiet: true },
+      });
+
+      const outFile = resolve(outDir, '1002.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
+
+    it('`.mjs` file should build correctly', async () => {
+      await build(['1003'], {
+        cwd,
+        console: { quiet: true },
+      });
+
+      const outFile = resolve(outDir, '1003.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
   });
 
-  describe('when the solution is in single directory and multiple files', () => {
+  describe('when the solution is in a single directory with multiple files', () => {
     it('A solution directory with `solution` and `testcases` should build correctly', async () => {
       await build(['2000'], {
         cwd,

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -106,6 +106,17 @@ describe('cjs', () => {
       strictEqual(result.status, 0);
       strictEqual(result.stdout, '3');
     });
+
+    it('User-created external modules using the `cjs` format should build correctly.', async () => {
+      await build(['1005'], configObject);
+
+      const outFile = resolve(outDir, '1005.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
   });
 
   describe('When the solution is in a single directory with multiple files', () => {
@@ -157,6 +168,17 @@ describe('cjs', () => {
       await build(['2004'], configObject);
 
       const outFile = resolve(outDir, '2004.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
+
+    it('User-created external modules using the `cjs` format should build correctly.', async () => {
+      await build(['2005'], configObject);
+
+      const outFile = resolve(outDir, '2005.js');
       const result = runOutFile(outFile, '1 2');
 
       ok(existsSync(outFile));

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -24,6 +24,7 @@ import { build } from 'bananass/commands';
 
 const cwd = resolve(import.meta.dirname, './fixtures/cjs');
 const outDir = resolve(cwd, '.bananass');
+const configObject = { cwd, console: { quiet: true } };
 
 /** @param {string} outFile @param {string} input */
 function runOutFile(outFile, input) {
@@ -45,12 +46,9 @@ afterEach(() => {
 });
 
 describe('cjs', () => {
-  describe('when the entire solution is in a single file', () => {
+  describe('When the entire solution is in a single file', () => {
     it('A single file with `solution` and `testcases` should build correctly', async () => {
-      await build(['1000'], {
-        cwd,
-        console: { quiet: true },
-      });
+      await build(['1000'], configObject);
 
       const outFile = resolve(outDir, '1000.js');
       const result = runOutFile(outFile, '1 2');
@@ -61,10 +59,7 @@ describe('cjs', () => {
     });
 
     it('A single file with only `solution` should build correctly', async () => {
-      await build(['1001'], {
-        cwd,
-        console: { quiet: true },
-      });
+      await build(['1001'], configObject);
 
       const outFile = resolve(outDir, '1001.js');
       const result = runOutFile(outFile, '1 2');
@@ -75,10 +70,7 @@ describe('cjs', () => {
     });
 
     it('`.cjs` file should build correctly', async () => {
-      await build(['1002'], {
-        cwd,
-        console: { quiet: true },
-      });
+      await build(['1002'], configObject);
 
       const outFile = resolve(outDir, '1002.js');
       const result = runOutFile(outFile, '1 2');
@@ -89,10 +81,7 @@ describe('cjs', () => {
     });
 
     it('`.mjs` file should build correctly', async () => {
-      await build(['1003'], {
-        cwd,
-        console: { quiet: true },
-      });
+      await build(['1003'], configObject);
 
       const outFile = resolve(outDir, '1003.js');
       const result = runOutFile(outFile, '1 2');
@@ -103,14 +92,22 @@ describe('cjs', () => {
     });
   });
 
-  describe('when the solution is in a single directory with multiple files', () => {
+  describe('When the solution is in a single directory with multiple files', () => {
     it('A solution directory with `solution` and `testcases` should build correctly', async () => {
-      await build(['2000'], {
-        cwd,
-        console: { quiet: true },
-      });
+      await build(['2000'], configObject);
 
       const outFile = resolve(outDir, '2000.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
+
+    it('A solution directory with only `solution` should build correctly', async () => {
+      await build(['2001'], configObject);
+
+      const outFile = resolve(outDir, '2001.js');
       const result = runOutFile(outFile, '1 2');
 
       ok(existsSync(outFile));
@@ -121,10 +118,7 @@ describe('cjs', () => {
 
   describe('Multiple files', () => {
     it('Multipe files should build correctly', async () => {
-      await build(['1000', '1001', '2000'], {
-        cwd,
-        console: { quiet: true },
-      });
+      await build(['1000', '1001', '2000'], configObject);
 
       const outFile1000 = resolve(outDir, '1000.js');
       const result1000 = runOutFile(outFile1000, '1 2');

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -69,7 +69,7 @@ describe('cjs', () => {
       strictEqual(result.stdout, '3');
     });
 
-    it('`.cjs` file should build correctly', async () => {
+    it('`file.cjs` file should build correctly', async () => {
       await build(['1002'], configObject);
 
       const outFile = resolve(outDir, '1002.js');
@@ -80,7 +80,7 @@ describe('cjs', () => {
       strictEqual(result.stdout, '3');
     });
 
-    it('`.mjs` file should build correctly', async () => {
+    it('`file.mjs` file should build correctly', async () => {
       await build(['1003'], configObject);
 
       const outFile = resolve(outDir, '1003.js');
@@ -108,6 +108,28 @@ describe('cjs', () => {
       await build(['2001'], configObject);
 
       const outFile = resolve(outDir, '2001.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
+
+    it('`directory/index.cjs` should build correctly', async () => {
+      await build(['2002'], configObject);
+
+      const outFile = resolve(outDir, '2002.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
+
+    it('`directory/index.mjs` should build correctly', async () => {
+      await build(['2003'], configObject);
+
+      const outFile = resolve(outDir, '2003.js');
       const result = runOutFile(outFile, '1 2');
 
       ok(existsSync(outFile));

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -147,6 +147,17 @@ describe('cjs', () => {
       strictEqual(result.status, 0);
       strictEqual(result.stdout, '3');
     });
+
+    it('`directory/index.mjs` with `export` should build correctly', async () => {
+      await build(['2004'], configObject);
+
+      const outFile = resolve(outDir, '2004.js');
+      const result = runOutFile(outFile, '1 2');
+
+      ok(existsSync(outFile));
+      strictEqual(result.status, 0);
+      strictEqual(result.stdout, '3');
+    });
   });
 
   describe('Multiple files', () => {

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/1000.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/1000.js
@@ -1,0 +1,21 @@
+const testcases = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];
+
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+module.exports = globalThis.IS_PROD ? { solution } : { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/1001.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/1001.js
@@ -1,0 +1,10 @@
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+module.exports = { solution };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/1002.cjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/1002.cjs
@@ -1,0 +1,10 @@
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+module.exports = { solution };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/1003.mjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/1003.mjs
@@ -1,0 +1,10 @@
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/1004.mjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/1004.mjs
@@ -1,0 +1,19 @@
+export function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+export const testcases = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/1005.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/1005.js
@@ -1,0 +1,23 @@
+const add = require('../utils/add');
+
+const testcases = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];
+
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return add(a, b);
+}
+
+module.exports = { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2000/index.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2000/index.js
@@ -1,0 +1,4 @@
+const solution = require('./solution');
+const testcases = require('./testcases');
+
+module.exports = { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2000/solution.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2000/solution.js
@@ -1,0 +1,10 @@
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+module.exports = solution;

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2000/testcases.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2000/testcases.js
@@ -1,0 +1,10 @@
+module.exports = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2001/index.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2001/index.js
@@ -1,0 +1,3 @@
+const solution = require('./solution');
+
+module.exports = { solution };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2001/solution.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2001/solution.js
@@ -1,0 +1,10 @@
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+module.exports = solution;

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2002/index.cjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2002/index.cjs
@@ -1,0 +1,4 @@
+const solution = require('./solution');
+const testcases = require('./testcases');
+
+module.exports = { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2002/solution.cjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2002/solution.cjs
@@ -1,0 +1,10 @@
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+module.exports = solution;

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2002/testcases.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2002/testcases.js
@@ -1,0 +1,10 @@
+module.exports = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2003/index.mjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2003/index.mjs
@@ -1,0 +1,4 @@
+import solution from './solution.mjs';
+import testcases from './testcases.mjs';
+
+export default { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2003/solution.mjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2003/solution.mjs
@@ -1,0 +1,8 @@
+export default function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2003/testcases.mjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2003/testcases.mjs
@@ -1,0 +1,10 @@
+export default [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2004/index.mjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2004/index.mjs
@@ -1,0 +1,2 @@
+export { solution } from './solution.mjs';
+export { testcases } from './testcases.mjs';

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2004/solution.mjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2004/solution.mjs
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+
+export function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2004/testcases.mjs
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2004/testcases.mjs
@@ -1,0 +1,12 @@
+/* eslint-disable import/prefer-default-export */
+
+export const testcases = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2005/index.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2005/index.js
@@ -1,0 +1,4 @@
+const solution = require('./solution');
+const testcases = require('./testcases');
+
+module.exports = { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2005/solution.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2005/solution.js
@@ -1,0 +1,12 @@
+const add = require('../../utils/add');
+
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return add(a, b);
+}
+
+module.exports = solution;

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/2005/testcases.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/2005/testcases.js
@@ -1,0 +1,10 @@
+module.exports = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];

--- a/tests/e2e/bananass-build/fixtures/cjs/package.json
+++ b/tests/e2e/bananass-build/fixtures/cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/tests/e2e/bananass-build/fixtures/cjs/utils/add.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/utils/add.js
@@ -1,0 +1,5 @@
+function add(a, b) {
+  return a + b;
+}
+
+module.exports = add;

--- a/tests/e2e/bananass-build/fixtures/cts/package.json
+++ b/tests/e2e/bananass-build/fixtures/cts/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/tests/e2e/bananass-build/fixtures/mjs/package.json
+++ b/tests/e2e/bananass-build/fixtures/mjs/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/tests/e2e/bananass-build/fixtures/mts/package.json
+++ b/tests/e2e/bananass-build/fixtures/mts/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "tests-e2e",
+  "version": "0.1.0-canary.2",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "bananass": "^0.1.0-canary.2"
+  }
+}


### PR DESCRIPTION
This pull request introduces end-to-end (E2E) testing for building CommonJS (CJS) solutions using the `bananass` package. It includes updates to the testing infrastructure, additional test cases, and new fixture files for testing various scenarios. The most important changes are grouped below by theme.

### Testing Infrastructure Enhancements:
* Added a new E2E test script `test:t:e2e` to the `package.json` for running tests in the `tests/e2e` directory.
* Updated `.gitignore` to exclude `.bananass` directories generated during E2E tests.

### E2E Tests for Building CJS Solutions:
* Implemented comprehensive E2E tests in `tests/e2e/bananass-build/cjs.test.js` to validate the build process for various CJS solution configurations, including single files, directories, and multiple files.

### Fixture Files for E2E Tests:
* Added fixture files in `tests/e2e/bananass-build/fixtures/cjs/bananass/` to test different solution formats:
  - Single-file solutions (`1000.js`, `1001.js`, `1002.cjs`, `1003.mjs`, `1004.mjs`). [[1]](diffhunk://#diff-f4c8c5a435a059e0bec3bad9809edbe0439a7db56111e192f4c827541dca2643R1-R21) [[2]](diffhunk://#diff-2a6283eef378f78caeb0e1e1432e4b85e20f3a6df685753ac750a2bd6852769aR1-R10) [[3]](diffhunk://#diff-78fb7250657c36d01066f293ea77c879dae5232b36174663f9dae7fd6395b0e9R1-R10) [[4]](diffhunk://#diff-ec61eaa2fe640789a842b9706235355df1931f79c2ed86941f270870e128dea1R1-R19)
  - Directory-based solutions with multiple files (`2000`, `2001`, `2002`, `2003`). [[1]](diffhunk://#diff-758336b9ad18b66ce65f7f38f3e8f3bb3e68c1d4849f282bbb43685b5e2edef2R1-R4) [[2]](diffhunk://#diff-138a32224f8e0b3ae11863c2391177a4dd245309ce2e0ae2f4746326308777f6R1-R10) [[3]](diffhunk://#diff-a7292ddab77cfeb3aeb10e70b9266096cf29efc880f5ebef2a10427f0f537071R1-R10) [[4]](diffhunk://#diff-dbc8fa7d8af36ffce0ab75289b144e35469890a305b1cad02efd09dd7cccfaf2R1-R3) [[5]](diffhunk://#diff-e85a9c99c78f4a4af3f2e561794f09fb142b5ef740cb94fd20e34a0f990352b2R1-R4) [[6]](diffhunk://#diff-d3cec280b8aab8a1452f6ba0c365b392b800542fa24effe50201df8ff56ddf3bR1-R8) 

### Package Configuration Updates:
* Extended the `exports` field in `packages/bananass/package.json` to include a new entry for `./commands`, enabling proper resolution of `bananass/commands` during testing and usage.