### PR TITLE
test(*): create integration tests for package json `engines.node` field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19844,6 +19844,10 @@
       "resolved": "tests/e2e",
       "link": true
     },
+    "node_modules/tests-integration": {
+      "resolved": "tests/integration",
+      "link": true
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -22516,6 +22520,15 @@
       "version": "0.1.0-canary.2",
       "devDependencies": {
         "bananass": "^0.1.0-canary.2"
+      }
+    },
+    "tests/integration": {
+      "name": "tests-integration",
+      "version": "0.1.0-canary.2",
+      "devDependencies": {
+        "bananass": "^0.1.0-canary.2",
+        "bananass-utils-console": "^0.1.0-canary.2",
+        "create-bananass": "^0.1.0-canary.2"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:pkg:ecb": "npm run test -w packages/eslint-config-bananass",
     "test:pkg:pcb": "npm run test -w packages/prettier-config-bananass",
     "test:t:e2e": "npm run test -w tests/e2e",
+    "test:t:i": "npm run test -w tests/integration",
     "build": "npx lerna run build --ignore npm-bananass",
     "build:ex:sb-cjs": "npm run bananass:build -w examples/solutions-bananass-cjs",
     "build:ex:sb-cts": "npm run bananass:build -w examples/solutions-bananass-cts",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -73,7 +73,7 @@
     "url": "https://github.com/lumirlumir/npm-bananass/issues"
   },
   "engines": {
-    "node": ">=20.18.0"
+    "node": "^20.18.0 || >= 22.3.0"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/bananass-utils-vitepress/package.json
+++ b/packages/bananass-utils-vitepress/package.json
@@ -54,9 +54,6 @@
   "bugs": {
     "url": "https://github.com/lumirlumir/npm-bananass/issues"
   },
-  "engines": {
-    "node": ">=20.18.0"
-  },
   "publishConfig": {
     "provenance": true
   },

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0-canary.2",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript.🍌",
+  "exports": {
+    "./package.json": "./package.json",
+    "./templates/javascript/package.json": "./templates/javascript/package.json",
+    "./templates/typescript/package.json": "./templates/typescript/package.json"
+  },
   "bin": {
     "create-bananass": "src/cli.js"
   },

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/lumirlumir/npm-bananass/issues"
   },
   "engines": {
-    "node": ">=20.18.0"
+    "node": "^20.18.0 || >= 22.3.0"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/create-bananass/templates/javascript/package.json
+++ b/packages/create-bananass/templates/javascript/package.json
@@ -3,7 +3,7 @@
   "name": "create-bananass-javascript",
   "version": "0.1.0-canary.2",
   "engines": {
-    "node": ">=20.18.0"
+    "node": "^20.18.0 || >= 22.3.0"
   },
   "scripts": {
     "build": "echo build"

--- a/packages/create-bananass/templates/typescript/package.json
+++ b/packages/create-bananass/templates/typescript/package.json
@@ -3,7 +3,7 @@
   "name": "create-bananass-typescript",
   "version": "0.1.0-canary.2",
   "engines": {
-    "node": ">=20.18.0"
+    "node": "^20.18.0 || >= 22.3.0"
   },
   "scripts": {
     "build": "echo build"

--- a/tests/integration/package-json.test.js
+++ b/tests/integration/package-json.test.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Test for `package.json` across the project.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { createRequire } from 'node:module';
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+
+const npmBananass = createRequire(import.meta.url)('../../package.json');
+const bananass = createRequire(import.meta.url)('bananass/package.json');
+const bananassUtilsConsole = createRequire(import.meta.url)(
+  'bananass-utils-console/package.json',
+);
+const createBananass = createRequire(import.meta.url)('create-bananass/package.json');
+const createBananassJS = createRequire(import.meta.url)(
+  'create-bananass/templates/javascript/package.json',
+);
+const createBananassTS = createRequire(import.meta.url)(
+  'create-bananass/templates/typescript/package.json',
+);
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('package-json', () => {
+  it('should have the same `engines.node` version', () => {
+    strictEqual(
+      new Set([
+        npmBananass.engines.node,
+        bananass.engines.node,
+        bananassUtilsConsole.engines.node,
+        createBananass.engines.node,
+        createBananassJS.engines.node,
+        createBananassTS.engines.node,
+      ]).size,
+      1,
+    );
+  });
+});

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "tests-integration",
+  "version": "0.1.0-canary.2",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "bananass": "^0.1.0-canary.2",
+    "bananass-utils-console": "^0.1.0-canary.2",
+    "create-bananass": "^0.1.0-canary.2"
+  }
+}


### PR DESCRIPTION
This pull request introduces several changes to the `npm-bananass` project, focusing on adding integration tests, updating Node.js engine requirements, and improving package exports. Below is a summary of the most important updates:

### Integration Testing
* Added a new integration test suite (`tests/integration`) to ensure consistency in `engines.node` versions across `package.json` files. This includes a test file (`tests/integration/package-json.test.js`) and a corresponding `package.json` configuration for the test suite. [[1]](diffhunk://#diff-6087f8ce19f5cb0a5122609a76f2f2b16db3cc86c5b4c949032ea9b47943bccbR1-R44) [[2]](diffhunk://#diff-c00d3342bd6ea1035b41a632bc4aa66fb142773d3ad70d34586e29976cd0f884R1-R14)

### Node.js Engine Updates
* Updated the `engines.node` field in various `package.json` files to support Node.js versions `^20.18.0` or `>=22.3.0`, ensuring compatibility with newer Node.js versions:
  - `packages/bananass-utils-console/package.json`
  - `packages/create-bananass/package.json`
  - `packages/create-bananass/templates/javascript/package.json`
  - `packages/create-bananass/templates/typescript/package.json`

### Package Exports
* Added explicit `exports` mappings in `packages/create-bananass/package.json` to expose specific files, including `package.json` files for JavaScript and TypeScript templates.

### Test Script Additions
* Introduced a new script (`test:t:i`) in the root `package.json` to run integration tests.