### PR TITLE
feat(bananass): support `Object.hasOwn` transpilation using custom babel plugin

### DIFF
--- a/packages/bananass/src/babel-plugins/index.js
+++ b/packages/bananass/src/babel-plugins/index.js
@@ -2,5 +2,10 @@
 
 import transformArrayPrototypeToReversed from './transform-array-prototype-to-reversed/index.js';
 import transformArrayPrototypeToSorted from './transform-array-prototype-to-sorted/index.js';
+import transformObjectHasOwn from './transform-object-has-own/index.js';
 
-export { transformArrayPrototypeToReversed, transformArrayPrototypeToSorted };
+export {
+  transformArrayPrototypeToReversed,
+  transformArrayPrototypeToSorted,
+  transformObjectHasOwn,
+};

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Transform ES2023 `array.prototype.toReversed()` to `array.prototype.slice().reverse()`.
+ * @fileoverview Transform ES2023 `Array.prototype.toReversed()` to `Array.prototype.slice().reverse()`.
  * AST: https://astexplorer.net/
  */
 
@@ -14,7 +14,7 @@ import { types as t } from '@babel/core';
 // --------------------------------------------------------------------------------
 
 /**
- * Transform ES2023 `array.prototype.toReversed()` to `array.prototype.slice().reverse()`.
+ * Transform ES2023 `Array.prototype.toReversed()` to `Array.prototype.slice().reverse()`.
  *
  * Compatibility: ES3
  * - `slice()`: ES3

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.js
@@ -51,3 +51,5 @@ export default function transformArrayPrototypeToReversed() {
     },
   };
 }
+
+// TODO: Add computed property support

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js
@@ -51,3 +51,5 @@ export default function transformArrayPrototypeToSorted() {
     },
   };
 }
+
+// TODO: Add computed property support

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Transform ES2023 `array.prototype.toSorted(compareFn)` to `array.prototype.slice().sort(compareFn)`.
+ * @fileoverview Transform ES2023 `Array.prototype.toSorted(compareFn)` to `Array.prototype.slice().sort(compareFn)`.
  * AST: https://astexplorer.net/
  */
 
@@ -14,7 +14,7 @@ import { types as t } from '@babel/core';
 // --------------------------------------------------------------------------------
 
 /**
- * Transform ES2023 `array.prototype.toSorted(compareFn)` to `array.prototype.slice().sort(compareFn)`.
+ * Transform ES2023 `Array.prototype.toSorted(compareFn)` to `Array.prototype.slice().sort(compareFn)`.
  *
  * Compatibility: ES3
  * - `slice()`: ES3

--- a/packages/bananass/src/babel-plugins/transform-object-has-own/index.js
+++ b/packages/bananass/src/babel-plugins/transform-object-has-own/index.js
@@ -1,0 +1,3 @@
+import transformObjectHasOwn from './transform-object-has-own.js';
+
+export default transformObjectHasOwn;

--- a/packages/bananass/src/babel-plugins/transform-object-has-own/transform-object-has-own.js
+++ b/packages/bananass/src/babel-plugins/transform-object-has-own/transform-object-has-own.js
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Transform ES2022 `Object.hasOwn(obj, prop)` to `Object.prototype.hasOwnProperty.call(obj, prop)`.
+ * AST: https://astexplorer.net/
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { types as t } from '@babel/core';
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Transform ES2022 `Object.hasOwn(obj, prop)` to `Object.prototype.hasOwnProperty.call(obj, prop)`.
+ *
+ * Compatibility: ES1
+ *
+ * @return {import("@babel/core").PluginObj}
+ */
+export default function transformObjectHasOwn() {
+  return {
+    name: 'transform-object-has-own',
+
+    visitor: {
+      CallExpression(path) {
+        const { node } = path;
+
+        if (
+          t.isMemberExpression(node.callee) &&
+          t.isIdentifier(node.callee.object, { name: 'Object' }) &&
+          (node.callee.computed
+            ? // bracket form: `Object['hasOwn']`
+              t.isStringLiteral(node.callee.property, { value: 'hasOwn' })
+            : // dot form: `Object.hasOwn`
+              t.isIdentifier(node.callee.property, { name: 'hasOwn' })) &&
+          node.arguments.length === 2
+        ) {
+          const [objArg, propArg] = node.arguments;
+
+          const replacement = t.callExpression(
+            t.memberExpression(
+              t.memberExpression(
+                t.memberExpression(t.identifier('Object'), t.identifier('prototype')),
+                t.identifier('hasOwnProperty'),
+              ),
+              t.identifier('call'),
+            ),
+            [objArg, propArg],
+          );
+
+          path.replaceWith(replacement);
+        }
+      },
+    },
+  };
+}

--- a/packages/bananass/src/babel-plugins/transform-object-has-own/transform-object-has-own.test.js
+++ b/packages/bananass/src/babel-plugins/transform-object-has-own/transform-object-has-own.test.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Test for `transform-object-has-own.js`.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { transformSync } from '@babel/core';
+
+import transformObjectHasOwn from './transform-object-has-own.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const options = {
+  plugins: [transformObjectHasOwn],
+};
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('transform-object-has-own.js', () => {
+  it('should transform dot form `Object.hasOwn(obj, prop)`', () => {
+    const code = 'Object.hasOwn(obj, prop);';
+    const transformedCode = transformSync(code, options).code;
+    const expected = 'Object.prototype.hasOwnProperty.call(obj, prop);';
+
+    strictEqual(transformedCode, expected);
+  });
+
+  it('should transform bracket form `Object["hasOwn"](obj, prop)`', () => {
+    const code = 'Object["hasOwn"](obj, prop);';
+    const transformedCode = transformSync(code, options).code;
+    const expected = 'Object.prototype.hasOwnProperty.call(obj, prop);';
+
+    strictEqual(transformedCode, expected);
+  });
+
+  it('should transform chained calls', () => {
+    const code = 'Object.hasOwn(obj, prop).toString();';
+    const transformedCode = transformSync(code, options).code;
+    const expected = 'Object.prototype.hasOwnProperty.call(obj, prop).toString();';
+
+    strictEqual(transformedCode, expected);
+  });
+
+  it('should not transform when argument count is not 2', () => {
+    const oneArg = 'Object.hasOwn(obj);';
+    strictEqual(transformSync(oneArg, options).code, oneArg);
+
+    const threeArgs = 'Object.hasOwn(a, b, c);';
+    strictEqual(transformSync(threeArgs, options).code, threeArgs);
+  });
+
+  it('should not touch other Object methods', () => {
+    const code = 'Object.keys(obj);';
+    const transformedCode = transformSync(code, options).code;
+
+    strictEqual(transformedCode, code);
+  });
+
+  it('should not transform non-Object calls named hasOwn', () => {
+    const code = 'foo.hasOwn(obj, prop);';
+    const transformedCode = transformSync(code, options).code;
+
+    strictEqual(transformedCode, code);
+  });
+});

--- a/packages/bananass/src/commands/bananass-build/build.js
+++ b/packages/bananass/src/commands/bananass-build/build.js
@@ -18,6 +18,7 @@ import webpack from 'webpack';
 import {
   transformArrayPrototypeToReversed,
   transformArrayPrototypeToSorted,
+  transformObjectHasOwn,
 } from '../../babel-plugins/index.js';
 
 import { defaultConfigObject as dco } from '../../core/conf/index.js';
@@ -155,6 +156,7 @@ export default async function build(problems, configObject = dco) {
                 plugins: [
                   transformArrayPrototypeToReversed,
                   transformArrayPrototypeToSorted,
+                  transformObjectHasOwn,
                 ],
               },
             },

--- a/tests/e2e/bananass-build/cjs.test.js
+++ b/tests/e2e/bananass-build/cjs.test.js
@@ -372,6 +372,20 @@ describe('cjs', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      it('Custom `transform-object-has-own` plugin should be applied correctly', async () => {
+        await build(['3003'], configObjectFS);
+
+        const outFile = resolve(outDir, '3003.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('Object.hasOwn'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
     });
 
     describe('`rl`(readline) template', () => {
@@ -414,6 +428,20 @@ describe('cjs', () => {
 
         const fileContent = readFileSync(outFile, 'utf-8');
         strictEqual(fileContent.includes('toReversed()'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-object-has-own` plugin should be applied correctly', async () => {
+        await build(['3003'], configObjectRL);
+
+        const outFile = resolve(outDir, '3003.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('Object.hasOwn'), false);
 
         const result = runOutFile(outFile, '1 2');
         strictEqual(result.status, 0);

--- a/tests/e2e/bananass-build/fixtures/cjs/bananass/3003.js
+++ b/tests/e2e/bananass-build/fixtures/cjs/bananass/3003.js
@@ -1,0 +1,12 @@
+function solution(input) {
+  const obj = { prop: 1 };
+
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return Object.hasOwn(obj, 'prop') ? a + b : a - b;
+}
+
+module.exports = { solution };

--- a/tests/e2e/bananass-build/fixtures/mjs/bananass/3003.js
+++ b/tests/e2e/bananass-build/fixtures/mjs/bananass/3003.js
@@ -1,0 +1,12 @@
+function solution(input) {
+  const obj = { prop: 1 };
+
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return Object.hasOwn(obj, 'prop') ? a + b : a - b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/mjs.test.js
+++ b/tests/e2e/bananass-build/mjs.test.js
@@ -372,6 +372,20 @@ describe('mjs', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      it('Custom `transform-object-has-own` plugin should be applied correctly', async () => {
+        await build(['3003'], configObjectFS);
+
+        const outFile = resolve(outDir, '3003.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('Object.hasOwn'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
     });
 
     describe('`rl`(readline) template', () => {
@@ -414,6 +428,20 @@ describe('mjs', () => {
 
         const fileContent = readFileSync(outFile, 'utf-8');
         strictEqual(fileContent.includes('toReversed()'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-object-has-own` plugin should be applied correctly', async () => {
+        await build(['3003'], configObjectRL);
+
+        const outFile = resolve(outDir, '3003.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('Object.hasOwn'), false);
 
         const result = runOutFile(outFile, '1 2');
         strictEqual(result.status, 0);


### PR DESCRIPTION
This pull request introduces a new Babel plugin, `transform-object-has-own`, to transform `Object.hasOwn(obj, prop)` into `Object.prototype.hasOwnProperty.call(obj, prop)`. It also includes updates to two existing plugins for `Array.prototype.toReversed` and `Array.prototype.toSorted`, along with corresponding tests and integration into the build process.

### New Plugin: `transform-object-has-own`

* Added a new Babel plugin `transform-object-has-own` to transform `Object.hasOwn(obj, prop)` into `Object.prototype.hasOwnProperty.call(obj, prop)` for ES2022 compatibility. Includes support for both dot and bracket notation. (`packages/bananass/src/babel-plugins/transform-object-has-own/transform-object-has-own.js`, [packages/bananass/src/babel-plugins/transform-object-has-own/transform-object-has-own.jsR1-R59](diffhunk://#diff-087c9a30e3bd240c7da5d6b6cc464110635bede242e8e8dee274e584eb13bbbeR1-R59))
* Added unit tests for `transform-object-has-own`, covering various cases such as valid transformations, incorrect argument counts, and non-Object calls. (`packages/bananass/src/babel-plugins/transform-object-has-own/transform-object-has-own.test.js`, [packages/bananass/src/babel-plugins/transform-object-has-own/transform-object-has-own.test.jsR1-R74](diffhunk://#diff-7a0fa052b72fe4d51bc9f26ba00ed6de583e4210616fce45f50e946ae2f3c15aR1-R74))

### Updates to Existing Plugins

* Corrected documentation for `transform-array-prototype-to-reversed` and `transform-array-prototype-to-sorted` to use proper capitalization for `Array.prototype` methods. (`packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.js`, [[1]](diffhunk://#diff-b463a2ad23181771ae5aa133821dc0cc5ae733374389abec1f667e32ee36b12cL2-R2) [[2]](diffhunk://#diff-b463a2ad23181771ae5aa133821dc0cc5ae733374389abec1f667e32ee36b12cL17-R17); `packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js`, [[3]](diffhunk://#diff-79ce84a8b35194ebf6fa4375aa1689168340392505ffd42237f665843bad43fdL2-R2) [[4]](diffhunk://#diff-79ce84a8b35194ebf6fa4375aa1689168340392505ffd42237f665843bad43fdL17-R17)
* Added TODO comments in both plugins to note the lack of support for computed properties. (`packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.js`, [[1]](diffhunk://#diff-b463a2ad23181771ae5aa133821dc0cc5ae733374389abec1f667e32ee36b12cR54-R55); `packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js`, [[2]](diffhunk://#diff-79ce84a8b35194ebf6fa4375aa1689168340392505ffd42237f665843bad43fdR54-R55)

### Build Process Integration

* Integrated `transform-object-has-own` into the Babel plugins used in the `bananass-build` command. (`packages/bananass/src/commands/bananass-build/build.js`, [[1]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4R21) [[2]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4R159)

### End-to-End Testing

* Added E2E tests for the `transform-object-has-own` plugin in both CommonJS and ES modules builds to verify proper application of the transformation. (`tests/e2e/bananass-build/cjs.test.js`, [[1]](diffhunk://#diff-3dd374fa0ef90c526843be817203fe90f0c59d84a194e80f47d8ba423739649aR375-R388) [[2]](diffhunk://#diff-3dd374fa0ef90c526843be817203fe90f0c59d84a194e80f47d8ba423739649aR436-R449); `tests/e2e/bananass-build/mjs.test.js`, [[3]](diffhunk://#diff-f65bc9379932f9437f660b6db68ad3e824de82e2988316171a6aa664e1f4a176R375-R388) [[4]](diffhunk://#diff-f65bc9379932f9437f660b6db68ad3e824de82e2988316171a6aa664e1f4a176R436-R449)
* Included fixtures for testing the `transform-object-has-own` plugin in both CJS and MJS formats. (`tests/e2e/bananass-build/fixtures/cjs/bananass/3003.js`, [[1]](diffhunk://#diff-e9a14f65195ffe8a4c2400cd669ee50b223563f631771fce353be9c547abaa67R1-R12); `tests/e2e/bananass-build/fixtures/mjs/bananass/3003.js`, [[2]](diffhunk://#diff-9464f60cf820888f4b500147033be5a0cd1aed440e98a1b2a1532a0e80ea881bR1-R12)