### PR TITLE
refactor(bananass): cleanup `run` command

### DIFF
--- a/packages/bananass-utils-console/src/icons/icons.js
+++ b/packages/bananass-utils-console/src/icons/icons.js
@@ -44,6 +44,10 @@ export const warningIcon = c.yellow.bold(choose('⚠', '!'));
 export const infoIcon = c.blue.bold(choose('✦', 'i'));
 /** @type {string} */
 export const bananassIcon = choose('🍌', '');
+/** @type {string} U+2022: "Bullet" (•) */
+export const bulletIcon = choose('\u2022', '*');
+/** @type {string} U+2500: "Box Drawings Light Horizontal" (─) */
+export const boxDrawingsLightHorizontalIcon = choose('\u2500', '-');
 
 // --------------------------------------------------------------------------------
 

--- a/packages/bananass/src/commands/bananass-run/run.js
+++ b/packages/bananass/src/commands/bananass-run/run.js
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Asynchronously run generated testcases and compare them with the expected outputs.
- *
  * Note that `Array.prototype.map` is stable, meaning that the order of the elements in the original array is preserved.
  */
 
@@ -13,6 +12,10 @@ import { resolve } from 'node:path';
 import createLogger from 'bananass-utils-console/logger';
 import createSpinner from 'bananass-utils-console/spinner';
 import { bananass, error, success } from 'bananass-utils-console/theme';
+import {
+  bulletIcon as BIcon,
+  boxDrawingsLightHorizontalIcon as BDLHIcon,
+} from 'bananass-utils-console/icons';
 
 import chalk from 'chalk';
 import { createJiti } from 'jiti';
@@ -65,6 +68,7 @@ export default async function run(problems, configObject = dco) {
       quiet = dco.console.quiet,
     } = dco.console,
   } = configObject;
+  const { columns } = process.stdout;
 
   const resolvedEntryDir = resolve(cwd, entryDir);
   let /** @type {string[]} */ resolvedEntryFiles;
@@ -149,45 +153,40 @@ export default async function run(problems, configObject = dco) {
 
     results.forEach(({ input, outputExpected, outputActual }, index, thisArg) => {
       logger
-        .log('\u2500'.repeat(process.stdout.columns))
+        .log(BDLHIcon.repeat(columns))
         .log(
-          '\u2022',
+          BIcon,
           chalk.cyan.bold(`TESTCASE`, chalk.underline(`#${index + 1}`)),
           chalk.green.bold('INPUT'),
         )
-        .log(chalk.gray.dim('-'.repeat(process.stdout.columns)))
+        .log(chalk.gray.dim('-'.repeat(columns)))
         .log(chalk.magenta.bold('Your Input:'))
         .log(input)
-        .log(chalk.gray.dim('\u2500'.repeat(process.stdout.columns)))
+        .log(chalk.gray.dim(BDLHIcon.repeat(columns)))
         .log(
-          '\u2022',
+          BIcon,
           chalk.cyan.bold(`TESTCASE`, chalk.underline(`#${index + 1}`)),
           chalk.greenBright.bold('OUTPUT'),
         )
-        .log(chalk.gray.dim('-'.repeat(process.stdout.columns)))
+        .log(chalk.gray.dim('-'.repeat(columns)))
         .log(chalk.magenta.bold('Expected Output:'))
         .log(outputExpected)
         .log(chalk.magenta.bold('Your Output:'))
         .log(outputActual);
 
       if (thisArg.length === index + 1) {
-        logger.log('\u2500'.repeat(process.stdout.columns));
+        logger.log(BDLHIcon.repeat(columns));
       }
     });
 
     results.forEach(({ isTestPassed }, index) => {
       logger.log(
-        '\u2022',
+        BIcon,
         chalk.cyan.bold(`TESTCASE`, chalk.underline(`#${index + 1}`)),
         isTestPassed ? chalk.green.bold('PASSED') : chalk.red.bold('FAILED'),
       );
     });
   });
-
-  // U+2015: "Figure Dash" (―)
-  // U+2022: "Bullet" (•)
-  // U+2500: "Box Drawings Light Horizontal" (━)
-  // U+2501: "Box Drawings Heavy Horizontal" (━)
 
   // ------------------------------------------------------------------------------
   // Exit with Code


### PR DESCRIPTION
This pull request introduces new icon constants for improved readability and updates the `bananass-run` command to utilize these constants, enhancing code maintainability. Additionally, it includes minor refactoring and cleanup in the `bananass-run` command file.

### Icon additions and usage updates:
* Added `bulletIcon` and `boxDrawingsLightHorizontalIcon` constants in `packages/bananass-utils-console/src/icons/icons.js` for reusable symbols (`•` and `─`).
* Updated `bananass-run` command to import and use the new `bulletIcon` and `boxDrawingsLightHorizontalIcon` constants, replacing inline Unicode characters for bullets and horizontal lines. [[1]](diffhunk://#diff-e32949e4dff2549ab48c17b6a98d88eff1f009162d34c041087ba9fdd1480ce2R15-R18) [[2]](diffhunk://#diff-e32949e4dff2549ab48c17b6a98d88eff1f009162d34c041087ba9fdd1480ce2L152-L191)

### Refactoring and cleanup:
* Introduced a `columns` variable to store `process.stdout.columns` for better readability and to avoid repetitive calls.
* Removed outdated comments about unused Unicode characters in the `bananass-run` file.

### Minor documentation update:
* Removed an unnecessary blank line in the file overview comment of `bananass-run`.