### PR TITLE
fix(create-bananass): make cli command to work in a non-interactive environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22481,13 +22481,26 @@
       "dependencies": {
         "bananass-utils-console": "^0.1.0-canary.4",
         "commander": "^13.1.0",
-        "consola": "^3.4.2"
+        "consola": "^3.4.2",
+        "is-interactive": "^2.0.0"
       },
       "bin": {
         "create-bananass": "src/cli.js"
       },
       "engines": {
         "node": "^20.18.0 || >= 22.3.0"
+      }
+    },
+    "packages/create-bananass/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/create-bananass/templates/javascript": {

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "bananass-utils-console": "^0.1.0-canary.4",
     "commander": "^13.1.0",
-    "consola": "^3.4.2"
+    "consola": "^3.4.2",
+    "is-interactive": "^2.0.0"
   }
 }

--- a/packages/create-bananass/src/cli.js
+++ b/packages/create-bananass/src/cli.js
@@ -20,6 +20,7 @@ import createSpinner from 'bananass-utils-console/spinner';
 import { bananass, error, success } from 'bananass-utils-console/theme';
 import { program } from 'commander';
 import { consola } from 'consola';
+import isInteractive from 'is-interactive';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -97,7 +98,7 @@ program
       let promptSkipGit;
       let promptSkipInstall;
 
-      if (!cliYes) {
+      if (isInteractive() && !cliYes) {
         promptDirectory = await consola.prompt(
           'Which directory should this project be located in?',
           {


### PR DESCRIPTION
This pull request introduces a new dependency, `is-interactive`, to enhance the interactivity of the CLI tool and updates the logic in the `cli.js` file to leverage this dependency. Below are the key changes:

### Dependency Updates:
* Added `is-interactive` version `^2.0.0` as a new dependency in `packages/create-bananass/package.json`.

### CLI Logic Enhancements:
* Imported `is-interactive` in `packages/create-bananass/src/cli.js` to check if the terminal session supports interactivity.
* Updated the conditional logic in the CLI flow to ensure prompts are only shown when the terminal is interactive and the `--yes` flag (`cliYes`) is not set.