### PR TITLE
fix(bananass): drop esbuild-loader and create e2e tests for bananass build with mts module system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -637,17 +637,17 @@
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
-      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
+      "integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
-        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
+        "@babel/traverse": "^7.27.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -790,14 +790,14 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+      "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/traverse": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1015,6 +1015,36 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
       "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1775,6 +1805,25 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.0.tgz",
+      "integrity": "sha512-fRGGjO2UEGPjvEcyAZXRXAS8AfdaQoq7HnxAbJoAoW10B9xOKesmmndJv+Sym2a+9FHWZ9KbyyLCe9s0Sn5jtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.27.0",
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/plugin-syntax-typescript": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
@@ -1942,6 +1991,25 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.0.tgz",
+      "integrity": "sha512-vxaPFfJtHhgeOVXRKuHpHPAOgymmy8V8I65T1q53R7GCZlefKeCaTyDs3zOPHTTbmquvNlQYC5klEvWsBAtrBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.26.3",
+        "@babel/plugin-transform-typescript": "^7.27.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -22307,6 +22375,7 @@
       "dependencies": {
         "@babel/core": "^7.26.10",
         "@babel/preset-env": "^7.26.9",
+        "@babel/preset-typescript": "^7.27.0",
         "babel-loader": "^10.0.0",
         "bananass-utils-console": "^0.1.0-canary.2",
         "c12": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2244,6 +2244,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2260,6 +2261,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2276,6 +2278,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2292,6 +2295,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,6 +2312,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2324,6 +2329,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2340,6 +2346,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,6 +2363,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2372,6 +2380,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2388,6 +2397,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2404,6 +2414,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2420,6 +2431,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2436,6 +2448,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2452,6 +2465,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2468,6 +2482,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2484,6 +2499,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,6 +2516,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2516,6 +2533,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2532,6 +2550,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2548,6 +2567,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2564,6 +2584,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2580,6 +2601,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2596,6 +2618,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2612,6 +2635,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2628,6 +2652,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7061,15 +7086,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/bin-links": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-4.0.4.tgz",
@@ -9119,15 +9135,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -9455,6 +9462,7 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
       "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9489,34 +9497,6 @@
         "@esbuild/win32-arm64": "0.25.0",
         "@esbuild/win32-ia32": "0.25.0",
         "@esbuild/win32-x64": "0.25.0"
-      }
-    },
-    "node_modules/esbuild-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esbuild-loader/-/esbuild-loader-4.3.0.tgz",
-      "integrity": "sha512-D7HeJNdkDKKMarPQO/3dlJT6RwN2YJO7ENU6RPlpOz5YxSHnUNi2yvW41Bckvi1EVwctIaLzlb0ni5ag2GINYA==",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "get-tsconfig": "^4.7.0",
-        "loader-utils": "^2.0.4",
-        "webpack-sources": "^1.4.3"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/esbuild-loader?sponsor=1"
-      },
-      "peerDependencies": {
-        "webpack": "^4.40.0 || ^5.0.0"
-      }
-    },
-    "node_modules/esbuild-loader/node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/escalade": {
@@ -13695,20 +13675,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
-      }
-    },
-    "node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/local-pkg": {
@@ -19194,12 +19160,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/source-list-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-      "license": "MIT"
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -22383,7 +22343,6 @@
         "commander": "^13.1.0",
         "enhanced-resolve": "^5.18.1",
         "envinfo": "^7.14.0",
-        "esbuild-loader": "^4.3.0",
         "jiti": "^2.4.2",
         "open": "^10.1.1",
         "superstruct": "^2.0.2",

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -101,7 +101,6 @@
     "commander": "^13.1.0",
     "enhanced-resolve": "^5.18.1",
     "envinfo": "^7.14.0",
-    "esbuild-loader": "^4.3.0",
     "jiti": "^2.4.2",
     "open": "^10.1.1",
     "superstruct": "^2.0.2",

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -93,6 +93,7 @@
   "dependencies": {
     "@babel/core": "^7.26.10",
     "@babel/preset-env": "^7.26.9",
+    "@babel/preset-typescript": "^7.27.0",
     "babel-loader": "^10.0.0",
     "bananass-utils-console": "^0.1.0-canary.2",
     "c12": "^3.0.3",

--- a/packages/bananass/src/commands/bananass-build/build.js
+++ b/packages/bananass/src/commands/bananass-build/build.js
@@ -139,7 +139,7 @@ export default async function build(problems, configObject = dco) {
         module: {
           rules: [
             {
-              test: /\.(?:js|mjs|cjs)$/i, // JavaScript
+              test: /\.(?:js|mjs|cjs|ts|mts|cts)$/i, // JavaScript and TypeScript.
               loader: 'babel-loader',
               options: {
                 targets: { node: '16.13' }, // TODO: Move Baekjoon Node.js version to constants.
@@ -152,21 +152,18 @@ export default async function build(problems, configObject = dco) {
                       targets: { node: '16.13' },
                     },
                   ],
+                  [
+                    '@babel/preset-typescript',
+                    {
+                      allowDeclareFields: true,
+                    },
+                  ],
                 ],
                 plugins: [
                   transformArrayPrototypeToReversed,
                   transformArrayPrototypeToSorted,
                   transformObjectHasOwn,
                 ],
-              },
-            },
-            {
-              test: /\.(?:ts|mts|cts)$/i, // TypeScript
-              loader: 'esbuild-loader',
-              options: {
-                loader: 'ts',
-                target: 'node14',
-                format: 'cjs',
               },
             },
           ],

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/1000.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/1000.ts
@@ -1,0 +1,23 @@
+import { Testcase, Input, Output } from '../types';
+
+const testcases: Testcase[] = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];
+
+function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+export default globalThis.IS_PROD ? { solution } : { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/1001.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/1001.ts
@@ -1,0 +1,12 @@
+import { Input, Output } from '../types';
+
+function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/1002.cts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/1002.cts
@@ -1,0 +1,12 @@
+import type { Input, Output } from '../types.d.ts';
+
+function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+module.exports = { solution };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/1003.mts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/1003.mts
@@ -1,0 +1,12 @@
+import { Input, Output } from '../types';
+
+function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/1004.mts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/1004.mts
@@ -1,0 +1,21 @@
+import { Testcase, Input, Output } from '../types';
+
+export function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+export const testcases = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+] satisfies Testcase[];

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/1005.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/1005.ts
@@ -1,0 +1,22 @@
+import add from '../utils/add';
+import { Testcase, Input, Output } from '../types';
+
+export const testcases: Testcase[] = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+];
+
+export function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return add(a, b);
+}

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2000/index.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2000/index.ts
@@ -1,0 +1,4 @@
+import solution from './solution';
+import testcases from './testcases';
+
+export default { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2000/solution.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2000/solution.ts
@@ -1,0 +1,10 @@
+import type { Input, Output } from '../../types.d.ts';
+
+export default function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2000/testcases.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2000/testcases.ts
@@ -1,0 +1,12 @@
+import type { Testcase } from '../../types.d.ts';
+
+export default [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+] satisfies Testcase[];

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2001/index.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2001/index.ts
@@ -1,0 +1,3 @@
+import solution from './solution.ts';
+
+export default { solution };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2001/solution.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2001/solution.ts
@@ -1,0 +1,10 @@
+import type { Input, Output } from '../../types.d.ts';
+
+export default function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2002/index.cts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2002/index.cts
@@ -1,0 +1,4 @@
+const solution = require('./solution');
+const testcases = require('./testcases');
+
+module.exports = { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2002/solution.cts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2002/solution.cts
@@ -1,0 +1,12 @@
+import type { Input, Output } from '../../types.d.ts';
+
+function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}
+
+module.exports = solution;

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2002/testcases.cts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2002/testcases.cts
@@ -1,0 +1,12 @@
+import type { Testcase } from '../../types.d.ts';
+
+module.exports = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+] as Testcase[];

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2003/index.mts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2003/index.mts
@@ -1,0 +1,4 @@
+import solution from './solution.mts';
+import testcases from './testcases.mts';
+
+export default { solution, testcases };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2003/solution.mts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2003/solution.mts
@@ -1,0 +1,10 @@
+import type { Input, Output } from '../../types';
+
+export default function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2003/testcases.mts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2003/testcases.mts
@@ -1,0 +1,12 @@
+import type { Testcase } from '../../types';
+
+export default [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+] satisfies Testcase[];

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2004/index.mts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2004/index.mts
@@ -1,0 +1,2 @@
+export { solution } from './solution.mts';
+export { testcases } from './testcases.mts';

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2004/solution.mts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2004/solution.mts
@@ -1,0 +1,12 @@
+/* eslint-disable import/prefer-default-export */
+
+import type { Input, Output } from '../../types';
+
+export function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return a + b;
+}

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2004/testcases.mts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2004/testcases.mts
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+
+import type { Testcase } from '../../types';
+
+export const testcases = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+] satisfies Testcase[];

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2005/index.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2005/index.ts
@@ -1,0 +1,2 @@
+export * from './solution';
+export * from './testcases';

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2005/solution.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2005/solution.ts
@@ -1,0 +1,13 @@
+/* eslint-disable import/prefer-default-export */
+
+import add from '../../utils/add';
+import type { Input, Output } from '../../types';
+
+export function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return add(a, b);
+}

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/2005/testcases.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/2005/testcases.ts
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+
+import type { Testcase } from '../../types';
+
+export const testcases = [
+  {
+    input: '1 2',
+    output: '3',
+  },
+  {
+    input: '3 4',
+    output: '7',
+  },
+] satisfies Testcase[];

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/3000.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/3000.ts
@@ -1,0 +1,14 @@
+import type { Input, Output } from '../types';
+
+function solution(input: Input): Output {
+  const test = /(?i:a)a/.test('aa');
+
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return test ? a + b : a + b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/3001.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/3001.ts
@@ -1,0 +1,14 @@
+import type { Input, Output } from '../types';
+
+function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val))
+    // @ts-expect-error -- Needed to test
+    .toSorted();
+
+  return a + b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/3002.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/3002.ts
@@ -1,0 +1,14 @@
+import type { Input, Output } from '../types';
+
+function solution(input: Input): Output {
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val))
+    // @ts-expect-error -- Needed to test
+    .toReversed();
+
+  return a + b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/fixtures/mts/bananass/3003.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/bananass/3003.ts
@@ -1,0 +1,14 @@
+import type { Input, Output } from '../types';
+
+function solution(input: Input): Output {
+  const obj = { prop: 1 };
+
+  const [a, b] = input
+    .trim()
+    .split(' ')
+    .map(val => Number(val));
+
+  return Object.hasOwn(obj, 'prop') ? a + b : a - b;
+}
+
+export default { solution };

--- a/tests/e2e/bananass-build/fixtures/mts/types.d.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/types.d.ts
@@ -1,0 +1,8 @@
+export type Input = string;
+
+export type Output = string | number | boolean;
+
+export interface Testcase {
+  input: Input;
+  output: Output;
+}

--- a/tests/e2e/bananass-build/fixtures/mts/utils/add.ts
+++ b/tests/e2e/bananass-build/fixtures/mts/utils/add.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number) {
+  return a + b;
+}

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -212,9 +212,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`directory/index.cjs` should build correctly', async () => {
+      it('`directory/index.cts` should build correctly', async () => {
         await build(['2002'], configObjectFS);
 
         const outFile = resolve(outDir, '2002.cjs');
@@ -224,6 +222,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`directory/index.mjs` with `export default` should build correctly', async () => {
         await build(['2003'], configObjectFS);
@@ -284,9 +284,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`directory/index.cjs` should build correctly', async () => {
+      it('`directory/index.cts` should build correctly', async () => {
         await build(['2002'], configObjectRL);
 
         const outFile = resolve(outDir, '2002.cjs');
@@ -296,6 +294,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`directory/index.mjs` with `export default` should build correctly', async () => {
         await build(['2003'], configObjectRL);

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -107,7 +107,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      it('User-created external modules using the `mjs` format should build correctly', async () => {
+      it('User-created external modules using the `mts` format should build correctly', async () => {
         await build(['1005'], configObjectFS);
 
         const outFile = resolve(outDir, '1005.cjs');
@@ -175,7 +175,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      it('User-created external modules using the `mjs` format should build correctly', async () => {
+      it('User-created external modules using the `mts` format should build correctly', async () => {
         await build(['1005'], configObjectRL);
 
         const outFile = resolve(outDir, '1005.cjs');
@@ -223,9 +223,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`directory/index.mjs` with `export default` should build correctly', async () => {
+      it('`directory/index.mts` with `export default` should build correctly', async () => {
         await build(['2003'], configObjectFS);
 
         const outFile = resolve(outDir, '2003.cjs');
@@ -235,6 +233,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`directory/index.mjs` with `export` should build correctly', async () => {
         await build(['2004'], configObjectFS);
@@ -295,9 +295,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`directory/index.mjs` with `export default` should build correctly', async () => {
+      it('`directory/index.mts` with `export default` should build correctly', async () => {
         await build(['2003'], configObjectRL);
 
         const outFile = resolve(outDir, '2003.cjs');
@@ -307,6 +305,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`directory/index.mjs` with `export` should build correctly', async () => {
         await build(['2004'], configObjectRL);

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -201,8 +201,6 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
       it('A solution directory with only `solution` should build correctly', async () => {
         await build(['2001'], configObjectFS);
 
@@ -213,6 +211,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`directory/index.cjs` should build correctly', async () => {
         await build(['2002'], configObjectFS);
@@ -273,8 +273,6 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
       it('A solution directory with only `solution` should build correctly', async () => {
         await build(['2001'], configObjectRL);
 
@@ -285,6 +283,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`directory/index.cjs` should build correctly', async () => {
         await build(['2002'], configObjectRL);

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -452,6 +452,8 @@ describe('mts', () => {
     });
   });
 
+  */
+
   describe('Multiple files', () => {
     it('Multiple files with `fs` template should build correctly', async () => {
       await build(['1000', '1001', '2000'], configObjectFS);
@@ -496,6 +498,4 @@ describe('mts', () => {
       strictEqual(result2000.stdout, '3');
     });
   });
-
-  */
 });

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -74,9 +74,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`file.cjs` should build correctly', async () => {
+      it('`file.cts` should build correctly', async () => {
         await build(['1002'], configObjectFS);
 
         const outFile = resolve(outDir, '1002.cjs');
@@ -86,6 +84,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`file.mjs` with `export default` should build correctly', async () => {
         await build(['1003'], configObjectFS);
@@ -146,9 +146,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`file.cjs` should build correctly', async () => {
+      it('`file.cts` should build correctly', async () => {
         await build(['1002'], configObjectRL);
 
         const outFile = resolve(outDir, '1002.cjs');
@@ -158,6 +156,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`file.mjs` with `export default` should build correctly', async () => {
         await build(['1003'], configObjectRL);

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -345,8 +345,6 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
       it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
         await build(['3001'], configObjectFS);
 
@@ -388,8 +386,6 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
-
-      */
     });
 
     describe('`rl`(readline) template', () => {
@@ -409,8 +405,6 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
-
-      /*
 
       it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
         await build(['3001'], configObjectRL);
@@ -453,8 +447,6 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
-
-      */
     });
   });
 

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -17,7 +17,7 @@ import { describe, it, afterEach } from 'node:test';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, rmSync, readFileSync } from 'node:fs';
 
 import { build } from 'bananass/commands';
 
@@ -326,8 +326,6 @@ describe('mts', () => {
     });
   });
 
-  /*
-
   describe('Latest ECMAScript features with `@babel/preset-env` and custom plugins should be transpiled correctly', () => {
     describe('`fs`(file system) template', () => {
       it('ES2025 `regexp-modifiers` should be transpiled correctly', async () => {
@@ -346,6 +344,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
         await build(['3001'], configObjectFS);
@@ -388,6 +388,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      */
     });
 
     describe('`rl`(readline) template', () => {
@@ -407,6 +409,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
         await build(['3001'], configObjectRL);
@@ -449,10 +453,10 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      */
     });
   });
-
-  */
 
   describe('Multiple files', () => {
     it('Multiple files with `fs` template should build correctly', async () => {

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -85,9 +85,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`file.mjs` with `export default` should build correctly', async () => {
+      it('`file.mts` with `export default` should build correctly', async () => {
         await build(['1003'], configObjectFS);
 
         const outFile = resolve(outDir, '1003.cjs');
@@ -97,6 +95,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`file.mjs` with `export` should build correctly', async () => {
         await build(['1004'], configObjectFS);
@@ -157,9 +157,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`file.mjs` with `export default` should build correctly', async () => {
+      it('`file.mts` with `export default` should build correctly', async () => {
         await build(['1003'], configObjectRL);
 
         const outFile = resolve(outDir, '1003.cjs');
@@ -169,6 +167,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`file.mjs` with `export` should build correctly', async () => {
         await build(['1004'], configObjectRL);

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -63,8 +63,6 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
       it('A single file with only `solution` should build correctly', async () => {
         await build(['1001'], configObjectFS);
 
@@ -75,6 +73,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`file.cjs` should build correctly', async () => {
         await build(['1002'], configObjectFS);
@@ -135,8 +135,6 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
       it('A single file with only `solution` should build correctly', async () => {
         await build(['1001'], configObjectRL);
 
@@ -147,6 +145,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('`file.cjs` should build correctly', async () => {
         await build(['1002'], configObjectRL);

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -188,8 +188,6 @@ describe('mts', () => {
     });
   });
 
-  /*
-
   describe('When the solution is in a single directory with multiple files', () => {
     describe('`fs`(file system) template', () => {
       it('A solution directory with `solution` and `testcases` should build correctly', async () => {
@@ -202,6 +200,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('A solution directory with only `solution` should build correctly', async () => {
         await build(['2001'], configObjectFS);
@@ -257,6 +257,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      */
     });
 
     describe('`rl`(readline) template', () => {
@@ -270,6 +272,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('A solution directory with only `solution` should build correctly', async () => {
         await build(['2001'], configObjectRL);
@@ -325,8 +329,12 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      */
     });
   });
+
+  /*
 
   describe('Latest ECMAScript features with `@babel/preset-env` and custom plugins should be transpiled correctly', () => {
     describe('`fs`(file system) template', () => {

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -245,9 +245,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('User-created external modules using the `mjs` format should build correctly.', async () => {
+      it('User-created external modules using the `mts` format should build correctly.', async () => {
         await build(['2005'], configObjectFS);
 
         const outFile = resolve(outDir, '2005.cjs');
@@ -257,8 +255,6 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
-
-      */
     });
 
     describe('`rl`(readline) template', () => {
@@ -317,9 +313,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('User-created external modules using the `mjs` format should build correctly.', async () => {
+      it('User-created external modules using the `mts` format should build correctly.', async () => {
         await build(['2005'], configObjectRL);
 
         const outFile = resolve(outDir, '2005.cjs');
@@ -329,8 +323,6 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
-
-      */
     });
   });
 

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -1,0 +1,509 @@
+/**
+ * @fileoverview E2E tests for building MTS solutions using Bananass.
+ *
+ * NOTE: None of the files in the `fixtures` directory are based on actual Baekjoon problems.
+ * They are simply A + B examples used for testing purposes.
+ */
+
+// TODO: Add tests for:
+// - External libraries: npm
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { ok, strictEqual } from 'node:assert';
+import { describe, it, afterEach } from 'node:test';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { existsSync, rmSync } from 'node:fs';
+
+import { build } from 'bananass/commands';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const cwd = resolve(import.meta.dirname, './fixtures/mts');
+const outDir = resolve(cwd, '.bananass');
+const configObjectFS = { cwd, console: { quiet: true }, build: { templateType: 'fs' } };
+const configObjectRL = { cwd, console: { quiet: true }, build: { templateType: 'rl' } };
+
+/** @param {string} outFile @param {string} input */
+function runOutFile(outFile, input) {
+  const { status, stdout } = spawnSync(process.execPath, [outFile], {
+    input,
+    encoding: 'utf-8',
+  });
+
+  return { status, stdout: stripAnsi(stdout).trim() };
+}
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+afterEach(() => {
+  // Clean up the output directory after each test
+  if (existsSync(outDir)) rmSync(outDir, { recursive: true, force: true });
+});
+
+describe('mts', () => {
+  describe('When the entire solution is in a single file', () => {
+    describe('`fs`(file system) template', () => {
+      it('A single file with `solution` and `testcases` should build correctly', async () => {
+        await build(['1000'], configObjectFS);
+
+        const outFile = resolve(outDir, '1000.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      /*
+
+      it('A single file with only `solution` should build correctly', async () => {
+        await build(['1001'], configObjectFS);
+
+        const outFile = resolve(outDir, '1001.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`file.cjs` should build correctly', async () => {
+        await build(['1002'], configObjectFS);
+
+        const outFile = resolve(outDir, '1002.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`file.mjs` with `export default` should build correctly', async () => {
+        await build(['1003'], configObjectFS);
+
+        const outFile = resolve(outDir, '1003.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`file.mjs` with `export` should build correctly', async () => {
+        await build(['1004'], configObjectFS);
+
+        const outFile = resolve(outDir, '1004.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      */
+
+      it('User-created external modules using the `mjs` format should build correctly', async () => {
+        await build(['1005'], configObjectFS);
+
+        const outFile = resolve(outDir, '1005.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+    });
+
+    describe('`rl`(readline) template', () => {
+      it('A single file with `solution` and `testcases` should build correctly', async () => {
+        await build(['1000'], configObjectRL);
+
+        const outFile = resolve(outDir, '1000.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      /*
+
+      it('A single file with only `solution` should build correctly', async () => {
+        await build(['1001'], configObjectRL);
+
+        const outFile = resolve(outDir, '1001.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`file.cjs` should build correctly', async () => {
+        await build(['1002'], configObjectRL);
+
+        const outFile = resolve(outDir, '1002.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`file.mjs` with `export default` should build correctly', async () => {
+        await build(['1003'], configObjectRL);
+
+        const outFile = resolve(outDir, '1003.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`file.mjs` with `export` should build correctly', async () => {
+        await build(['1004'], configObjectRL);
+
+        const outFile = resolve(outDir, '1004.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      */
+
+      it('User-created external modules using the `mjs` format should build correctly', async () => {
+        await build(['1005'], configObjectRL);
+
+        const outFile = resolve(outDir, '1005.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+    });
+  });
+
+  /*
+
+  describe('When the solution is in a single directory with multiple files', () => {
+    describe('`fs`(file system) template', () => {
+      it('A solution directory with `solution` and `testcases` should build correctly', async () => {
+        await build(['2000'], configObjectFS);
+
+        const outFile = resolve(outDir, '2000.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('A solution directory with only `solution` should build correctly', async () => {
+        await build(['2001'], configObjectFS);
+
+        const outFile = resolve(outDir, '2001.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`directory/index.cjs` should build correctly', async () => {
+        await build(['2002'], configObjectFS);
+
+        const outFile = resolve(outDir, '2002.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`directory/index.mjs` with `export default` should build correctly', async () => {
+        await build(['2003'], configObjectFS);
+
+        const outFile = resolve(outDir, '2003.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`directory/index.mjs` with `export` should build correctly', async () => {
+        await build(['2004'], configObjectFS);
+
+        const outFile = resolve(outDir, '2004.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('User-created external modules using the `mjs` format should build correctly.', async () => {
+        await build(['2005'], configObjectFS);
+
+        const outFile = resolve(outDir, '2005.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+    });
+
+    describe('`rl`(readline) template', () => {
+      it('A solution directory with `solution` and `testcases` should build correctly', async () => {
+        await build(['2000'], configObjectRL);
+
+        const outFile = resolve(outDir, '2000.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('A solution directory with only `solution` should build correctly', async () => {
+        await build(['2001'], configObjectRL);
+
+        const outFile = resolve(outDir, '2001.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`directory/index.cjs` should build correctly', async () => {
+        await build(['2002'], configObjectRL);
+
+        const outFile = resolve(outDir, '2002.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`directory/index.mjs` with `export default` should build correctly', async () => {
+        await build(['2003'], configObjectRL);
+
+        const outFile = resolve(outDir, '2003.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('`directory/index.mjs` with `export` should build correctly', async () => {
+        await build(['2004'], configObjectRL);
+
+        const outFile = resolve(outDir, '2004.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('User-created external modules using the `mjs` format should build correctly.', async () => {
+        await build(['2005'], configObjectRL);
+
+        const outFile = resolve(outDir, '2005.cjs');
+        const result = runOutFile(outFile, '1 2');
+
+        ok(existsSync(outFile));
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+    });
+  });
+
+  describe('Latest ECMAScript features with `@babel/preset-env` and custom plugins should be transpiled correctly', () => {
+    describe('`fs`(file system) template', () => {
+      it('ES2025 `regexp-modifiers` should be transpiled correctly', async () => {
+        // https://babeljs.io/docs/babel-plugin-transform-regexp-modifiers
+
+        await build(['3000'], configObjectFS);
+
+        const outFile = resolve(outDir, '3000.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('/(?:[Aa])a/'), true);
+        strictEqual(fileContent.includes('/(?i:a)a/'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
+        await build(['3001'], configObjectFS);
+
+        const outFile = resolve(outDir, '3001.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('toSorted()'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-array-prototype-to-reversed` plugin should be applied correctly', async () => {
+        await build(['3002'], configObjectFS);
+
+        const outFile = resolve(outDir, '3002.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('toReversed()'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-object-has-own` plugin should be applied correctly', async () => {
+        await build(['3003'], configObjectFS);
+
+        const outFile = resolve(outDir, '3003.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('Object.hasOwn'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+    });
+
+    describe('`rl`(readline) template', () => {
+      it('ES2025 `regexp-modifiers` should be transpiled correctly', async () => {
+        // https://babeljs.io/docs/babel-plugin-transform-regexp-modifiers
+
+        await build(['3000'], configObjectRL);
+
+        const outFile = resolve(outDir, '3000.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('/(?:[Aa])a/'), true);
+        strictEqual(fileContent.includes('/(?i:a)a/'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-array-prototype-to-sorted` plugin should be applied correctly', async () => {
+        await build(['3001'], configObjectRL);
+
+        const outFile = resolve(outDir, '3001.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('toSorted()'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-array-prototype-to-reversed` plugin should be applied correctly', async () => {
+        await build(['3002'], configObjectRL);
+
+        const outFile = resolve(outDir, '3002.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('toReversed()'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+
+      it('Custom `transform-object-has-own` plugin should be applied correctly', async () => {
+        await build(['3003'], configObjectRL);
+
+        const outFile = resolve(outDir, '3003.cjs');
+        ok(existsSync(outFile));
+
+        const fileContent = readFileSync(outFile, 'utf-8');
+        strictEqual(fileContent.includes('Object.hasOwn'), false);
+
+        const result = runOutFile(outFile, '1 2');
+        strictEqual(result.status, 0);
+        strictEqual(result.stdout, '3');
+      });
+    });
+  });
+
+  describe('Multiple files', () => {
+    it('Multiple files with `fs` template should build correctly', async () => {
+      await build(['1000', '1001', '2000'], configObjectFS);
+
+      const outFile1000 = resolve(outDir, '1000.cjs');
+      const result1000 = runOutFile(outFile1000, '1 2');
+
+      const outFile1001 = resolve(outDir, '1001.cjs');
+      const result1001 = runOutFile(outFile1001, '1 2');
+
+      const outFile2000 = resolve(outDir, '2000.cjs');
+      const result2000 = runOutFile(outFile2000, '1 2');
+
+      ok(existsSync(outFile1000));
+      strictEqual(result1000.status, 0);
+      strictEqual(result1000.stdout, '3');
+
+      ok(existsSync(outFile1001));
+      strictEqual(result1001.status, 0);
+      strictEqual(result1001.stdout, '3');
+
+      ok(existsSync(outFile2000));
+      strictEqual(result2000.status, 0);
+      strictEqual(result2000.stdout, '3');
+    });
+
+    it('Multiple files with `rl` template should build correctly', async () => {
+      await build(['1000', '2000'], configObjectRL);
+
+      const outFile1000 = resolve(outDir, '1000.cjs');
+      const result1000 = runOutFile(outFile1000, '1 2');
+
+      const outFile2000 = resolve(outDir, '2000.cjs');
+      const result2000 = runOutFile(outFile2000, '1 2');
+
+      ok(existsSync(outFile1000));
+      strictEqual(result1000.status, 0);
+      strictEqual(result1000.stdout, '3');
+
+      ok(existsSync(outFile2000));
+      strictEqual(result2000.status, 0);
+      strictEqual(result2000.stdout, '3');
+    });
+  });
+
+  */
+});

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -234,9 +234,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`directory/index.mjs` with `export` should build correctly', async () => {
+      it('`directory/index.mts` with `export` should build correctly', async () => {
         await build(['2004'], configObjectFS);
 
         const outFile = resolve(outDir, '2004.cjs');
@@ -246,6 +244,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('User-created external modules using the `mjs` format should build correctly.', async () => {
         await build(['2005'], configObjectFS);
@@ -306,9 +306,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`directory/index.mjs` with `export` should build correctly', async () => {
+      it('`directory/index.mts` with `export` should build correctly', async () => {
         await build(['2004'], configObjectRL);
 
         const outFile = resolve(outDir, '2004.cjs');
@@ -318,6 +316,8 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
+
+      /*
 
       it('User-created external modules using the `mjs` format should build correctly.', async () => {
         await build(['2005'], configObjectRL);

--- a/tests/e2e/bananass-build/mts.test.js
+++ b/tests/e2e/bananass-build/mts.test.js
@@ -96,9 +96,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`file.mjs` with `export` should build correctly', async () => {
+      it('`file.mts` with `export` should build correctly', async () => {
         await build(['1004'], configObjectFS);
 
         const outFile = resolve(outDir, '1004.cjs');
@@ -108,8 +106,6 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
-
-      */
 
       it('User-created external modules using the `mjs` format should build correctly', async () => {
         await build(['1005'], configObjectFS);
@@ -168,9 +164,7 @@ describe('mts', () => {
         strictEqual(result.stdout, '3');
       });
 
-      /*
-
-      it('`file.mjs` with `export` should build correctly', async () => {
+      it('`file.mts` with `export` should build correctly', async () => {
         await build(['1004'], configObjectRL);
 
         const outFile = resolve(outDir, '1004.cjs');
@@ -180,8 +174,6 @@ describe('mts', () => {
         strictEqual(result.status, 0);
         strictEqual(result.stdout, '3');
       });
-
-      */
 
       it('User-created external modules using the `mjs` format should build correctly', async () => {
         await build(['1005'], configObjectRL);


### PR DESCRIPTION
This pull request refactors the `bananass` package to unify JavaScript and TypeScript handling in the build process and introduces comprehensive end-to-end test fixtures for TypeScript support. The key changes include replacing `esbuild-loader` with `babel-loader` for TypeScript, adding TypeScript presets, and creating new test fixtures for various TypeScript module formats.

### Build Process Updates:
* Added `@babel/preset-typescript` to `dependencies` in `packages/bananass/package.json` and removed `esbuild-loader` to standardize TypeScript handling with Babel. [[1]](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432R96-L103) [[2]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4L163-L171)
* Updated the Webpack configuration in `bananass-build/build.js` to include TypeScript file extensions (`.ts`, `.mts`, `.cts`) in the `test` regex and added the `@babel/preset-typescript` preset with `allowDeclareFields` option. [[1]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4L142-R142) [[2]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4R155-R160)

### End-to-End Test Fixtures:
* Added test fixtures for TypeScript solutions in various module formats (`.ts`, `.mts`, `.cts`) under `tests/e2e/bananass-build/fixtures/mts/bananass/`. These include solutions, test cases, and index files for each format. [[1]](diffhunk://#diff-d6ccb51c179ec152138870aad779065c7c76c07e6b323bf2340e97673d2580d1R1-R23) [[2]](diffhunk://#diff-b2591f2adbddd4214378f98df56de10576e22076fbc9a44cf82f4230d69c1c5fR1-R12) [[3]](diffhunk://#diff-b91eee05eb65a54c113032cfa11c6a541ddc4ac633195f8f4056454034cf24e5R1-R12) [[4]](diffhunk://#diff-07ce88e94939378476e5b771ae39835d485c4a5b1e3c23ac2145d95f22fd1652R1-R21) [[5]](diffhunk://#diff-e5369bad25173bf64e23d51f14be8a3d64a2bef1153262ad2c69cbcc8d49ef0fR1-R22) [[6]](diffhunk://#diff-305db360d62074f9d705eb6b39f003f4e8e9f863673f0f220a3d28624882c161R1-R4) [[7]](diffhunk://#diff-6e1f74ae70f08f2fa9e5b8b52b6e4024fa32b9c53dfd29d0cf0612717e6f3cb2R1-R10) [[8]](diffhunk://#diff-7e8ae8ff57a5605aca5ee249f3aa1bc024de969b1be16a67b924ce696de6ceddR1-R12) [[9]](diffhunk://#diff-59d4cb7b62578937fca2fae110631a1b7543ef0aab6c8c3b5433e5dc10617804R1-R3) [[10]](diffhunk://#diff-eb670f4a1de7bcfb7c7040b837e1c7978ed111c50037796debe90f529f1dd158R1-R4) [[11]](diffhunk://#diff-2c978dec00ed9533ff30ef299c3314d1cdfd0e73a279453ffcec9785ad29242bR1-R12) [[12]](diffhunk://#diff-15ce626f35a8bfddb243710e957e513e457a4120809f69449c58af1659bc66cfR1-R12) [[13]](diffhunk://#diff-2f579c8d356122ba549d95f50612004e3a8de6ef81d855436e2cdc50f521d36aR1-R4) [[14]](diffhunk://#diff-ebdbd9edb2aa605679c7130c381703b43eba0559d69c1b725f807a0d571e8aaaR1-R10) [[15]](diffhunk://#diff-2bd0d197c28d22e417f3f0dd9a9b6b1f49f9875a8cc01587976019e5caed708fR1-R12) [[16]](diffhunk://#diff-d519d6fb5ad59a6c04822a3537789a3025e46ad4977c5f54fa962e5e26925746R1-R2)

These changes improve TypeScript support in the `bananass` package and provide extensive test coverage for different module formats.