### PR TITLE
docs(websites-vitepress): consolidate submitting section

### DIFF
--- a/websites/vitepress/.vitepress/config/en.js
+++ b/websites/vitepress/.vitepress/config/en.js
@@ -268,17 +268,7 @@ export default defineConfig({
             },
             {
               text: 'Submitting a Solution File',
-              collapsed: true,
-              items: [
-                {
-                  text: 'Submitting Directly on the Website',
-                  link: '/submitting-directly-on-the-website',
-                },
-                {
-                  text: 'Submitting Using CLI Command',
-                  link: '/submitting-using-cli-command',
-                },
-              ],
+              link: '/submitting-a-solution-file',
             },
             {
               text: 'Other Useful CLI Commands',

--- a/websites/vitepress/.vitepress/config/ko.js
+++ b/websites/vitepress/.vitepress/config/ko.js
@@ -268,17 +268,7 @@ export default defineConfig({
             },
             {
               text: '문제 풀이 파일 제출하기',
-              collapsed: true,
-              items: [
-                {
-                  text: '홈페이지에 직접 제출하기',
-                  link: '/submitting-directly-on-the-website',
-                },
-                {
-                  text: 'CLI 명령어를 통해 제출하기',
-                  link: '/submitting-using-cli-command',
-                },
-              ],
+              link: '/submitting-a-solution-file',
             },
             {
               text: '이외의 유용한 CLI 명령어들',

--- a/websites/vitepress/en/learn/submitting-a-solution-file.md
+++ b/websites/vitepress/en/learn/submitting-a-solution-file.md
@@ -1,0 +1,3 @@
+# Submitting a Solution File {#submitting-a-solution-file}
+
+<!-- @include: @/shared/wip.en.md -->

--- a/websites/vitepress/en/learn/submitting-directly-on-the-website.md
+++ b/websites/vitepress/en/learn/submitting-directly-on-the-website.md
@@ -1,3 +1,0 @@
-# Submitting Directly on the Website {#submitting-directly-on-the-website}
-
-<!-- @include: @/shared/wip.en.md -->

--- a/websites/vitepress/en/learn/submitting-using-cli-command.md
+++ b/websites/vitepress/en/learn/submitting-using-cli-command.md
@@ -1,3 +1,0 @@
-# Submitting Using CLI Command {#submitting-using-cli-command}
-
-<!-- @include: @/shared/wip.en.md -->

--- a/websites/vitepress/ko/get-started/quick-start.md
+++ b/websites/vitepress/ko/get-started/quick-start.md
@@ -121,7 +121,7 @@ bananass-project/
 
 `package.json`은 바나나 프레임워크의 설정을 담고 있는 파일입니다!
 
-`package.json`의 `scripts` 항목에는 여러 명령어가 추가되어 있습니다. `scripts`에 추가되어 있는 명령어들은 [`npm run build 1000`](../learn/building-a-solution-file.md), [`npm run run 1000`](../learn/running-a-solution-file.md), [`npm run open 1000`](../learn/submitting-directly-on-the-website.md) 등의 터미널(CLI) 명령어를 통해 실행할 수 있습니다.
+`package.json`의 `scripts` 항목에는 여러 명령어가 추가되어 있습니다. `scripts`에 추가되어 있는 명령어들은 [`npm run build 1000`](../learn/building-a-solution-file.md), [`npm run run 1000`](../learn/running-a-solution-file.md), [`npm run open 1000`](../learn/submitting-a-solution-file.md) 등의 터미널(CLI) 명령어를 통해 실행할 수 있습니다.
 
 `scripts`에 존재하는 여러 명령어들 중 `build`, `run`, `open` 명령어에 집중해주세요! 앞으로, 이 명령어들을 활용하여 함께 문제를 풀고 제출하려 합니다.
 

--- a/websites/vitepress/ko/learn/submitting-a-solution-file.md
+++ b/websites/vitepress/ko/learn/submitting-a-solution-file.md
@@ -1,0 +1,3 @@
+# 문제 풀이 파일 제출하기 {#submitting-a-solution-file}
+
+<!-- @include: @/shared/wip.ko.md -->

--- a/websites/vitepress/ko/learn/submitting-directly-on-the-website.md
+++ b/websites/vitepress/ko/learn/submitting-directly-on-the-website.md
@@ -1,3 +1,0 @@
-# 홈페이지에 직접 제출하기 {#submitting-directly-on-the-website}
-
-<!-- @include: @/shared/wip.ko.md -->

--- a/websites/vitepress/ko/learn/submitting-using-cli-command.md
+++ b/websites/vitepress/ko/learn/submitting-using-cli-command.md
@@ -1,3 +1,0 @@
-# CLI 명령어를 통해 제출하기 {#submitting-using-cli-command}
-
-<!-- @include: @/shared/wip.ko.md -->


### PR DESCRIPTION
This pull request consolidates documentation for submitting solution files by merging separate pages into a single unified page and updating references accordingly. The changes simplify the navigation structure and ensure consistency across English and Korean versions of the documentation.

### Documentation Consolidation:

* In both `websites/vitepress/.vitepress/config/en.js` and `websites/vitepress/.vitepress/config/ko.js`, replaced the nested structure for "Submitting a Solution File" with a direct link to the unified page `/submitting-a-solution-file`. [[1]](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beL271-R271) [[2]](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57L271-R271)
* Created a new unified page `submitting-a-solution-file.md` for both English and Korean documentation, replacing the previous individual pages for "Submitting Directly on the Website" and "Submitting Using CLI Command." [[1]](diffhunk://#diff-add98ca7b131b93ef5c36cd43dc646441a7654940ccfb72dffc34cfb59bc3578R1-R3) [[2]](diffhunk://#diff-e307a5daf65f6ce1878fd3d0c126981d762c2461cc7339013f142f21972e4623R1-R3)
* Removed the now-obsolete files `submitting-directly-on-the-website.md` and `submitting-using-cli-command.md` from both English and Korean documentation. [[1]](diffhunk://#diff-fac50e93a52ec83659ae8c37bd0367612ad8085bccbbdc79426de90d8a0a4189L1-L3) [[2]](diffhunk://#diff-5d2d7f5972c7708527bb765da15836c24e925237081e8efcf3ee4dac13da7072L1-L3) [[3]](diffhunk://#diff-df2ec3e9fdb7008f2321ab7ba5b041b48ddbbe7cc3897a0402a54daee5d96828L1-L3) [[4]](diffhunk://#diff-82ddc4ea32a002d4173ba879099f7ef43bdb0afe925b3ae8934c855aa6e402e8L1-L3)

### Reference Updates:

* Updated the link in `websites/vitepress/ko/get-started/quick-start.md` to point to the new unified page `/submitting-a-solution-file.md` instead of the removed `submitting-directly-on-the-website.md`.