### PR TITLE
fix(bananass): run command should be considered a match regardless of whether it ends with whitespace

### DIFF
--- a/examples/solutions-bananass-cjs/bananass/31403.js
+++ b/examples/solutions-bananass-cjs/bananass/31403.js
@@ -1,0 +1,22 @@
+const testcases = [
+  {
+    input: `3
+4
+5
+`,
+    output: `2
+29
+`,
+  },
+];
+
+function solution(input) {
+  const [A, B, C] = input.trim().split('\n');
+
+  const number = Number(A) + Number(B) - Number(C);
+  const string = Number(A + B) - Number(C);
+
+  return [number, string].join('\n');
+}
+
+module.exports = { testcases, solution };

--- a/examples/solutions-bananass-cts/bananass/31403.ts
+++ b/examples/solutions-bananass-cts/bananass/31403.ts
@@ -1,0 +1,24 @@
+import type { Testcases, Input, Output } from 'bananass';
+
+const testcases = [
+  {
+    input: `3
+4
+5
+`,
+    output: `2
+29
+`,
+  },
+] satisfies Testcases;
+
+function solution(input: Input): Output {
+  const [A, B, C] = input.trim().split('\n');
+
+  const number = Number(A) + Number(B) - Number(C);
+  const string = Number(A + B) - Number(C);
+
+  return [number, string].join('\n');
+}
+
+module.exports = { testcases, solution };

--- a/examples/solutions-bananass-mjs/bananass/31403.js
+++ b/examples/solutions-bananass-mjs/bananass/31403.js
@@ -1,0 +1,22 @@
+const testcases = [
+  {
+    input: `3
+4
+5
+`,
+    output: `2
+29
+`,
+  },
+];
+
+function solution(input) {
+  const [A, B, C] = input.trim().split('\n');
+
+  const number = Number(A) + Number(B) - Number(C);
+  const string = Number(A + B) - Number(C);
+
+  return [number, string].join('\n');
+}
+
+export default { testcases, solution };

--- a/examples/solutions-bananass-mts/bananass/31403.ts
+++ b/examples/solutions-bananass-mts/bananass/31403.ts
@@ -1,0 +1,24 @@
+import type { Testcases, Input, Output } from 'bananass';
+
+const testcases = [
+  {
+    input: `3
+4
+5
+`,
+    output: `2
+29
+`,
+  },
+] satisfies Testcases;
+
+function solution(input: Input): Output {
+  const [A, B, C] = input.trim().split('\n');
+
+  const number = Number(A) + Number(B) - Number(C);
+  const string = Number(A + B) - Number(C);
+
+  return [number, string].join('\n');
+}
+
+export default { testcases, solution };

--- a/packages/bananass/src/commands/bananass-run/run.js
+++ b/packages/bananass/src/commands/bananass-run/run.js
@@ -69,7 +69,7 @@ export default async function run(problems, configObject = dco) {
   const resolvedEntryDir = resolve(cwd, entryDir);
   let /** @type {string[]} */ resolvedEntryFiles;
   let /** @type {SolutionWithTestcases[]} */ importedModules;
-  let testResults;
+  let /** @type {ReturnType<testRunner>[]} */ testResults;
 
   const logger = createLogger({ debug, quiet, textPrefix: false });
   const spinner = createSpinner();

--- a/packages/bananass/src/commands/bananass-run/test-runner.js
+++ b/packages/bananass/src/commands/bananass-run/test-runner.js
@@ -6,7 +6,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { SolutionWithTestcases, Testcase } from '../../core/structs/index.js';
+import { SolutionWithTestcases, Input, Output } from '../../core/structs/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -14,7 +14,17 @@ import { SolutionWithTestcases, Testcase } from '../../core/structs/index.js';
 
 /**
  * @typedef {import('../../core/types.js').SolutionWithTestcases} SolutionWithTestcases
+ * @typedef {import('../../core/types.js').Output} Output
  */
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+/** @param {Output} output */
+function transformOutput(output) {
+  return String(output).trimEnd();
+}
 
 // --------------------------------------------------------------------------------
 // Export
@@ -42,26 +52,30 @@ export default function testRunner(solutionWithTestcases) {
   // Test Runner
   // ------------------------------------------------------------------------------
 
-  const results = testcases.map(({ input, output }) => {
-    Testcase.assert({ input, output: solution(input) }); // `solution(input)` should be `Testcase.output` type.
+  const results = testcases.map(({ input, output: outputExpected }) => {
+    const outputActual = solution(input);
 
-    const outputExpected = String(output);
-    const outputActual = String(solution(input));
-    const isTestPassed = Object.is(outputExpected, outputActual);
+    Input.assert(input);
+    Output.assert(outputExpected);
+    Output.assert(outputActual);
+
+    const outputExpectedTransformed = transformOutput(outputExpected);
+    const outputActualTransformed = transformOutput(outputActual);
 
     return {
       input,
       outputExpected,
       outputActual,
-      isTestPassed,
+      outputExpectedTransformed,
+      outputActualTransformed,
+      isTestPassed: Object.is(outputExpectedTransformed, outputActualTransformed),
     };
   });
 
   const numberOfTests = testcases.length;
   const numberOfTestsPassed = results.filter(({ isTestPassed }) => isTestPassed).length;
   const numberOfTestsFailed = numberOfTests - numberOfTestsPassed;
-
-  const isAllTestsPassed = numberOfTests === numberOfTestsPassed;
+  const isAllTestsPassed = Object.is(numberOfTests, numberOfTestsPassed);
 
   // ------------------------------------------------------------------------------
   // Return


### PR DESCRIPTION
This pull request introduces new solutions for the "bananass" problem in multiple module formats (CommonJS, ESM, TypeScript), along with updates to the `bananass-run` command to improve type safety and test result handling. Below is a summary of the key changes:

### New Problem Solutions

* Added solutions for the "bananass" problem in the following formats:
  - CommonJS JavaScript (`examples/solutions-bananass-cjs/bananass/31403.js`)
  - TypeScript with CommonJS (`examples/solutions-bananass-cts/bananass/31403.ts`)
  - ESM JavaScript (`examples/solutions-bananass-mjs/bananass/31403.js`)
  - TypeScript with ESM (`examples/solutions-bananass-mts/bananass/31403.ts`)

### Enhancements to `bananass-run`

* Improved type annotations in `run.js` for the `testResults` variable, ensuring it matches the return type of the `testRunner` function (`packages/bananass/src/commands/bananass-run/run.js`).
* Enhanced the `testRunner` function to:
  - Validate inputs and outputs using `Input` and `Output` assertions.
  - Introduce a helper function `transformOutput` to standardize output comparison.
  - Update test result structure to include transformed outputs for more robust test evaluation (`packages/bananass/src/commands/bananass-run/test-runner.js`).
* Added type imports for `Input` and `Output` to improve clarity and type safety in `test-runner.js` (`packages/bananass/src/commands/bananass-run/test-runner.js`).