### PR TITLE
docs(websites-vitepress): fix the ordering of solution files in sidebar

### DIFF
--- a/websites/vitepress/.vitepress/config/en.js
+++ b/websites/vitepress/.vitepress/config/en.js
@@ -9,6 +9,7 @@
 // --------------------------------------------------------------------------------
 
 import { readdirSync } from 'node:fs';
+import { parse } from 'node:path';
 
 import {
   URL_NPM,
@@ -113,12 +114,12 @@ export default defineConfig({
               base: '/en/solutions/baekjoon',
               text: 'Baekjoon',
               collapsed: true,
-              items: readdirSync(
-                new URL('../../en/solutions/baekjoon', import.meta.url),
-              ).map(fileName => ({
-                text: fileName.replace(/\.md$/, ''),
-                link: `/${fileName.replace(/\.md$/, '')}`,
-              })),
+              items: readdirSync(new URL('../../en/solutions/baekjoon', import.meta.url))
+                .sort((a, b) => parse(a).name - parse(b).name)
+                .map(fileName => ({
+                  text: parse(fileName).name,
+                  link: `/${parse(fileName).name}`,
+                })),
             },
             {
               base: '/en/solutions/codeforces',
@@ -127,8 +128,8 @@ export default defineConfig({
               items: readdirSync(
                 new URL('../../en/solutions/codeforces', import.meta.url),
               ).map(fileName => ({
-                text: fileName.replace(/\.md$/, ''),
-                link: `/${fileName.replace(/\.md$/, '')}`,
+                text: parse(fileName).name,
+                link: `/${parse(fileName).name}`,
               })),
             },
           ],

--- a/websites/vitepress/.vitepress/config/ko.js
+++ b/websites/vitepress/.vitepress/config/ko.js
@@ -9,6 +9,7 @@
 // --------------------------------------------------------------------------------
 
 import { readdirSync } from 'node:fs';
+import { parse } from 'node:path';
 
 import {
   URL_NPM,
@@ -113,12 +114,12 @@ export default defineConfig({
               base: '/solutions/baekjoon',
               text: '백준',
               collapsed: true,
-              items: readdirSync(
-                new URL('../../ko/solutions/baekjoon', import.meta.url),
-              ).map(fileName => ({
-                text: fileName.replace(/\.md$/, ''),
-                link: `/${fileName.replace(/\.md$/, '')}`,
-              })),
+              items: readdirSync(new URL('../../ko/solutions/baekjoon', import.meta.url))
+                .sort((a, b) => parse(a).name - parse(b).name)
+                .map(fileName => ({
+                  text: parse(fileName).name,
+                  link: `/${parse(fileName).name}`,
+                })),
             },
             {
               base: '/solutions/codeforces',
@@ -127,8 +128,8 @@ export default defineConfig({
               items: readdirSync(
                 new URL('../../ko/solutions/codeforces', import.meta.url),
               ).map(fileName => ({
-                text: fileName.replace(/\.md$/, ''),
-                link: `/${fileName.replace(/\.md$/, '')}`,
+                text: parse(fileName).name,
+                link: `/${parse(fileName).name}`,
               })),
             },
           ],


### PR DESCRIPTION
This pull request refactors the `items` generation logic in the VitePress configuration files for both English (`en.js`) and Korean (`ko.js`) locales. The changes improve code readability and ensure that items are sorted alphabetically by file name.

### Refactoring and Sorting Enhancements:

* **Introduced `node:path` module**: Added `parse` from `node:path` to both `websites/vitepress/.vitepress/config/en.js` and `websites/vitepress/.vitepress/config/ko.js` to facilitate file name parsing. [[1]](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beR12) [[2]](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57R12)

* **Alphabetical sorting for Baekjoon solutions**:
  - Updated the `items` generation logic for Baekjoon solutions in the English config to sort file names alphabetically using `parse(a).name - parse(b).name`.
  - Applied the same sorting logic for Baekjoon solutions in the Korean config.

* **Refactored `items` mapping for Codeforces solutions**:
  - Simplified the `items` mapping for Codeforces solutions in both English and Korean configs by using `parse(fileName).name` for text and link generation, improving code consistency. [[1]](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beL130-R132) [[2]](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57L130-R132)