### PR TITLE
feat(bananass): add support computed bracket form for `toSorted` and `toReversed`

### DIFF
--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.js
@@ -32,7 +32,11 @@ export default function transformArrayPrototypeToReversed() {
 
         if (
           t.isMemberExpression(node.callee) &&
-          t.isIdentifier(node.callee.property, { name: 'toReversed' }) &&
+          (node.callee.computed
+            ? // bracket form: `arr['toReversed']`
+              t.isStringLiteral(node.callee.property, { value: 'toReversed' })
+            : // dot form: `arr.toReversed`
+              t.isIdentifier(node.callee.property, { name: 'toReversed' })) &&
           node.arguments.length === 0
         ) {
           const arr = node.callee.object;
@@ -51,5 +55,3 @@ export default function transformArrayPrototypeToReversed() {
     },
   };
 }
-
-// TODO: Add computed property support

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.test.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-reversed/transform-array-prototype-to-reversed.test.js
@@ -26,8 +26,16 @@ const options = {
 // --------------------------------------------------------------------------------
 
 describe('transform-array-prototype-to-reversed.js', () => {
-  it('should transform `arr.toReversed()` to `arr.slice().reverse()`', () => {
+  it('should transform dot form `arr.toReversed()` to `arr.slice().reverse()`', () => {
     const code = '[1, 2, 3].toReversed();';
+    const transformedCode = transformSync(code, options).code;
+    const expected = '[1, 2, 3].slice().reverse();';
+
+    strictEqual(transformedCode, expected);
+  });
+
+  it('should transform bracket form `arr["toReversed"]()` to `arr.slice().reverse()`', () => {
+    const code = '[1, 2, 3]["toReversed"]();';
     const transformedCode = transformSync(code, options).code;
     const expected = '[1, 2, 3].slice().reverse();';
 

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.js
@@ -32,7 +32,11 @@ export default function transformArrayPrototypeToSorted() {
 
         if (
           t.isMemberExpression(node.callee) &&
-          t.isIdentifier(node.callee.property, { name: 'toSorted' }) &&
+          (node.callee.computed
+            ? // bracket form: `arr['toSorted']`
+              t.isStringLiteral(node.callee.property, { value: 'toSorted' })
+            : // dot form: `arr.toSorted`
+              t.isIdentifier(node.callee.property, { name: 'toSorted' })) &&
           node.arguments.length <= 1
         ) {
           const arr = node.callee.object;
@@ -51,5 +55,3 @@ export default function transformArrayPrototypeToSorted() {
     },
   };
 }
-
-// TODO: Add computed property support

--- a/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.test.js
+++ b/packages/bananass/src/babel-plugins/transform-array-prototype-to-sorted/transform-array-prototype-to-sorted.test.js
@@ -26,8 +26,16 @@ const options = {
 // --------------------------------------------------------------------------------
 
 describe('transform-array-prototype-to-sorted.js', () => {
-  it('should transform `arr.toSorted()` to `arr.slice().sort()`', () => {
+  it('should transform dot form `arr.toSorted()` to `arr.slice().sort()`', () => {
     const code = '[1, 2, 3].toSorted();';
+    const transformedCode = transformSync(code, options).code;
+    const expected = '[1, 2, 3].slice().sort();';
+
+    strictEqual(transformedCode, expected);
+  });
+
+  it('should transform bracket form `arr["toSorted"]()` to `arr.slice().sort()`', () => {
+    const code = '[1, 2, 3]["toSorted"]();';
     const transformedCode = transformSync(code, options).code;
     const expected = '[1, 2, 3].slice().sort();';
 


### PR DESCRIPTION
This pull request enhances the Babel plugins `transform-array-prototype-to-reversed` and `transform-array-prototype-to-sorted` to support both dot notation (`arr.toReversed()` / `arr.toSorted()`) and bracket notation (`arr["toReversed"]()` / `arr["toSorted"]()`). It also updates the corresponding test files to verify the new functionality.

### Updates to Babel plugins:

* [`transform-array-prototype-to-reversed.js`](diffhunk://#diff-b463a2ad23181771ae5aa133821dc0cc5ae733374389abec1f667e32ee36b12cL35-R39): Added support for computed properties (e.g., bracket notation) when transforming `toReversed` calls. Removed the outdated TODO comment about adding computed property support. [[1]](diffhunk://#diff-b463a2ad23181771ae5aa133821dc0cc5ae733374389abec1f667e32ee36b12cL35-R39) [[2]](diffhunk://#diff-b463a2ad23181771ae5aa133821dc0cc5ae733374389abec1f667e32ee36b12cL54-L55)
* [`transform-array-prototype-to-sorted.js`](diffhunk://#diff-79ce84a8b35194ebf6fa4375aa1689168340392505ffd42237f665843bad43fdL35-R39): Added support for computed properties (e.g., bracket notation) when transforming `toSorted` calls. Removed the outdated TODO comment about adding computed property support. [[1]](diffhunk://#diff-79ce84a8b35194ebf6fa4375aa1689168340392505ffd42237f665843bad43fdL35-R39) [[2]](diffhunk://#diff-79ce84a8b35194ebf6fa4375aa1689168340392505ffd42237f665843bad43fdL54-L55)

### Updates to test files:

* [`transform-array-prototype-to-reversed.test.js`](diffhunk://#diff-e01a5cb911518d2c155e2aaa3d6f71eeec93540760423f03323290dc378c8142L29-R44): Added a test case to validate the transformation of bracket notation `arr["toReversed"]()` to `arr.slice().reverse()`. Updated the description of the existing test case for dot notation to clarify its scope.
* [`transform-array-prototype-to-sorted.test.js`](diffhunk://#diff-4bd884ab58c0e2da1e86552e1bd4fc25305b80a8480051332d34db6f13cef542L29-R44): Added a test case to validate the transformation of bracket notation `arr["toSorted"]()` to `arr.slice().sort()`. Updated the description of the existing test case for dot notation to clarify its scope.