### PR TITLE
docs(websites-vitepress): add Linux and WSL browser error Q&A

### DIFF
--- a/websites/vitepress/ko/learn/q-and-a.md
+++ b/websites/vitepress/ko/learn/q-and-a.md
@@ -10,20 +10,74 @@
 
 `create-bananass` 명령어를 통해 바나나 프레임워크를 설치하였을 시, 바나나 프레임워크는 `solution` 함수의 인자로 전달하는 모든 `input`에 대해, 줄 바꿈 (개행) 문자로 LF(`\n`)를 사용하도록 설정되어 있습니다. 따라서, 윈도우<sup>Windows</sup> 환경이라고 해서 줄 바꿈 문자를 구분할 때 CRLF(`\r\n`)를 사용할 필요는 없습니다!
 
-## Q. `Error: spawn xdg-mime ENOENT`이나 `Error: spawn xdg-open ENOENT`가 발생하는 경우 {#error-spawn-xdg-mime-or-xdg-open-enoent}
+## Q. `Error: spawn xdg-mime ENOENT` 혹은 `Error: spawn xdg-open ENOENT` 오류가 발생하는 경우에는 어떻게 해야하나요? {#error-spawn-xdg-mime-or-xdg-open-enoent}
 
-이는 웹 브라우저를 실행하는 과정 중 리눅스 환경(또는 WSL)에서 `xdg-mime`과 `xdg-open` 명령어가 존재하지 않아 발생하는 오류입니다.
+> 관련 이슈: [#378](https://github.com/lumirlumir/npm-bananass/discussions/378)
 
-`sudo apt-get install xdg-utils`를 통해 해당 패키지를 설치하시면 이 문제를 해결할 수 있습니다.
+이는 웹 브라우저를 실행하는 과정 중 리눅스 (또는 WSL) 환경에서 `xdg-mime`과 `xdg-open` 명령어가 존재하지 않아 발생하는 오류입니다.
 
-## Q. WSL 환경에서 설치되어 있지 않은 브라우저로 시도하거나 또는 `Error: Wslview is not supported as a default browser` 같은 오류가 발생할 경우 {#wsl-browser-error}
+`sudo apt-get install xdg-utils`를 통해 해당 패키지를 설치하시면 이 문제를 해결할 수 있습니다!
 
-이는 웹 브라우저를 실행하는 과정 중 WSL 환경에서 정확한 브라우저를 찾지 못해서 발생하는 오류입니다.
+## Q. WSL 환경에서 파이어폭스 등 설치되어 있지 않은 브라우저로 시도하거나, `Error: Wslview is not supported as a default browser` 같은 오류가 발생할 경우에는 어떻게 해야하나요? {#error-wslview-is-not-supported-as-a-default-browser}
 
-[현재 관련 이슈](https://github.com/sindresorhus/open/issues/357)를 제출해 해결 방안을 찾고 있습니다.
+> 관련 이슈: [#378](https://github.com/lumirlumir/npm-bananass/discussions/378), [sindresorhus/open#357](https://github.com/sindresorhus/open/issues/357)
 
-그동안은 사용하시는 브라우저를 아래와 같이 명령어에 정확하게 입력해주세요.
+이는 웹 브라우저를 실행하는 과정 중 WSL 환경에서 정확한 브라우저를 찾지 못해서 발생하는 오류로, [현재 관련 이슈](https://github.com/sindresorhus/open/issues/357)를 제출해 해결 방안을 찾고 있습니다.
 
-```log
+그동안은 사용하시는 브라우저를 아래와 같이 명령어에 정확하게 입력해주세요. (이는, `bug`, `discussion`, `home`, `open` 등 브라우저를 여는 모든 CLI 명령어에 적용됩니다!)
+
+```sh
 npx bananass open 1000 --browser chrome
 ```
+
+혹은 일괄 적용을 원하신다면, `bananass.config` 파일의 `browser` 옵션을 아래와 같이 설정해주세요.
+
+::: code-group
+
+```js [bananass.config.mjs]
+/** @type {import('bananass').ConfigObject} */
+export default {
+  // ...
+  browser: {
+    browser: 'chrome', // 사용하고자 하는 브라우저의 이름
+  }
+  // ...
+};
+```
+
+```js [bananass.config.cjs]
+/** @type {import('bananass').ConfigObject} */
+module.exports = {
+  // ...
+  browser: {
+    browser: 'chrome', // 사용하고자 하는 브라우저의 이름
+  }
+  // ...
+};
+```
+
+```ts [bananass.config.mts]
+import type { ConfigObject } from 'bananass';
+
+export default {
+  // ...
+  browser: {
+    browser: 'chrome', // 사용하고자 하는 브라우저의 이름
+  }
+  // ...
+} satisfies ConfigObject;
+```
+
+```ts [bananass.config.cts]
+import type { ConfigObject } from 'bananass';
+
+module.exports = {
+  // ...
+  browser: {
+    browser: 'chrome', // 사용하고자 하는 브라우저의 이름
+  }
+  // ...
+} satisfies ConfigObject;
+```
+
+:::

--- a/websites/vitepress/ko/learn/q-and-a.md
+++ b/websites/vitepress/ko/learn/q-and-a.md
@@ -9,3 +9,21 @@
 ## Q. 윈도우<sup>Windows</sup> 환경인데, 개행 문자로 Line Feed (LF, `\n`)를 사용할 수 있나요? {#can-i-use-line-feed-lf-in-windows}
 
 `create-bananass` 명령어를 통해 바나나 프레임워크를 설치하였을 시, 바나나 프레임워크는 `solution` 함수의 인자로 전달하는 모든 `input`에 대해, 줄 바꿈 (개행) 문자로 LF(`\n`)를 사용하도록 설정되어 있습니다. 따라서, 윈도우<sup>Windows</sup> 환경이라고 해서 줄 바꿈 문자를 구분할 때 CRLF(`\r\n`)를 사용할 필요는 없습니다!
+
+## Q. `Error: spawn xdg-mime ENOENT`이나 `Error: spawn xdg-open ENOENT`가 발생하는 경우 {#error-spawn-xdg-mime-or-xdg-open-enoent}
+
+이는 웹 브라우저를 실행하는 과정 중 리눅스 환경(또는 WSL)에서 `xdg-mime`과 `xdg-open` 명령어가 존재하지 않아 발생하는 오류입니다.
+
+`sudo apt-get install xdg-utils`를 통해 해당 패키지를 설치하시면 이 문제를 해결할 수 있습니다.
+
+## Q. WSL 환경에서 설치되어 있지 않은 브라우저로 시도하거나 또는 `Error: Wslview is not supported as a default browser` 같은 오류가 발생할 경우 {#wsl-browser-error}
+
+이는 웹 브라우저를 실행하는 과정 중 WSL 환경에서 정확한 브라우저를 찾지 못해서 발생하는 오류입니다.
+
+[현재 관련 이슈](https://github.com/sindresorhus/open/issues/357)를 제출해 해결 방안을 찾고 있습니다.
+
+그동안은 사용하시는 브라우저를 아래와 같이 명령어에 정확하게 입력해주세요.
+
+```log
+npx bananass open 1000 --browser chrome
+```


### PR DESCRIPTION
This pull request updates the Korean Q&A documentation to include answers to common browser-related errors on Linux and WSL environments.

Documentation Updates:
- Added a new question regarding `Error: spawn xdg-mime ENOENT` or `Error: spawn xdg-open ENOENT`, explaining that it's caused by missing `xdg-utils` in Linux or WSL and how to install it.
- Added a new question addressing WSL-specific browser launch issues such as `Wslview is not supported as a default browser`, with a workaround using the `--browser` option in the Banana CLI.

These additions aim to help users troubleshoot common issues encountered when running browser-related commands in Linux and WSL environments.