### PR TITLE
feat(bananass): support `Array.prototype.toSorted` transpilation using custom babel plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5416,6 +5416,51 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
+      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.20.7"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -22274,6 +22319,9 @@
       "bin": {
         "b": "src/cli.js",
         "bananass": "src/cli.js"
+      },
+      "devDependencies": {
+        "@types/babel__core": "^7.20.5"
       },
       "engines": {
         "node": "^20.18.0 || >= 22.3.0"

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -105,5 +105,8 @@
     "open": "^10.1.1",
     "superstruct": "^2.0.2",
     "webpack": "^5.99.6"
+  },
+  "devDependencies": {
+    "@types/babel__core": "^7.20.5"
   }
 }

--- a/packages/bananass/src/babel-plugins/index.js
+++ b/packages/bananass/src/babel-plugins/index.js
@@ -1,0 +1,3 @@
+import transformArrayPrototypeToSorted from './transform-array-prototype-to-sorted/index.js';
+
+export { transformArrayPrototypeToSorted };

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/index.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/index.js
@@ -1,0 +1,3 @@
+import transformArrayPrototypeToSorted from './transform-array-prototype-to-sorted.js';
+
+export default transformArrayPrototypeToSorted;

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Transform `array.prototype.toSorted(compareFn)` to `array.prototype.slice().sort(compareFn)`.
+ * AST: https://astexplorer.net/
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { types as t } from '@babel/core';
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Transform `array.prototype.toSorted(compareFn)` to `array.prototype.slice().sort(compareFn)`.
+ *
+ * Compatibility: ES3
+ * - `slice()`: ES3
+ * - `sort()`: ES1
+ *
+ * @return {import("@babel/core").PluginObj}
+ */
+export default function transformArrayPrototypeToSorted() {
+  return {
+    name: 'transform-array-prototype-to-sorted',
+
+    visitor: {
+      CallExpression(path) {
+        const { node } = path;
+
+        if (
+          t.isMemberExpression(node.callee) &&
+          t.isIdentifier(node.callee.property, { name: 'toSorted' }) &&
+          node.arguments.length <= 1
+        ) {
+          // `arr.toSorted(args)` => `arr.slice().sort(args)`
+          const arr = node.callee.object;
+          const sliceCall = t.callExpression(
+            t.memberExpression(arr, t.identifier('slice')),
+            [],
+          );
+          const sortCall = t.callExpression(
+            t.memberExpression(sliceCall, t.identifier('sort')),
+            node.arguments,
+          );
+
+          path.replaceWith(sortCall);
+        }
+      },
+    },
+  };
+}

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.test.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.test.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Test for `transform-array-prototype-to-sorted.js`.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { transformSync } from '@babel/core';
+
+import transformArrayPrototypeToSorted from './transform-array-prototype-to-sorted.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const options = {
+  plugins: [transformArrayPrototypeToSorted],
+};
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('transform-array-prototype-to-sorted.js', () => {
+  it('should transform `arr.toSorted()` to `arr.slice().sort()`', () => {
+    const code = '[1, 2, 3].toSorted();';
+    const transformedCode = transformSync(code, options).code;
+    const expected = '[1, 2, 3].slice().sort();';
+
+    strictEqual(transformedCode, expected);
+  });
+
+  it('should transform with a compare function', () => {
+    const code = '[3, 1, 2].toSorted((a, b) => b - a);';
+    const transformedCode = transformSync(code, options).code;
+    const expected = '[3, 1, 2].slice().sort((a, b) => b - a);';
+
+    strictEqual(transformedCode, expected);
+  });
+
+  it('should transform chained calls', () => {
+    const code = 'getArr().toSorted().map(x => x * 2);';
+    const transformedCode = transformSync(code, options).code;
+    const expected = 'getArr().slice().sort().map(x => x * 2);';
+
+    strictEqual(transformedCode, expected);
+  });
+
+  it('should not transform when more than one argument is passed', () => {
+    const code = '[1, 2].toSorted(compareFn, extra);';
+    const transformedCode = transformSync(code, options).code;
+
+    strictEqual(transformedCode, code);
+  });
+
+  it('should not touch non-toSorted methods', () => {
+    const code = '[1, 2, 3].slice();';
+    const transformedCode = transformSync(code, options).code;
+
+    strictEqual(transformedCode, code);
+  });
+});

--- a/packages/bananass/src/commands/bananass-build/build.js
+++ b/packages/bananass/src/commands/bananass-build/build.js
@@ -15,6 +15,8 @@ import createSpinner from 'bananass-utils-console/spinner';
 import { bananass, success, error } from 'bananass-utils-console/theme';
 import webpack from 'webpack';
 
+import { transformArrayPrototypeToSorted } from '../../babel-plugins/index.js';
+
 import { defaultConfigObject as dco } from '../../core/conf/index.js';
 import { Problems, ConfigObject } from '../../core/structs/index.js';
 import {
@@ -147,6 +149,7 @@ export default async function build(problems, configObject = dco) {
                     },
                   ],
                 ],
+                plugins: [transformArrayPrototypeToSorted],
               },
             },
             {

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -326,7 +326,7 @@ describe('cjs', () => {
     });
   });
 
-  describe('Latest ECMAScript features with `@babel/preset-env` should be transpiled correctly', () => {
+  describe('Latest ECMAScript features with `@babel/preset-env` and custom plugins should be transpiled correctly', () => {
     describe('`fs`(file system) template', () => {
       it('ES2025 `regexp-modifiers` should be transpiled correctly', async () => {
         // https://babeljs.io/docs/babel-plugin-transform-regexp-modifiers
@@ -339,6 +339,20 @@ describe('cjs', () => {
         const fileContent = readFileSync(outFile, 'utf-8');
         strictEqual(fileContent.includes('/(?:[Aa])a/'), true);
         strictEqual(fileContent.includes('/(?i:a)a/'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
+        await build(['3001'], configObjectFS);
+
+        const outFile = resolve(outDir, '3001.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('toSorted()'), false);
 
         const result = runOutFile(outFile, '1 2');
         strictEqual(result.status, 0);
@@ -358,6 +372,20 @@ describe('cjs', () => {
         const fileContent = readFileSync(outFile, 'utf-8');
         strictEqual(fileContent.includes('/(?:[Aa])a/'), true);
         strictEqual(fileContent.includes('/(?i:a)a/'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
+        await build(['3001'], configObjectRL);
+
+        const outFile = resolve(outDir, '3001.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('toSorted()'), false);
 
         const result = runOutFile(outFile, '1 2');
         strictEqual(result.status, 0);

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/3001.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/3001.js
@@ -1,0 +1,11 @@
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val))
+    .toSorted();
+
+  return a + b;
+}
+
+module.exports = { solution };

--- a/tests/e2e/bananass-build/fixtures/mjs/bananass/3001.js
+++ b/tests/e2e/bananass-build/fixtures/mjs/bananass/3001.js
@@ -1,0 +1,11 @@
+function solution(input) {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val))
+    .toSorted();
+
+  return a + b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/mjs.test.js
+++ b/tests/e2e/bananass-build/mjs.test.js
@@ -326,7 +326,7 @@ describe('mjs', () => {
     });
   });
 
-  describe('Latest ECMAScript features with `@babel/preset-env` should be transpiled correctly', () => {
+  describe('Latest ECMAScript features with `@babel/preset-env` and custom plugins should be transpiled correctly', () => {
     describe('`fs`(file system) template', () => {
       it('ES2025 `regexp-modifiers` should be transpiled correctly', async () => {
         // https://babeljs.io/docs/babel-plugin-transform-regexp-modifiers
@@ -339,6 +339,20 @@ describe('mjs', () => {
         const fileContent = readFileSync(outFile, 'utf-8');
         strictEqual(fileContent.includes('/(?:[Aa])a/'), true);
         strictEqual(fileContent.includes('/(?i:a)a/'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
+        await build(['3001'], configObjectFS);
+
+        const outFile = resolve(outDir, '3001.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('toSorted()'), false);
 
         const result = runOutFile(outFile, '1 2');
         strictEqual(result.status, 0);
@@ -358,6 +372,20 @@ describe('mjs', () => {
         const fileContent = readFileSync(outFile, 'utf-8');
         strictEqual(fileContent.includes('/(?:[Aa])a/'), true);
         strictEqual(fileContent.includes('/(?i:a)a/'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
+        await build(['3001'], configObjectRL);
+
+        const outFile = resolve(outDir, '3001.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('toSorted()'), false);
 
         const result = runOutFile(outFile, '1 2');
         strictEqual(result.status, 0);


### PR DESCRIPTION
This pull request introduces a new Babel plugin, `transform-array-prototype-to-sorted`, which transforms calls to `array.prototype.toSorted(compareFn)` into `array.prototype.slice().sort(compareFn)` for compatibility with older JavaScript environments. The changes include the implementation of the plugin, its integration into the build process, and extensive testing to ensure correctness.

### Babel Plugin Implementation and Integration:

* **New Babel Plugin**: Added the `transform-array-prototype-to-sorted` Babel plugin to transform `toSorted` calls into compatible `slice().sort()` calls. The implementation is located in `packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js`.
* **Export and Indexing**: The plugin is exported and made accessible through the Babel plugins index (`packages/bananass/src/babel-plugins/index.js`) and its own index file (`packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/index.js`) [[1]](diffhunk://#diff-267f2147e669d155bc596d8563c871f224a04e126bfeefdafd2260573ee45f14R1-R3) [[2]](diffhunk://#diff-e60c16b9d7a2a507c08edb8b62c5f34346d02ec2d132b99e1eff60768c2a446bR1-R3).
* **Build Process Integration**: Integrated the plugin into the Babel configuration for the `bananass-build` command to ensure it is applied during the build process (`packages/bananass/src/commands/bananass-build/build.js`) [[1]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4R18-R19) [[2]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4R152).

### Testing Enhancements:

* **Unit Tests**: Added unit tests for the plugin to validate transformations and ensure edge cases are handled correctly (`packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.test.js`).
* **End-to-End Tests**: Updated E2E tests for both CommonJS (`tests/e2e/bananass-build/cjs.test.js`) and ES Modules (`tests/e2e/bananass-build/mjs.test.js`) to verify the plugin's functionality in real-world scenarios [[1]](diffhunk://#diff-3dd374fa0ef90c526843be817203fe90f0c59d84a194e80f47d8ba423739649aL329-R329) [[2]](diffhunk://#diff-3dd374fa0ef90c526843be817203fe90f0c59d84a194e80f47d8ba423739649aR347-R360) [[3]](diffhunk://#diff-3dd374fa0ef90c526843be817203fe90f0c59d84a194e80f47d8ba423739649aR380-R393) [[4]](diffhunk://#diff-f65bc9379932f9437f660b6db68ad3e824de82e2988316171a6aa664e1f4a176L329-R329) [[5]](diffhunk://#diff-f65bc9379932f9437f660b6db68ad3e824de82e2988316171a6aa664e1f4a176R347-R360) [[6]](diffhunk://#diff-f65bc9379932f9437f660b6db68ad3e824de82e2988316171a6aa664e1f4a176R380-R393).
* **Fixtures**: Added new test fixtures demonstrating the use of `toSorted` in both CommonJS and ES Modules (`tests/e2e/bananass-build/fixtures/cjs/bananass/3001.js`, `tests/e2e/bananass-build/fixtures/mjs/bananass/3001.js`) [[1]](diffhunk://#diff-30ee7306330793bbc0d34a9e3fd642d607499f60c5f684f565607e84229404e1R1-R11) [[2]](diffhunk://#diff-f1012a0cc309bd0b88ea5bc1c7808576bfc78884dc4f00c500d90749258aa11fR1-R11).

### Dependency Updates:

* **Development Dependency**: Added `@types/babel__core` to `devDependencies` in `packages/bananass/package.json` to support TypeScript typings for Babel development.