### PR TITLE
chore(release): bump package versions from `v0.1.0` to `v0.1.1` (`patch`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0"
+    "bananass": "^0.1.1"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0"
+    "bananass": "^0.1.1"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0"
+    "bananass": "^0.1.1"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.0"
+    "bananass": "^0.1.1"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.1.0",
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.27.0",
-        "eslint-config-bananass": "^0.1.0",
+        "eslint-config-bananass": "^0.1.1",
         "eslint-plugin-mark": "^0.1.0-canary.5",
         "husky": "^9.1.7",
         "lerna": "^8.2.2",
         "lint-staged": "^16.0.0",
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0",
+        "prettier-config-bananass": "^0.1.1",
         "shx": "^0.4.0",
         "textlint": "^14.7.1",
         "textlint-rule-allowed-uris": "^1.1.0",
@@ -40,7 +40,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -52,30 +52,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0"
+        "bananass": "^0.1.1"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0"
+        "bananass": "^0.1.1"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0"
+        "bananass": "^0.1.1"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0"
+        "bananass": "^0.1.1"
       }
     },
     "examples/solutions-readline": {
@@ -85,7 +85,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -94,7 +94,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -22356,14 +22356,14 @@
       }
     },
     "packages/bananass": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.1",
         "@babel/preset-env": "^7.27.2",
         "@babel/preset-typescript": "^7.27.1",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.1.0",
+        "bananass-utils-console": "^0.1.1",
         "c12": "^3.0.4",
         "chalk": "^5.4.1",
         "commander": "^14.0.0",
@@ -22398,7 +22398,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -22446,7 +22446,7 @@
       }
     },
     "packages/bananass-utils-vitepress": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT"
     },
     "packages/bananass/node_modules/chalk": {
@@ -22474,10 +22474,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.1.0",
+        "bananass-utils-console": "^0.1.1",
         "commander": "^14.0.0",
         "consola": "^3.4.2",
         "is-interactive": "^2.0.0"
@@ -22518,13 +22518,13 @@
     },
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0",
+        "bananass": "^0.1.1",
         "eslint": "^9.27.0",
-        "eslint-config-bananass": "^0.1.0",
+        "eslint-config-bananass": "^0.1.1",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0"
+        "prettier-config-bananass": "^0.1.1"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22532,13 +22532,13 @@
     },
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0",
+        "bananass": "^0.1.1",
         "eslint": "^9.27.0",
-        "eslint-config-bananass": "^0.1.0",
+        "eslint-config-bananass": "^0.1.1",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0"
+        "prettier-config-bananass": "^0.1.1"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22562,14 +22562,14 @@
     },
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0",
+        "bananass": "^0.1.1",
         "eslint": "^9.27.0",
-        "eslint-config-bananass": "^0.1.0",
+        "eslint-config-bananass": "^0.1.1",
         "jiti": "^2.4.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0",
+        "prettier-config-bananass": "^0.1.1",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -22578,14 +22578,14 @@
     },
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0",
+        "bananass": "^0.1.1",
         "eslint": "^9.27.0",
-        "eslint-config-bananass": "^0.1.0",
+        "eslint-config-bananass": "^0.1.1",
         "jiti": "^2.4.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.0",
+        "prettier-config-bananass": "^0.1.1",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -22601,7 +22601,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.3.2",
@@ -22655,7 +22655,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -22663,18 +22663,18 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0"
+        "bananass": "^0.1.1"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
-        "bananass": "^0.1.0",
-        "bananass-utils-console": "^0.1.0",
-        "create-bananass": "^0.1.0"
+        "bananass": "^0.1.1",
+        "bananass-utils-console": "^0.1.1",
+        "create-bananass": "^0.1.1"
       }
     },
     "website": {
@@ -22747,10 +22747,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@eslint/config-inspector": "^1.0.2",
-        "eslint-config-bananass": "^0.1.0"
+        "eslint-config-bananass": "^0.1.1"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -22764,11 +22764,11 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
-        "bananass": "^0.1.0",
-        "bananass-utils-vitepress": "^0.1.0",
+        "bananass": "^0.1.1",
+        "bananass-utils-vitepress": "^0.1.1",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -70,14 +70,14 @@
     "concurrently": "^9.1.0",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.27.0",
-    "eslint-config-bananass": "^0.1.0",
+    "eslint-config-bananass": "^0.1.1",
     "eslint-plugin-mark": "^0.1.0-canary.5",
     "husky": "^9.1.7",
     "lerna": "^8.2.2",
     "lint-staged": "^16.0.0",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0",
+    "prettier-config-bananass": "^0.1.1",
     "shx": "^0.4.0",
     "textlint": "^14.7.1",
     "textlint-rule-allowed-uris": "^1.1.0",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass-utils-vitepress/package.json
+++ b/packages/bananass-utils-vitepress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-vitepress",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "VitePress Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -96,7 +96,7 @@
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-typescript": "^7.27.1",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.1.0",
+    "bananass-utils-console": "^0.1.1",
     "c12": "^3.0.4",
     "chalk": "^5.4.1",
     "commander": "^14.0.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -56,7 +56,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.1.0",
+    "bananass-utils-console": "^0.1.1",
     "commander": "^14.0.0",
     "consola": "^3.4.2",
     "is-interactive": "^2.0.0"

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-cjs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.1.0",
+    "bananass": "^0.1.1",
     "eslint": "^9.27.0",
-    "eslint-config-bananass": "^0.1.0",
+    "eslint-config-bananass": "^0.1.1",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0"
+    "prettier-config-bananass": "^0.1.1"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-esm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.1.0",
+    "bananass": "^0.1.1",
     "eslint": "^9.27.0",
-    "eslint-config-bananass": "^0.1.0",
+    "eslint-config-bananass": "^0.1.1",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0"
+    "prettier-config-bananass": "^0.1.1"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-cjs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.1.0",
+    "bananass": "^0.1.1",
     "eslint": "^9.27.0",
-    "eslint-config-bananass": "^0.1.0",
+    "eslint-config-bananass": "^0.1.1",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0",
+    "prettier-config-bananass": "^0.1.1",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-esm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.1.0",
+    "bananass": "^0.1.1",
     "eslint": "^9.27.0",
-    "eslint-config-bananass": "^0.1.0",
+    "eslint-config-bananass": "^0.1.1",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.0",
+    "prettier-config-bananass": "^0.1.1",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.0"
+    "bananass": "^0.1.1"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.0",
-    "bananass-utils-console": "^0.1.0",
-    "create-bananass": "^0.1.0"
+    "bananass": "^0.1.1",
+    "bananass-utils-console": "^0.1.1",
+    "create-bananass": "^0.1.1"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.0.2",
-    "eslint-config-bananass": "^0.1.0"
+    "eslint-config-bananass": "^0.1.1"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",
-    "bananass": "^0.1.0",
-    "bananass-utils-vitepress": "^0.1.0",
+    "bananass": "^0.1.1",
+    "bananass-utils-vitepress": "^0.1.1",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.1`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.1.0` to `v0.1.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/15141914141) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 8801962       |
| Old Version | `v0.1.0`  |
| New Version | `v0.1.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :toolbox: Chores
* chore(*): remove `is-interactive` dependency and update Codecov configuration by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/441
### :memo: Documentation
* docs(websites-vitepress): update api documentation by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/450
* docs(websites-vitepress): update documentation by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/458
* docs(websites-vitepress): update documentation by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/459
* docs(websites-vitepress): consolidate submitting section by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/468
### :recycle: Code Refactoring
* refactor(eslint-config-bananass): migrate to `eslint-plugin-react-hooks@rc` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/451
* refactor(bananass): remove `login` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/466
* refactor(bananass): remove `submit` command by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/467
### :arrow_up: Dependency Updates
* chore(deps): bump the typescript-eslint group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/438
* chore(deps): bump eslint-plugin-react-compiler from 19.1.0-rc.1 to 19.1.0-rc.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/443
* chore(deps): bump undici from 6.21.1 to 6.21.3 in the npm_and_yarn group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/447
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.5.2 to 1.5.5 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/448
* chore(deps-dev): bump markdownlint-cli from 0.44.0 to 0.45.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/452
* chore(deps): bump commander from 13.1.0 to 14.0.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/453
* chore(deps): bump c12 from 3.0.3 to 3.0.4 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/454
* chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/460
* chore(deps-dev): bump @types/node from 22.15.17 to 22.15.19 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/462


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.1.0...v0.1.1