### PR TITLE
refactor(bananass): detach `webpackResolve` logic from `run.js`

### DIFF
--- a/packages/bananass/src/commands/bananass-run/run.js
+++ b/packages/bananass/src/commands/bananass-run/run.js
@@ -15,12 +15,11 @@ import createSpinner from 'bananass-utils-console/spinner';
 import { bananass, error, success } from 'bananass-utils-console/theme';
 
 import chalk from 'chalk';
-import enhancedResolve from 'enhanced-resolve';
 import { createJiti } from 'jiti';
 
 import { defaultConfigObject as dco } from '../../core/conf/index.js';
+import { webpackResolve } from '../../core/fs/index.js';
 import { Problems, ConfigObject } from '../../core/structs/index.js';
-import { SUPPORTED_SOLUTION_FILE_EXTENSIONS } from '../../core/constants.js';
 
 import testRunner from './test-runner.js';
 
@@ -56,9 +55,6 @@ export default async function run(problems, configObject = dco) {
   // Declarations
   // ------------------------------------------------------------------------------
 
-  const webpackResolve = enhancedResolve.create({
-    extensions: SUPPORTED_SOLUTION_FILE_EXTENSIONS,
-  });
   const jiti = createJiti(import.meta.url);
 
   const {
@@ -110,7 +106,7 @@ export default async function run(problems, configObject = dco) {
   // ------------------------------------------------------------------------------
 
   try {
-    // @ts-expect-error -- TODO: Delete it.
+    // @ts-expect-error Types cannot be matched in JavaScript.
     importedModules = await Promise.all(
       resolvedEntryFiles.map(resolvedEntryFile =>
         jiti.import(resolvedEntryFile, { default: true }),

--- a/packages/bananass/src/commands/bananass-run/run.js
+++ b/packages/bananass/src/commands/bananass-run/run.js
@@ -19,9 +19,10 @@ import enhancedResolve from 'enhanced-resolve';
 import { createJiti } from 'jiti';
 
 import { defaultConfigObject as dco } from '../../core/conf/index.js';
-import testRunner from './test-runner.js';
 import { Problems, ConfigObject } from '../../core/structs/index.js';
 import { SUPPORTED_SOLUTION_FILE_EXTENSIONS } from '../../core/constants.js';
+
+import testRunner from './test-runner.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs

--- a/packages/bananass/src/core/fs/index.js
+++ b/packages/bananass/src/core/fs/index.js
@@ -1,3 +1,4 @@
 import findRootDir from './find-root-dir/index.js';
+import webpackResolve from './webpack-resolve/index.js';
 
-export { findRootDir };
+export { findRootDir, webpackResolve };

--- a/packages/bananass/src/core/fs/webpack-resolve/index.js
+++ b/packages/bananass/src/core/fs/webpack-resolve/index.js
@@ -1,0 +1,3 @@
+import webpackResolve from './webpack-resolve.js';
+
+export default webpackResolve;

--- a/packages/bananass/src/core/fs/webpack-resolve/webpack-resolve.js
+++ b/packages/bananass/src/core/fs/webpack-resolve/webpack-resolve.js
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Webpack resolve using `enhanced-resolve` to resolve module paths.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import enhancedResolve from 'enhanced-resolve';
+import { SUPPORTED_SOLUTION_FILE_EXTENSIONS } from '../../constants.js';
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Webpack resolve using `enhanced-resolve` to resolve module paths.
+ */
+const webpackResolve = enhancedResolve.create({
+  extensions: SUPPORTED_SOLUTION_FILE_EXTENSIONS,
+});
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+export default webpackResolve;


### PR DESCRIPTION
This pull request refactors the use of the `enhanced-resolve` library by encapsulating its functionality into a dedicated `webpack-resolve` module. This change improves code organization and reusability across the project. Additionally, a minor update was made to clarify a TypeScript error comment.

### Refactoring and code organization:

* Moved the `enhanced-resolve` logic into a new `webpack-resolve` module located at `packages/bananass/src/core/fs/webpack-resolve/webpack-resolve.js`. The module creates a resolver with `SUPPORTED_SOLUTION_FILE_EXTENSIONS` and exports it for reuse.
* Updated the `fs/index.js` file to re-export the new `webpackResolve` module alongside `findRootDir`.
* Replaced the inline `enhanced-resolve` logic in `bananass-run/run.js` with the imported `webpackResolve` from the new module. This reduces duplication and centralizes the logic. [[1]](diffhunk://#diff-e32949e4dff2549ab48c17b6a98d88eff1f009162d34c041087ba9fdd1480ce2L18-R24) [[2]](diffhunk://#diff-e32949e4dff2549ab48c17b6a98d88eff1f009162d34c041087ba9fdd1480ce2L58-L60)

### Minor improvements:

* Updated a TypeScript error comment in `bananass-run/run.js` to provide a more descriptive explanation of the issue.