### PR TITLE
refactor(bananass): streamline command options with new groups for better organization

### DIFF
--- a/packages/bananass/src/cli/bananass-add.js
+++ b/packages/bananass/src/cli/bananass-add.js
@@ -22,7 +22,6 @@ import { warning } from 'bananass-utils-console/theme';
 
 /**
  * Add: `npx bananass add` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function add(program) {

--- a/packages/bananass/src/cli/bananass-bug.js
+++ b/packages/bananass/src/cli/bananass-bug.js
@@ -12,6 +12,7 @@ import { bug as bugCmd } from '../commands/index.js';
 import { configLoader } from '../core/conf/index.js';
 
 import { bug as bugDesc } from '../core/cli/descriptions.js';
+import { browser as browserGroup, console as consoleGroup } from '../core/cli/groups.js';
 import {
   browser as browserOpt,
   secretMode as secretModeOpt,
@@ -33,18 +34,17 @@ import {
 
 /**
  * Bug: `npx bananass bug` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function bug(program) {
   program
     .command('bug')
-    .alias('bugs')
-    .alias('issue')
-    .alias('issues')
+    .aliases(['bugs', 'issue', 'issues'])
     .description(bugDesc)
+    .optionsGroup(browserGroup)
     .option(...browserOpt)
     .option(...secretModeOpt)
+    .optionsGroup(consoleGroup)
     .option(...debugOpt)
     .option(...quietOpt)
     .action(async (options, command) => {

--- a/packages/bananass/src/cli/bananass-build.js
+++ b/packages/bananass/src/cli/bananass-build.js
@@ -14,6 +14,11 @@ import { configLoader } from '../core/conf/index.js';
 import { build as buildDesc } from '../core/cli/descriptions.js';
 import { problems as problemsArg } from '../core/cli/arguments.js';
 import {
+  global as globalGroup,
+  console as consoleGroup,
+  build as buildGroup,
+} from '../core/cli/groups.js';
+import {
   cwd as cwdOpt,
   entryDir as entryDirOpt,
   outDir as outDirOpt,
@@ -37,7 +42,6 @@ import {
 
 /**
  * Build: `npx bananass build` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function build(program) {
@@ -45,11 +49,14 @@ export default function build(program) {
     .command('build')
     .description(buildDesc)
     .argument(...problemsArg)
+    .optionsGroup(globalGroup)
     .option(...cwdOpt)
     .option(...entryDirOpt)
     .option(...outDirOpt)
+    .optionsGroup(consoleGroup)
     .option(...debugOpt)
     .option(...quietOpt)
+    .optionsGroup(buildGroup)
     .option(...cleanOpt)
     .option(...templateTypeOpt)
     .action(async (problems, options, command) => {

--- a/packages/bananass/src/cli/bananass-discussion.js
+++ b/packages/bananass/src/cli/bananass-discussion.js
@@ -12,6 +12,7 @@ import { discussion as discussionCmd } from '../commands/index.js';
 import { configLoader } from '../core/conf/index.js';
 
 import { discussion as discussionDesc } from '../core/cli/descriptions.js';
+import { browser as browserGroup, console as consoleGroup } from '../core/cli/groups.js';
 import {
   browser as browserOpt,
   secretMode as secretModeOpt,
@@ -33,20 +34,17 @@ import {
 
 /**
  * Discussion: `npx bananass discussion` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function discussion(program) {
   program
     .command('discussion')
-    .alias('discussions')
-    .alias('discuss')
-    .alias('disc')
-    .alias('question')
-    .alias('questions')
+    .aliases(['discussions', 'discuss', 'disc', 'question', 'questions'])
     .description(discussionDesc)
+    .optionsGroup(browserGroup)
     .option(...browserOpt)
     .option(...secretModeOpt)
+    .optionsGroup(consoleGroup)
     .option(...debugOpt)
     .option(...quietOpt)
     .action(async (options, command) => {

--- a/packages/bananass/src/cli/bananass-home.js
+++ b/packages/bananass/src/cli/bananass-home.js
@@ -12,6 +12,7 @@ import { home as homeCmd } from '../commands/index.js';
 import { configLoader } from '../core/conf/index.js';
 
 import { home as homeDesc } from '../core/cli/descriptions.js';
+import { browser as browserGroup, console as consoleGroup } from '../core/cli/groups.js';
 import {
   browser as browserOpt,
   secretMode as secretModeOpt,
@@ -33,15 +34,16 @@ import {
 
 /**
  * Home: `npx bananass home` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function home(program) {
   program
     .command('home')
     .description(homeDesc)
+    .optionsGroup(browserGroup)
     .option(...browserOpt)
     .option(...secretModeOpt)
+    .optionsGroup(consoleGroup)
     .option(...debugOpt)
     .option(...quietOpt)
     .action(async (options, command) => {

--- a/packages/bananass/src/cli/bananass-info.js
+++ b/packages/bananass/src/cli/bananass-info.js
@@ -12,6 +12,7 @@ import { info as infoCmd } from '../commands/index.js';
 import { configLoader } from '../core/conf/index.js';
 
 import { info as infoDesc } from '../core/cli/descriptions.js';
+import { console as consoleGroup, info as infoGroup } from '../core/cli/groups.js';
 import {
   debug as debugOpt,
   quiet as quietOpt,
@@ -32,15 +33,16 @@ import {
 
 /**
  * Info: `npx bananass info` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function info(program) {
   program
     .command('info')
     .description(infoDesc)
+    .optionsGroup(consoleGroup)
     .option(...debugOpt)
     .option(...quietOpt)
+    .optionsGroup(infoGroup)
     .option(...allOpt)
     .action(async (options, command) => {
       const { debug, quiet, all } = options;

--- a/packages/bananass/src/cli/bananass-open.js
+++ b/packages/bananass/src/cli/bananass-open.js
@@ -12,6 +12,7 @@ import { open as openCmd } from '../commands/index.js';
 import { configLoader } from '../core/conf/index.js';
 
 import { open as openDesc } from '../core/cli/descriptions.js';
+import { browser as browserGroup, console as consoleGroup } from '../core/cli/groups.js';
 import { problems as problemsArg } from '../core/cli/arguments.js';
 import {
   browser as browserOpt,
@@ -34,7 +35,6 @@ import {
 
 /**
  * Open: `npx bananass open` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function open(program) {
@@ -42,8 +42,10 @@ export default function open(program) {
     .command('open')
     .description(openDesc)
     .argument(...problemsArg)
+    .optionsGroup(browserGroup)
     .option(...browserOpt)
     .option(...secretModeOpt)
+    .optionsGroup(consoleGroup)
     .option(...debugOpt)
     .option(...quietOpt)
     .action(async (problems, options, command) => {

--- a/packages/bananass/src/cli/bananass-repo.js
+++ b/packages/bananass/src/cli/bananass-repo.js
@@ -12,6 +12,7 @@ import { repo as repoCmd } from '../commands/index.js';
 import { configLoader } from '../core/conf/index.js';
 
 import { repo as repoDesc } from '../core/cli/descriptions.js';
+import { browser as browserGroup, console as consoleGroup } from '../core/cli/groups.js';
 import {
   browser as browserOpt,
   secretMode as secretModeOpt,
@@ -33,15 +34,16 @@ import {
 
 /**
  * Repo: `npx bananass repo` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function repo(program) {
   program
     .command('repo')
     .description(repoDesc)
+    .optionsGroup(browserGroup)
     .option(...browserOpt)
     .option(...secretModeOpt)
+    .optionsGroup(consoleGroup)
     .option(...debugOpt)
     .option(...quietOpt)
     .action(async (options, command) => {

--- a/packages/bananass/src/cli/bananass-run.js
+++ b/packages/bananass/src/cli/bananass-run.js
@@ -13,6 +13,7 @@ import { configLoader } from '../core/conf/index.js';
 
 import { run as runDesc } from '../core/cli/descriptions.js';
 import { problems as problemsArg } from '../core/cli/arguments.js';
+import { global as globalGroup, console as consoleGroup } from '../core/cli/groups.js';
 import {
   cwd as cwdOpt,
   entryDir as entryDirOpt,
@@ -34,7 +35,6 @@ import {
 
 /**
  * Run: `npx bananass run` command.
- *
  * @param {Command} program The `commander` package's `program`.
  */
 export default function run(program) {
@@ -42,8 +42,10 @@ export default function run(program) {
     .command('run')
     .description(runDesc)
     .argument(...problemsArg)
+    .optionsGroup(globalGroup)
     .option(...cwdOpt)
     .option(...entryDirOpt)
+    .optionsGroup(consoleGroup)
     .option(...debugOpt)
     .option(...quietOpt)
     .action(async (problems, options, command) => {

--- a/packages/bananass/src/core/cli/groups.js
+++ b/packages/bananass/src/core/cli/groups.js
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview `group`s used in `commander` for `bananass` CLI.
+ */
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/** @satisfies {string} */
+export const global = 'Global Options:';
+/** @satisfies {string} */
+export const browser = 'Browser Options:';
+/** @satisfies {string} */
+export const console = 'Console Options:';
+/** @satisfies {string} */
+export const build = 'Build Options:';
+/** @satisfies {string} */
+export const info = 'Info Options:';

--- a/packages/bananass/src/core/cli/options.js
+++ b/packages/bananass/src/core/cli/options.js
@@ -14,6 +14,7 @@ import { defaultConfigObject as dco } from '../conf/index.js';
 // Helpers
 // --------------------------------------------------------------------------------
 
+/** @param {string | boolean} defaultValue */
 function formatDefaultValue(defaultValue) {
   return `(default: ${defaultValue})`;
 }


### PR DESCRIPTION
This pull request introduces several enhancements to the `bananass` CLI by adding grouped options to commands and improving the organization of CLI options. The most significant changes include the creation of reusable option groups, updates to individual commands to use these groups, and minor improvements to the codebase for clarity and maintainability.

### Grouped Options for CLI Commands:
* [`packages/bananass/src/core/cli/groups.js`](diffhunk://#diff-e5689e43172bd0a53d671cf2a795cc52b5e44b6f21774a15c63345d9fbaf1653R1-R18): Introduced reusable option groups (`global`, `browser`, `console`, `build`, `info`) to standardize and organize CLI options. These groups are used across multiple commands.

### Updates to Individual Commands:
* Updated the following commands to use the new option groups:
  - `bug` command: Added `browserGroup` and `consoleGroup` and replaced individual aliases with a single `.aliases` method. (`packages/bananass/src/cli/bananass-bug.js`) [[1]](diffhunk://#diff-196f36c2928080b1421ad5f1091b6715ba428f781678296dc43ee5fd1b7f4bd4R15) [[2]](diffhunk://#diff-196f36c2928080b1421ad5f1091b6715ba428f781678296dc43ee5fd1b7f4bd4L36-R47)
  - `build` command: Added `globalGroup`, `consoleGroup`, and `buildGroup`. (`packages/bananass/src/cli/bananass-build.js`) [[1]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776R16-R20) [[2]](diffhunk://#diff-2303a83467664c32322f8bcdc363e8348ef50a284af4d2dd7501dcf64c21f776L40-R59)
  - `discussion`, `home`, `open`, and `repo` commands: Added `browserGroup` and `consoleGroup`. [[1]](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6R15) [[2]](diffhunk://#diff-4c48cc7ffa1263ce11a655a343ce65a17a24698cf8e694a10ea92045e323a0b6L36-R47) [[3]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeR15) [[4]](diffhunk://#diff-c12d0a891fa6e9d26f5f7592e03138038d5898b95d08fcaa07580ff517172eeeL36-R46) [[5]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bR15) [[6]](diffhunk://#diff-9d4a836ada9ae83082ec770982e73c8cd1399ef1153f4a61e894471101f6c99bL37-R48) [[7]](diffhunk://#diff-18cad518a6aa21886b7a585bd6846ed203fcbb98516a9191ed3c29e82e30869cR15) [[8]](diffhunk://#diff-18cad518a6aa21886b7a585bd6846ed203fcbb98516a9191ed3c29e82e30869cL36-R46)
  - `info` command: Added `consoleGroup` and `infoGroup`. (`packages/bananass/src/cli/bananass-info.js`) [[1]](diffhunk://#diff-bff245da03f8a2d2d1dc34bee509e9bc4a2eaaa81cf70498e71536284f9267caR15) [[2]](diffhunk://#diff-bff245da03f8a2d2d1dc34bee509e9bc4a2eaaa81cf70498e71536284f9267caL35-R45)
  - `run` command: Added `globalGroup` and `consoleGroup`. (`packages/bananass/src/cli/bananass-run.js`) [[1]](diffhunk://#diff-b60d6936d484b4fe5468cf7087467bdab42ddc70d1a1466f0301b5d41aa98658R16) [[2]](diffhunk://#diff-b60d6936d484b4fe5468cf7087467bdab42ddc70d1a1466f0301b5d41aa98658L37-R48)

### Codebase Improvements:
* [`packages/bananass/src/core/cli/options.js`](diffhunk://#diff-dfd07f0b101d852284bb7229d33c6c43fd8ffe2aa88a16484b64079d25550de1R17): Added a JSDoc-annotated helper function `formatDefaultValue` to improve the clarity of default value formatting.