### PR TITLE
chore(*): remove deprecated `reviewers` field from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,8 +31,6 @@ updates:
         patterns:
           - '@typescript-eslint/*'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'lumirlumir'
     schedule:
       interval: 'daily'
       time: '10:00'
@@ -51,8 +49,6 @@ updates:
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'lumirlumir'
     schedule:
       interval: 'weekly'
       day: 'monday'


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration file by removing the `reviewers` field from two sections. This simplifies the configuration by no longer assigning a specific reviewer (`lumirlumir`) for Dependabot pull requests.

Configuration updates:

* Removed the `reviewers` field from the daily update schedule configuration.
* Removed the `reviewers` field from the weekly update schedule configuration.