### PR TITLE
chore(*): update ESLint config and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
       typescript-eslint:
         patterns:
           - '@typescript-eslint/*'
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
     schedule:
       interval: 'daily'
       time: '10:00'
@@ -48,7 +48,7 @@ updates:
       include: 'scope'
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
     schedule:
       interval: 'weekly'
       day: 'monday'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,13 @@
-import { defineConfig } from 'eslint/config';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import bananass from 'eslint-config-bananass';
 import mark from 'eslint-plugin-mark';
 
 /** @type {import("eslint").Linter.Config[]} */
 export default defineConfig([
-  {
-    name: 'global/ignores',
-    ignores: ['**/build/', '**/coverage/', '**/.vitepress/cache/', '**/.bananass/'],
-  },
+  globalIgnores(
+    ['**/build/', '**/coverage/', '**/.vitepress/cache/', '**/.bananass/'],
+    'global/ignores',
+  ),
   bananass.configs.js,
   bananass.configs.ts,
   mark.configs.recommendedGfm,


### PR DESCRIPTION
This pull request includes updates to the Dependabot configuration and a refactor in the ESLint configuration file to improve maintainability and consistency. The most important changes are grouped below:

### Dependabot Configuration Updates:
* Reduced the `open-pull-requests-limit` from 3 to 2 for both the `typescript-eslint` and the scoped dependencies in the `.github/dependabot.yml` file. This helps manage the number of active pull requests more effectively. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L33-R33) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L51-R51)

### ESLint Configuration Refactor:
* Replaced the inline `ignores` configuration with the `globalIgnores` helper function in `eslint.config.mjs`, simplifying the configuration and improving readability.