### PR TITLE
chore(deps): bump `eslint-plugin-react-compiler`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9966,26 +9966,6 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
-    "node_modules/eslint-plugin-react-compiler": {
-      "version": "19.0.0-beta-714736e-20250131",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-714736e-20250131.tgz",
-      "integrity": "sha512-iTPUaHzvBejGqicSwZLCDBgWBxLzU1Dvqjs31loNoOPRnsey5dcOupaZajECKVvXmB1wcbIWNp6/VR5+dM9d6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.24.4",
-        "@babel/parser": "^7.24.4",
-        "@babel/plugin-proposal-private-methods": "^7.18.6",
-        "hermes-parser": "^0.25.1",
-        "zod": "^3.22.4",
-        "zod-validation-error": "^3.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7"
-      }
-    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
@@ -22551,7 +22531,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-n": "^17.17.0",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-compiler": "^19.0.0-beta-714736e-20250131",
+        "eslint-plugin-react-compiler": "^19.1.0-rc.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "globals": "^16.0.0"
       },
@@ -22572,6 +22552,26 @@
       "peerDependencies": {
         "eslint": "^9.0.0",
         "react": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "packages/eslint-config-bananass/node_modules/eslint-plugin-react-compiler": {
+      "version": "19.1.0-rc.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.1.0-rc.1.tgz",
+      "integrity": "sha512-3umw5eqZXapBl7aQGmvcjheKhUbsElb9jTETxRZg371e1LG4EPs/zCHt2JzP+wNcdaZWzjU/R730zPUJblY2zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^3.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
       }
     },
     "packages/prettier-config-bananass": {

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-n": "^17.17.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-compiler": "^19.0.0-beta-714736e-20250131",
+    "eslint-plugin-react-compiler": "^19.1.0-rc.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^16.0.0"
   }


### PR DESCRIPTION
This pull request updates the version of the `eslint-plugin-react-compiler` dependency in the `packages/eslint-config-bananass/package.json` file to a newer release candidate version (`^19.1.0-rc.1`).