### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.3` to `v0.1.0-canary.4` (`prerelease`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "scripts": {
     "bananass:build": "npx bananass build",
     "bananass:run": "npx bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.3"
+    "bananass": "^0.1.0-canary.4"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "scripts": {
     "bananass:build": "npx bananass build",
     "bananass:run": "npx bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.3"
+    "bananass": "^0.1.0-canary.4"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "bananass:build": "npx bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.3"
+    "bananass": "^0.1.0-canary.4"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "bananass:build": "npx bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.3"
+    "bananass": "^0.1.0-canary.4"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.3"
+  "version": "0.1.0-canary.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.1.0",
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.25.1",
-        "eslint-config-bananass": "^0.1.0-canary.3",
+        "eslint-config-bananass": "^0.1.0-canary.4",
         "eslint-plugin-mark": "^0.1.0-canary.1",
         "husky": "^9.1.7",
         "lerna": "^8.2.2",
         "lint-staged": "^15.5.1",
         "markdownlint-cli": "^0.44.0",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.3",
+        "prettier-config-bananass": "^0.1.0-canary.4",
         "shx": "^0.4.0",
         "textlint": "^14.6.0",
         "textlint-rule-allowed-uris": "^1.1.0",
@@ -40,7 +40,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.1.0-canary.3"
+      "version": "0.1.0-canary.4"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -52,30 +52,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.3"
+        "bananass": "^0.1.0-canary.4"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.3"
+        "bananass": "^0.1.0-canary.4"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.3"
+        "bananass": "^0.1.0-canary.4"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.3"
+        "bananass": "^0.1.0-canary.4"
       }
     },
     "examples/solutions-readline": {
@@ -85,7 +85,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.1.0-canary.3"
+      "version": "0.1.0-canary.4"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -94,7 +94,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.1.0-canary.3"
+      "version": "0.1.0-canary.4"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -22370,14 +22370,14 @@
       }
     },
     "packages/bananass": {
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.10",
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-typescript": "^7.27.0",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.1.0-canary.3",
+        "bananass-utils-console": "^0.1.0-canary.4",
         "c12": "^3.0.3",
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
@@ -22412,7 +22412,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -22460,7 +22460,7 @@
       }
     },
     "packages/bananass-utils-vitepress": {
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "license": "MIT"
     },
     "packages/bananass/node_modules/chalk": {
@@ -22488,10 +22488,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.1.0-canary.3",
+        "bananass-utils-console": "^0.1.0-canary.4",
         "commander": "^13.1.0",
         "consola": "^3.4.2"
       },
@@ -22504,13 +22504,13 @@
     },
     "packages/create-bananass/templates/javascript": {
       "name": "create-bananass-javascript",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.3",
+        "bananass": "^0.1.0-canary.4",
         "eslint": "^9.25.1",
-        "eslint-config-bananass": "^0.1.0-canary.3",
+        "eslint-config-bananass": "^0.1.0-canary.4",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.3"
+        "prettier-config-bananass": "^0.1.0-canary.4"
       },
       "engines": {
         "node": "^20.18.0 || >= 22.3.0"
@@ -22518,14 +22518,14 @@
     },
     "packages/create-bananass/templates/typescript": {
       "name": "create-bananass-typescript",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.3",
+        "bananass": "^0.1.0-canary.4",
         "eslint": "^9.25.1",
-        "eslint-config-bananass": "^0.1.0-canary.3",
+        "eslint-config-bananass": "^0.1.0-canary.4",
         "jiti": "^2.4.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.3"
+        "prettier-config-bananass": "^0.1.0-canary.4"
       },
       "engines": {
         "node": "^20.18.0 || >= 22.3.0"
@@ -22540,7 +22540,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.3.1",
@@ -22575,7 +22575,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -22583,18 +22583,18 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.3"
+        "bananass": "^0.1.0-canary.4"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.3",
-        "bananass-utils-console": "^0.1.0-canary.3",
-        "create-bananass": "^0.1.0-canary.3"
+        "bananass": "^0.1.0-canary.4",
+        "bananass-utils-console": "^0.1.0-canary.4",
+        "create-bananass": "^0.1.0-canary.4"
       }
     },
     "website": {
@@ -22667,10 +22667,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
         "@eslint/config-inspector": "^1.0.2",
-        "eslint-config-bananass": "^0.1.0-canary.3"
+        "eslint-config-bananass": "^0.1.0-canary.4"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -22684,11 +22684,11 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
-        "bananass": "^0.1.0-canary.3",
-        "bananass-utils-vitepress": "^0.1.0-canary.3",
+        "bananass": "^0.1.0-canary.4",
+        "bananass-utils-vitepress": "^0.1.0-canary.4",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
@@ -70,14 +70,14 @@
     "concurrently": "^9.1.0",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.25.1",
-    "eslint-config-bananass": "^0.1.0-canary.3",
+    "eslint-config-bananass": "^0.1.0-canary.4",
     "eslint-plugin-mark": "^0.1.0-canary.1",
     "husky": "^9.1.7",
     "lerna": "^8.2.2",
     "lint-staged": "^15.5.1",
     "markdownlint-cli": "^0.44.0",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.3",
+    "prettier-config-bananass": "^0.1.0-canary.4",
     "shx": "^0.4.0",
     "textlint": "^14.6.0",
     "textlint-rule-allowed-uris": "^1.1.0",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass-utils-vitepress/package.json
+++ b/packages/bananass-utils-vitepress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-vitepress",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "description": "VitePress Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -96,7 +96,7 @@
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.27.0",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.1.0-canary.3",
+    "bananass-utils-console": "^0.1.0-canary.4",
     "c12": "^3.0.3",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -54,7 +54,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.1.0-canary.3",
+    "bananass-utils-console": "^0.1.0-canary.4",
     "commander": "^13.1.0",
     "consola": "^3.4.2"
   }

--- a/packages/create-bananass/templates/javascript/package.json
+++ b/packages/create-bananass/templates/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
   },
@@ -9,10 +9,10 @@
     "build": "echo build"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.3",
+    "bananass": "^0.1.0-canary.4",
     "eslint": "^9.25.1",
-    "eslint-config-bananass": "^0.1.0-canary.3",
+    "eslint-config-bananass": "^0.1.0-canary.4",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.3"
+    "prettier-config-bananass": "^0.1.0-canary.4"
   }
 }

--- a/packages/create-bananass/templates/typescript/package.json
+++ b/packages/create-bananass/templates/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
   },
@@ -9,11 +9,11 @@
     "build": "echo build"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.3",
+    "bananass": "^0.1.0-canary.4",
     "eslint": "^9.25.1",
-    "eslint-config-bananass": "^0.1.0-canary.3",
+    "eslint-config-bananass": "^0.1.0-canary.4",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.3"
+    "prettier-config-bananass": "^0.1.0-canary.4"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.3"
+    "bananass": "^0.1.0-canary.4"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.3",
-    "bananass-utils-console": "^0.1.0-canary.3",
-    "create-bananass": "^0.1.0-canary.3"
+    "bananass": "^0.1.0-canary.4",
+    "bananass-utils-console": "^0.1.0-canary.4",
+    "create-bananass": "^0.1.0-canary.4"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.0.2",
-    "eslint-config-bananass": "^0.1.0-canary.3"
+    "eslint-config-bananass": "^0.1.0-canary.4"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",
-    "bananass": "^0.1.0-canary.3",
-    "bananass-utils-vitepress": "^0.1.0-canary.3",
+    "bananass": "^0.1.0-canary.4",
+    "bananass-utils-vitepress": "^0.1.0-canary.4",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.4`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.3` to `v0.1.0-canary.4` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/14666575875) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 07d7535       |
| Old Version | `v0.1.0-canary.3`  |
| New Version | `v0.1.0-canary.4`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(create-bananass): `.gitignore` file is ignored when publish to npm by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/368
### :arrows_counterclockwise: Continuous Integrations
* ci(*): create `test-cross-platform.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/363
### :recycle: Code Refactoring
* refactor(bananass): remove unused `clean` command and cleanup by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/364
* refactor(*): standardize variable names from `inputFile` to `inputStr` across examples and templates by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/365
* refactor(create-bananass): update templates by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/339
### :test_tube: Tests
* test(bananass): create unit test for bananass build by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/366
### :arrow_up: Dependency Updates
* chore(deps-dev): bump @types/node from 22.14.1 to 22.15.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/367


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.1.0-canary.3...v0.1.0-canary.4