### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.5` to `v0.1.0-canary.6` (`prerelease`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5"
+    "bananass": "^0.1.0-canary.6"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5"
+    "bananass": "^0.1.0-canary.6"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5"
+    "bananass": "^0.1.0-canary.6"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5"
+    "bananass": "^0.1.0-canary.6"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.5"
+  "version": "0.1.0-canary.6"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.1.0",
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.26.0",
-        "eslint-config-bananass": "^0.1.0-canary.5",
+        "eslint-config-bananass": "^0.1.0-canary.6",
         "eslint-plugin-mark": "^0.1.0-canary.5",
         "husky": "^9.1.7",
         "lerna": "^8.2.2",
         "lint-staged": "^15.5.2",
         "markdownlint-cli": "^0.44.0",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.5",
+        "prettier-config-bananass": "^0.1.0-canary.6",
         "shx": "^0.4.0",
         "textlint": "^14.7.1",
         "textlint-rule-allowed-uris": "^1.1.0",
@@ -40,7 +40,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.1.0-canary.5"
+      "version": "0.1.0-canary.6"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -52,30 +52,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5"
+        "bananass": "^0.1.0-canary.6"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5"
+        "bananass": "^0.1.0-canary.6"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5"
+        "bananass": "^0.1.0-canary.6"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5"
+        "bananass": "^0.1.0-canary.6"
       }
     },
     "examples/solutions-readline": {
@@ -85,7 +85,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.1.0-canary.5"
+      "version": "0.1.0-canary.6"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -94,7 +94,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.1.0-canary.5"
+      "version": "0.1.0-canary.6"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -23016,14 +23016,14 @@
       }
     },
     "packages/bananass": {
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.1",
         "@babel/preset-env": "^7.27.2",
         "@babel/preset-typescript": "^7.27.1",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.1.0-canary.5",
+        "bananass-utils-console": "^0.1.0-canary.6",
         "c12": "^3.0.3",
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
@@ -23058,7 +23058,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -23106,7 +23106,7 @@
       }
     },
     "packages/bananass-utils-vitepress": {
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "license": "MIT"
     },
     "packages/bananass/node_modules/chalk": {
@@ -23134,10 +23134,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.1.0-canary.5",
+        "bananass-utils-console": "^0.1.0-canary.6",
         "commander": "^13.1.0",
         "consola": "^3.4.2",
         "is-interactive": "^2.0.0"
@@ -23178,13 +23178,13 @@
     },
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5",
+        "bananass": "^0.1.0-canary.6",
         "eslint": "^9.26.0",
-        "eslint-config-bananass": "^0.1.0-canary.5",
+        "eslint-config-bananass": "^0.1.0-canary.6",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.5"
+        "prettier-config-bananass": "^0.1.0-canary.6"
       },
       "engines": {
         "node": "^20.18.0 || >= 22.3.0"
@@ -23192,13 +23192,13 @@
     },
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5",
+        "bananass": "^0.1.0-canary.6",
         "eslint": "^9.26.0",
-        "eslint-config-bananass": "^0.1.0-canary.5",
+        "eslint-config-bananass": "^0.1.0-canary.6",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.5"
+        "prettier-config-bananass": "^0.1.0-canary.6"
       },
       "engines": {
         "node": "^20.18.0 || >= 22.3.0"
@@ -23222,14 +23222,14 @@
     },
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5",
+        "bananass": "^0.1.0-canary.6",
         "eslint": "^9.26.0",
-        "eslint-config-bananass": "^0.1.0-canary.5",
+        "eslint-config-bananass": "^0.1.0-canary.6",
         "jiti": "^2.4.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.5",
+        "prettier-config-bananass": "^0.1.0-canary.6",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -23238,14 +23238,14 @@
     },
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5",
+        "bananass": "^0.1.0-canary.6",
         "eslint": "^9.26.0",
-        "eslint-config-bananass": "^0.1.0-canary.5",
+        "eslint-config-bananass": "^0.1.0-canary.6",
         "jiti": "^2.4.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0-canary.5",
+        "prettier-config-bananass": "^0.1.0-canary.6",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -23261,7 +23261,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.3.2",
@@ -23316,7 +23316,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -23324,18 +23324,18 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5"
+        "bananass": "^0.1.0-canary.6"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "bananass": "^0.1.0-canary.5",
-        "bananass-utils-console": "^0.1.0-canary.5",
-        "create-bananass": "^0.1.0-canary.5"
+        "bananass": "^0.1.0-canary.6",
+        "bananass-utils-console": "^0.1.0-canary.6",
+        "create-bananass": "^0.1.0-canary.6"
       }
     },
     "website": {
@@ -23408,10 +23408,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
         "@eslint/config-inspector": "^1.0.2",
-        "eslint-config-bananass": "^0.1.0-canary.5"
+        "eslint-config-bananass": "^0.1.0-canary.6"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -23425,11 +23425,11 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
-        "bananass": "^0.1.0-canary.5",
-        "bananass-utils-vitepress": "^0.1.0-canary.5",
+        "bananass": "^0.1.0-canary.6",
+        "bananass-utils-vitepress": "^0.1.0-canary.6",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
@@ -70,14 +70,14 @@
     "concurrently": "^9.1.0",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.26.0",
-    "eslint-config-bananass": "^0.1.0-canary.5",
+    "eslint-config-bananass": "^0.1.0-canary.6",
     "eslint-plugin-mark": "^0.1.0-canary.5",
     "husky": "^9.1.7",
     "lerna": "^8.2.2",
     "lint-staged": "^15.5.2",
     "markdownlint-cli": "^0.44.0",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.5",
+    "prettier-config-bananass": "^0.1.0-canary.6",
     "shx": "^0.4.0",
     "textlint": "^14.7.1",
     "textlint-rule-allowed-uris": "^1.1.0",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass-utils-vitepress/package.json
+++ b/packages/bananass-utils-vitepress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-vitepress",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "description": "VitePress Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -96,7 +96,7 @@
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-typescript": "^7.27.1",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.1.0-canary.5",
+    "bananass-utils-console": "^0.1.0-canary.6",
     "c12": "^3.0.3",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -56,7 +56,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.1.0-canary.5",
+    "bananass-utils-console": "^0.1.0-canary.6",
     "commander": "^13.1.0",
     "consola": "^3.4.2",
     "is-interactive": "^2.0.0"

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-cjs",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
@@ -25,10 +25,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5",
+    "bananass": "^0.1.0-canary.6",
     "eslint": "^9.26.0",
-    "eslint-config-bananass": "^0.1.0-canary.5",
+    "eslint-config-bananass": "^0.1.0-canary.6",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.5"
+    "prettier-config-bananass": "^0.1.0-canary.6"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-esm",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
@@ -25,10 +25,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5",
+    "bananass": "^0.1.0-canary.6",
     "eslint": "^9.26.0",
-    "eslint-config-bananass": "^0.1.0-canary.5",
+    "eslint-config-bananass": "^0.1.0-canary.6",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.5"
+    "prettier-config-bananass": "^0.1.0-canary.6"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-cjs",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
@@ -26,12 +26,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5",
+    "bananass": "^0.1.0-canary.6",
     "eslint": "^9.26.0",
-    "eslint-config-bananass": "^0.1.0-canary.5",
+    "eslint-config-bananass": "^0.1.0-canary.6",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.5",
+    "prettier-config-bananass": "^0.1.0-canary.6",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-esm",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || >= 22.3.0"
@@ -26,12 +26,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5",
+    "bananass": "^0.1.0-canary.6",
     "eslint": "^9.26.0",
-    "eslint-config-bananass": "^0.1.0-canary.5",
+    "eslint-config-bananass": "^0.1.0-canary.6",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0-canary.5",
+    "prettier-config-bananass": "^0.1.0-canary.6",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5"
+    "bananass": "^0.1.0-canary.6"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.0-canary.5",
-    "bananass-utils-console": "^0.1.0-canary.5",
-    "create-bananass": "^0.1.0-canary.5"
+    "bananass": "^0.1.0-canary.6",
+    "bananass-utils-console": "^0.1.0-canary.6",
+    "create-bananass": "^0.1.0-canary.6"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.0.2",
-    "eslint-config-bananass": "^0.1.0-canary.5"
+    "eslint-config-bananass": "^0.1.0-canary.6"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",
-    "bananass": "^0.1.0-canary.5",
-    "bananass-utils-vitepress": "^0.1.0-canary.5",
+    "bananass": "^0.1.0-canary.6",
+    "bananass-utils-vitepress": "^0.1.0-canary.6",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.6`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.5` to `v0.1.0-canary.6` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/14907692682) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 3df3983       |
| Old Version | `v0.1.0-canary.5`  |
| New Version | `v0.1.0-canary.6`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(bananass): run command should be considered a match regardless of whether it ends with whitespace by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/397
### :toolbox: Chores
* chore(*): cleanup examples and update scripts field of `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/389
* chore(websites-vitepress): create `logo-og.png` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/394
* chore(*): remove deprecated `reviewers` field from `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/407
### :memo: Documentation
* docs(websites-vitepress): create more documentations and remove unused `docs` directory by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/382
* docs(*): update eslint config and translate `CONTRIBUTING.en.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/383
* docs(websites-vitepress): add Linux and WSL browser error Q&A by @sukjuhong in https://github.com/lumirlumir/npm-bananass/pull/384
* docs(websites-vitepress): create dummy docs for structuring by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/385
* docs(*): cleanup examples, create dummy docs, and `writing-a-solution-function.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/386
* docs(websites-vitepress): create more docs by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/395
* docs(*): add more examples and related docs by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/404
### :recycle: Code Refactoring
* refactor(create-bananass): update `README.md` in templates by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/392
* refactor(create-bananass): update solution exmaples in templates by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/393
* refactor(bananass): detach `webpackResolve` logic from `run.js` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/396
### :test_tube: Tests
* test(tests-e2e): create more test cases for bananass build by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/391
* test(*): create test to verify the number of solution files and update `eslint.config.mjs` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/416
### :arrow_up: Dependency Updates
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/380
* chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/381
* chore(deps): bump the babel group across 2 directories with 3 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/387
* chore(deps): bump `open` from `v10.1.1` to `v10.1.2` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/388
* chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/399
* chore(deps-dev): bump textlint from 14.6.0 to 14.7.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/398
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/405
* chore(deps-dev): bump @types/node from 22.15.3 to 22.15.10 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/406
* chore(deps-dev): bump lint-staged from 15.5.1 to 15.5.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/408
* chore(deps): bump the babel group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/411
* chore(deps-dev): bump @types/node from 22.15.12 to 22.15.15 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/414
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/412

## New Contributors
* @sukjuhong made their first contribution in https://github.com/lumirlumir/npm-bananass/pull/384

**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.1.0-canary.5...v0.1.0-canary.6