### PR TITLE
chore(*)!: drop support for Node.js 23

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -24,7 +24,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 23.0.0
+          - 24.0.0
           - 22.3.0
           - 20.18.0
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0-canary.6",
   "packageManager": "npm@10.9.2",
   "engines": {
-    "node": "^20.18.0 || >= 22.3.0"
+    "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
   },
   "workspaces": [
     ".",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -74,7 +74,7 @@
     "url": "https://github.com/lumirlumir/npm-bananass/issues"
   },
   "engines": {
-    "node": "^20.18.0 || >= 22.3.0"
+    "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -80,7 +80,7 @@
     "url": "https://github.com/lumirlumir/npm-bananass/issues"
   },
   "engines": {
-    "node": "^20.18.0 || >= 22.3.0"
+    "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/lumirlumir/npm-bananass/issues"
   },
   "engines": {
-    "node": "^20.18.0 || >= 22.3.0"
+    "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0-canary.6",
   "type": "commonjs",
   "engines": {
-    "node": "^20.18.0 || >= 22.3.0"
+    "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
   },
   "scripts": {
     "add": "echo `add` command is still working in progress!",

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0-canary.6",
   "type": "module",
   "engines": {
-    "node": "^20.18.0 || >= 22.3.0"
+    "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
   },
   "scripts": {
     "add": "echo `add` command is still working in progress!",

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0-canary.6",
   "type": "commonjs",
   "engines": {
-    "node": "^20.18.0 || >= 22.3.0"
+    "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
   },
   "scripts": {
     "add": "echo `add` command is still working in progress!",

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0-canary.6",
   "type": "module",
   "engines": {
-    "node": "^20.18.0 || >= 22.3.0"
+    "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
   },
   "scripts": {
     "add": "echo `add` command is still working in progress!",

--- a/websites/vitepress/ko/get-started/quick-start.md
+++ b/websites/vitepress/ko/get-started/quick-start.md
@@ -6,9 +6,9 @@
 
 :::
 
-지금 바로 바나나 프레임워크를 만나볼 수 있는, 빠르게 시작하기 문서에 오신 것을 환영합니다!
+지금 바로 바나나 프레임워크를 만나볼 수 있는, **빠르게 시작하기** 문서에 오신 것을 환영합니다!
 
-이번 챕터에서는 `create-bananass` 명령어를 이용하여 바나나 프레임워크를 설치하고, 예제로 추가되어 있는 [백준 1000번 문제](https://www.acmicpc.net/problem/1000)를 풀고 제출하는 방법에 대해 소개합니다!
+이번 챕터에서는 [`create-bananass`](installation#getting-started-with-create-bananass) 명령어를 이용하여 바나나 프레임워크를 설치하고, 예제로 추가되어 있는 [백준 1000번 문제](https://www.acmicpc.net/problem/1000)를 풀고 제출하는 방법에 대해 소개합니다!
 
 ---
 
@@ -24,11 +24,11 @@
 
 ### 선행 설치 사항 {#prerequisites}
 
-`create-bananass` 명령어를 실행하기 전, `^20.18.0 || >= 22.3.0` 범위에 해당하는 최신 버전의 [Node.js](https://nodejs.org/) 및 [Git](https://git-scm.com/)을 설치해주세요.
+`create-bananass` 명령어를 실행하기 전, `^20.18.0 || ^22.3.0 || >= 24.0.0` 범위에 해당하는 최신 버전의 [Node.js](https://nodejs.org/) 및 [Git](https://git-scm.com/)을 설치해주세요.
 
 ### `create-bananass`로 설치하기 {#install-with-create-bananass}
 
-Node.js 및 Git을 설치하셨나요? 이제, 아래 명령어 중 하나를 통해 `create-bananass`를 실행해주세요!
+Node.js 및 Git을 설치하셨나요? 이제, 아래 명령어 중 하나를 터미널(CLI)에 입력해 `create-bananass`를 실행해주세요!
 
 ::: code-group
 


### PR DESCRIPTION
This pull request updates the supported Node.js versions across the project to include version 24.0.0 and makes minor documentation improvements. The key changes are grouped into updates to Node.js version support and documentation enhancements.

### Updates to Node.js version support:
* [`.github/workflows/test-cross-platform.yml`](diffhunk://#diff-290907d9a4bcf13181105b134bd1645da5a3ef27c54f148ad5823e6b77e88426L27-R27): Updated the Node.js version matrix for CI testing to include version `24.0.0`.
* `package.json` and multiple `package.json` files in sub-packages (`packages/bananass-utils-console`, `packages/bananass`, `packages/create-bananass`, and its templates): Updated the `engines.node` field to include support for `^24.0.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R7) [[2]](diffhunk://#diff-14dc0ab8d918f740c0f0d225fcfbbfdbf6620ab25f1e833d884d3878b35a9a0eL77-R77) [[3]](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432L83-R83) [[4]](diffhunk://#diff-4e7987f9676b9c8ddd0dbe15cb714c5d6323a04c94eb3ec11a9ad92f2be50d99L47-R47) [[5]](diffhunk://#diff-42713ec054f9472f55d8476a47fa8966479fa3b991c54b5a6e52037dc1858321L7-R7) [[6]](diffhunk://#diff-7d8f76a6fe5151322ec90712993636eaffc45203a9fc063c1eab82781ca25a55L7-R7) [[7]](diffhunk://#diff-7d4b13fd6a718a86a0affe334165f4e6441dbea4326c844913cb8316c4ec856eL7-R7) [[8]](diffhunk://#diff-ad0802df97b176eeb018326dc9d480d5ba4a9be365096dde2eae5980bee06a38L7-R7)

### Documentation enhancements:
* [`websites/vitepress/ko/get-started/quick-start.md`](diffhunk://#diff-77242a59b0fb3f9db7c913870a35319a98eae32f71914e8f273d54eba8ba1ed5L9-R11): Improved the clarity and formatting of the Korean quick-start guide, including highlighting the `create-bananass` command and updating Node.js version requirements to reflect the inclusion of `^24.0.0`. [[1]](diffhunk://#diff-77242a59b0fb3f9db7c913870a35319a98eae32f71914e8f273d54eba8ba1ed5L9-R11) [[2]](diffhunk://#diff-77242a59b0fb3f9db7c913870a35319a98eae32f71914e8f273d54eba8ba1ed5L27-R31)