### PR TITLE
docs(*): add example for BOJ Problem 30802

### DIFF
--- a/examples/solutions-bananass-cjs/bananass/30802.js
+++ b/examples/solutions-bananass-cjs/bananass/30802.js
@@ -1,0 +1,34 @@
+const testcases = [
+  {
+    input: '23\n3 1 4 1 5 9\n5 7',
+    output: '7\n3 2',
+  },
+];
+
+function solution(input) {
+  const inputParsed = input
+    .trim()
+    .split('\n')
+    .map(val => val.split(' ').map(Number));
+
+  let lineIdx = 0;
+  const [N] = inputParsed[lineIdx++];
+  const sizes = inputParsed[lineIdx++];
+  const [T, P] = inputParsed[lineIdx];
+
+  const result = [];
+
+  let tShirtsBundleCnt = 0;
+  sizes.forEach(size => {
+    tShirtsBundleCnt += Math.ceil(size / T);
+  });
+  result.push(tShirtsBundleCnt);
+
+  const penBundleCnt = Math.floor(N / P);
+  const penCnt = N % P;
+  result.push(`${penBundleCnt} ${penCnt}`);
+
+  return result.join('\n');
+}
+
+module.exports = { solution, testcases };

--- a/examples/solutions-bananass-cts/bananass/30802.ts
+++ b/examples/solutions-bananass-cts/bananass/30802.ts
@@ -1,0 +1,36 @@
+import type { Input, Output, Testcases } from 'bananass';
+
+const testcases = [
+  {
+    input: '23\n3 1 4 1 5 9\n5 7',
+    output: '7\n3 2',
+  },
+] satisfies Testcases;
+
+function solution(input: Input): Output {
+  const inputParsed = input
+    .trim()
+    .split('\n')
+    .map(val => val.split(' ').map(Number));
+
+  let lineIdx = 0;
+  const [N] = inputParsed[lineIdx++];
+  const sizes = inputParsed[lineIdx++];
+  const [T, P] = inputParsed[lineIdx];
+
+  const result = [];
+
+  let tShirtsBundleCnt = 0;
+  sizes.forEach(size => {
+    tShirtsBundleCnt += Math.ceil(size / T);
+  });
+  result.push(tShirtsBundleCnt);
+
+  const penBundleCnt = Math.floor(N / P);
+  const penCnt = N % P;
+  result.push(`${penBundleCnt} ${penCnt}`);
+
+  return result.join('\n');
+}
+
+module.exports = { solution, testcases };

--- a/examples/solutions-bananass-mjs/bananass/30802.js
+++ b/examples/solutions-bananass-mjs/bananass/30802.js
@@ -1,0 +1,34 @@
+const testcases = [
+  {
+    input: '23\n3 1 4 1 5 9\n5 7',
+    output: '7\n3 2',
+  },
+];
+
+function solution(input) {
+  const inputParsed = input
+    .trim()
+    .split('\n')
+    .map(val => val.split(' ').map(Number));
+
+  let lineIdx = 0;
+  const [N] = inputParsed[lineIdx++];
+  const sizes = inputParsed[lineIdx++];
+  const [T, P] = inputParsed[lineIdx];
+
+  const result = [];
+
+  let tShirtsBundleCnt = 0;
+  sizes.forEach(size => {
+    tShirtsBundleCnt += Math.ceil(size / T);
+  });
+  result.push(tShirtsBundleCnt);
+
+  const penBundleCnt = Math.floor(N / P);
+  const penCnt = N % P;
+  result.push(`${penBundleCnt} ${penCnt}`);
+
+  return result.join('\n');
+}
+
+export default { solution, testcases };

--- a/examples/solutions-bananass-mts/bananass/30802.ts
+++ b/examples/solutions-bananass-mts/bananass/30802.ts
@@ -1,0 +1,36 @@
+import type { Input, Output, Testcases } from 'bananass';
+
+const testcases = [
+  {
+    input: '23\n3 1 4 1 5 9\n5 7',
+    output: '7\n3 2',
+  },
+] satisfies Testcases;
+
+function solution(input: Input): Output {
+  const inputParsed = input
+    .trim()
+    .split('\n')
+    .map(val => val.split(' ').map(Number));
+
+  let lineIdx = 0;
+  const [N] = inputParsed[lineIdx++];
+  const sizes = inputParsed[lineIdx++];
+  const [T, P] = inputParsed[lineIdx];
+
+  const result = [];
+
+  let tShirtsBundleCnt = 0;
+  sizes.forEach(size => {
+    tShirtsBundleCnt += Math.ceil(size / T);
+  });
+  result.push(tShirtsBundleCnt);
+
+  const penBundleCnt = Math.floor(N / P);
+  const penCnt = N % P;
+  result.push(`${penBundleCnt} ${penCnt}`);
+
+  return result.join('\n');
+}
+
+export default { solution, testcases };

--- a/websites/vitepress/en/solutions/baekjoon/30802.md
+++ b/websites/vitepress/en/solutions/baekjoon/30802.md
@@ -1,0 +1,54 @@
+# [30802. 웰컴 키트](https://www.acmicpc.net/problem/30802) {#30802}
+
+## Solutions {#solutions}
+
+::: code-group
+
+<<< @/../../examples/solutions-bananass-mjs/bananass/30802.js [30802.mjs]
+
+<<< @/../../examples/solutions-bananass-cjs/bananass/30802.js [30802.cjs]
+
+<<< @/../../examples/solutions-bananass-mts/bananass/30802.ts [30802.mts]
+
+<<< @/../../examples/solutions-bananass-cts/bananass/30802.ts [30802.cts]
+
+:::
+
+## Explanation {#explanation}
+
+### Number of T-shirt Bundles {#number-of-t-shirt-bundles}
+
+The number of bundles required for each T-shirt size is as follows:
+
+$$
+\left\lceil \frac{S}{T} \right\rceil,\
+\left\lceil \frac{M}{T} \right\rceil,\
+\left\lceil \frac{L}{T} \right\rceil,\
+\left\lceil \frac{XL}{T} \right\rceil,\
+\left\lceil \frac{XXL}{T} \right\rceil,\
+\left\lceil \frac{XXXL}{T} \right\rceil
+$$
+
+$\therefore$ the total number of T-shirt bundles is:
+
+$$
+\left\lceil \frac{S}{T} \right\rceil +
+\left\lceil \frac{M}{T} \right\rceil +
+\left\lceil \frac{L}{T} \right\rceil +
+\left\lceil \frac{XL}{T} \right\rceil +
+\left\lceil \frac{XXL}{T} \right\rceil +
+\left\lceil \frac{XXXL}{T} \right\rceil
+$$
+
+### Number of Pen Bundles and Loose Pens {#number-of-pen-bundles-and-loose-pens}
+
+Total number of participants: $N$  
+
+Exactly $N$ pens must be prepared.
+
+- Maximum number of pen bundles: $\left\lfloor\frac{N}{P}\right\rfloor$
+- Number of individual pens: $N\bmod P$
+
+## Contributors {#contributors}
+
+- [sukjuhong](https://github.com/sukjuhong)

--- a/websites/vitepress/en/solutions/baekjoon/30802.md
+++ b/websites/vitepress/en/solutions/baekjoon/30802.md
@@ -1,4 +1,4 @@
-# [30802. 웰컴 키트](https://www.acmicpc.net/problem/30802) {#30802}
+# [30802. Welcome Kit](https://www.acmicpc.net/problem/30802) {#30802}
 
 ## Solutions {#solutions}
 

--- a/websites/vitepress/ko/solutions/baekjoon/30802.md
+++ b/websites/vitepress/ko/solutions/baekjoon/30802.md
@@ -1,0 +1,54 @@
+# [30802. 웰컴 키트](https://www.acmicpc.net/problem/30802) {#30802}
+
+## 문제 풀이 {#solutions}
+
+::: code-group
+
+<<< @/../../examples/solutions-bananass-mjs/bananass/30802.js [30802.mjs]
+
+<<< @/../../examples/solutions-bananass-cjs/bananass/30802.js [30802.cjs]
+
+<<< @/../../examples/solutions-bananass-mts/bananass/30802.ts [30802.mts]
+
+<<< @/../../examples/solutions-bananass-cts/bananass/30802.ts [30802.cts]
+
+:::
+
+## 해설 {#explanation}
+
+### 티셔츠 묶음 수 {#number-of-t-shirt-bundles}
+
+각 사이즈별 필요한 묶음 수는 다음과 같습니다:
+
+$$
+\left\lceil \frac{S}{T} \right\rceil,\
+\left\lceil \frac{M}{T} \right\rceil,\
+\left\lceil \frac{L}{T} \right\rceil,\
+\left\lceil \frac{XL}{T} \right\rceil,\
+\left\lceil \frac{XXL}{T} \right\rceil,\
+\left\lceil \frac{XXXL}{T} \right\rceil
+$$
+
+$\therefore$ 총 티셔츠 묶음 수는:
+
+$$
+\left\lceil \frac{S}{T} \right\rceil +
+\left\lceil \frac{M}{T} \right\rceil +
+\left\lceil \frac{L}{T} \right\rceil +
+\left\lceil \frac{XL}{T} \right\rceil +
+\left\lceil \frac{XXL}{T} \right\rceil +
+\left\lceil \frac{XXXL}{T} \right\rceil
+$$
+
+### 펜 묶음 수와 낱개 수 {#number-of-pen-bundles-and-loose-pens}
+
+총 참가자 수: $N$  
+
+펜은 정확히 $N$자루 준비해야 함.
+
+- 최대한 많은 묶음: $\left\lfloor\frac{N}{P}\right\rfloor$
+- 낱개 주문 수: $N\bmod P$
+
+## 기여자 {#contributors}
+
+- [sukjuhong](https://github.com/sukjuhong)


### PR DESCRIPTION
## Summary

This PR adds:
- An example input/output case for BOJ Problem 30802 – T-shirt and Pen Distribution
- A Markdown file (30802.md) with a concise explanation including LaTeX-formatted formulas

## Details

- The example is added in all supported formats:
  - CommonJS (.cjs)
  - ES Module (.mjs)
  - TypeScript CommonJS (.cts)
  - TypeScript ES Module (.mts)
- The explanation is written in both Korean and English documents, using LaTeX for clean math formatting

### Screenshots

![localhost_5173_solutions_baekjoon_30802](https://github.com/user-attachments/assets/139ad57c-adb5-4f35-83b7-faca93ebc07f)