### PR TITLE
chore(*): remove `is-interactive` dependency and update Codecov configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
     steps:
       - name: Set up checkout
         uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -23308,24 +23308,10 @@
         "@codecov/vite-plugin": "^1.9.0",
         "bananass": "^0.1.0",
         "bananass-utils-vitepress": "^0.1.0",
-        "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^1.6.3",
         "vitepress-plugin-group-icons": "^1.5.2"
-      }
-    },
-    "websites/vitepress/node_modules/is-interactive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/websites/vitepress/.vitepress/config/shared.js
+++ b/websites/vitepress/.vitepress/config/shared.js
@@ -14,7 +14,6 @@ import footnote from 'markdown-it-footnote';
 import { defineConfig } from 'vitepress';
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
-import isInteractive from 'is-interactive';
 
 // --------------------------------------------------------------------------------
 // Constants
@@ -107,7 +106,7 @@ export default defineConfig({
       groupIconVitePlugin(),
       codecovVitePlugin({
         // Put the Codecov vite plugin after all other plugins
-        enableBundleAnalysis: !isInteractive(), // Works only in CI
+        enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined, // Works only in CI when CODECOV_TOKEN is set
         bundleName: 'websites-vitepress',
         uploadToken: process.env.CODECOV_TOKEN,
         gitService: 'github',

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -12,7 +12,6 @@
     "@codecov/vite-plugin": "^1.9.0",
     "bananass": "^0.1.0",
     "bananass-utils-vitepress": "^0.1.0",
-    "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
This pull request introduces changes to integrate Codecov for test coverage reporting and remove the `is-interactive` dependency. The most important changes include adding the `CODECOV_TOKEN` environment variable to the GitHub Actions workflow, updating the VitePress configuration to use this token for bundle analysis, and cleaning up unused dependencies.

### Codecov integration:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R21-R23): Added the `CODECOV_TOKEN` environment variable to the test job in the GitHub Actions workflow to enable Codecov integration.
* [`websites/vitepress/.vitepress/config/shared.js`](diffhunk://#diff-73876f6a978dec27dfeeaa8c70437d5664ae37af70af0cda625a8d54373d237bL110-R109): Updated the `codecovVitePlugin` configuration to enable bundle analysis only when the `CODECOV_TOKEN` environment variable is set.

### Dependency cleanup:

* [`websites/vitepress/.vitepress/config/shared.js`](diffhunk://#diff-73876f6a978dec27dfeeaa8c70437d5664ae37af70af0cda625a8d54373d237bL17): Removed the unused `is-interactive` import.
* [`websites/vitepress/package.json`](diffhunk://#diff-10ef64608fffd18cd9a3d2a3b2adb3361c324abf4a0040a210720ab259c6acd2L15): Removed the `is-interactive` dependency since it is no longer used.