### PR TITLE
docs(websites-vitepress): complete `other-useful-cli-commands.md`

### DIFF
--- a/websites/vitepress/ko/apis/create-bananass.md
+++ b/websites/vitepress/ko/apis/create-bananass.md
@@ -6,3 +6,7 @@
 [![npm package create-bananass next version](https://img.shields.io/npm/v/create-bananass/next?label=create-bananass@next&color=fff478&labelColor=333333&logo=npm)](https://www.npmjs.com/package/create-bananass)
 
 <!-- @include: @/shared/wip.ko.md -->
+
+## CLI {#cli}
+
+<!-- @include: @/shared/wip.ko.md -->

--- a/websites/vitepress/ko/learn/other-useful-cli-commands.md
+++ b/websites/vitepress/ko/learn/other-useful-cli-commands.md
@@ -2,17 +2,26 @@
 
 이번 챕터에서는 바나나 프레임워크에서 제공하는 모든 CLI 명령어들을 소개합니다!
 
+바나나 프레임워크의 [`build`](#build), [`run`](#run), [`open`](#open) 등의 모든 CLI 명령어들은 `npx bananass` 혹은 `npx b` 명령어를 통해 실행할 수 있습니다.
+
+- `-v, --version` 옵션을 통해 현재 설치된 바나나 프레임워크의 버전을 확인할 수 있습니다.
+- `-h, --help` 옵션을 통해 사용 가능한 모든 명령어와 옵션을 확인할 수 있습니다.
+
+```sh
+npx bananass [options] [command]
+# 또는
+npx b [options] [command]
+```
+
 ::: danger 반드시 읽어주세요!
 
 **사용 예시** 및 **옵션**에서 사용하는 꺾쇠 괄호(`<>`) 및 대괄호(`[]`)의 의미는 다음과 같습니다.
 
 - 꺾쇠 괄호(`<>`)는 *필수* 인자를 의미합니다.
 - 대괄호(`[]`)는 *선택적* 인자를 의미합니다.
-- **꺽쇠 괄호** 및 **대괄호**와 함께 사용된 점점점(`...`)은 *여러 개*의 인자를 의미합니다.
+- **꺾쇠 괄호** 및 **대괄호**와 함께 사용된 점점점(`...`)은 *여러 개*의 인자를 의미합니다.
 
----
-
-또한, <strong>별칭<sup>Alias</sup></strong>은 해당 명령어를 실행할 수 있는 다른 이름을 의미합니다. 예를 들어, `bananass` 명령어의 별칭이 `b`이므로, `npx bananass` 대신 `npx b`로도 명령어를 실행할 수 있습니다.
+또한, <strong>별칭<sup>Alias</sup></strong>은 해당 명령어를 실행할 수 있는 다른 이름을 의미합니다. 예를 들어, `bananass` 명령어의 별칭이 `b`이므로, `npx bananass` 대신 `npx b`를 사용하여 명령어를 실행할 수도 있습니다.
 
 :::
 
@@ -24,32 +33,27 @@ CLI 명령어를 입력할 때마다 자주 사용하는 옵션을 매번 입력
 
 :::
 
+::: warning CLI 명령어와 `bananass.config.*` 중 어떤 옵션이 우선시되나요?
+
+옵션의 우선순위는 아래와 같습니다!
+
+1. CLI 명령어에 입력한 옵션 (가장 높은 우선순위)
+1. `bananass.config.*` 파일에 설정한 옵션
+1. 바나나 프레임워크의 기본 옵션 (가장 낮은 우선순위)
+
+:::
+
 ---
 
 [[TOC]]
 
-## `bananass` {#bananass}
-
-> 별칭: `b`
-
-바나나 프레임워크의 모든 CLI 명령어들은 `npx bananass` 명령어를 통해 실행할 수 있습니다!
-
-- `-v, --version` 옵션을 통해 현재 설치된 바나나 프레임워크의 버전을 확인할 수 있습니다.
-- `-h, --help` 옵션을 통해 사용 가능한 모든 명령어와 옵션을 확인할 수 있습니다.
-
-```sh
-npx bananass [options] [command]
-```
-
----
-
-### `add` {#add}
+## `add` {#add}
 
 > 별칭: `create`
 
 <!-- @include: @/shared/wip.ko.md -->
 
-### `bug` {#bug}
+## `bug` {#bug}
 
 > 별칭: `bugs`, `issue`, `issues`
 
@@ -57,13 +61,13 @@ npx bananass [options] [command]
 
 바나나 프레임워크와 관련된 버그를 제보하거나, 기능 개선 요청 등의 피드백을 남기고 싶을 때 유용하게 사용할 수 있습니다!
 
-#### 사용 예시 {#bug-example}
+### 사용 예시 {#bug-example}
 
 ```sh
 npx bananass bug [options]
 ```
 
-#### 옵션 `[options]` {#bug-options}
+### 옵션 `[options]` {#bug-options}
 
 | 옵션                    | 인자         | 기본값     | 설명                                                                                        |
 | ----------------------- | ----------- | --------- | ------------------------------------------------------------------------------------------ |
@@ -73,19 +77,19 @@ npx bananass bug [options]
 | `-q`, `--quiet`         | X           | `false`   | 출력 로그를 최소화하는 조용한 모드를 실행합니다.                                                  |
 | `-h`, `--help`          | X           |           | 사용 가능한 옵션과 도움말 정보를 표시합니다.                                                     |
 
-### `build` {#build}
+## `build` {#build}
 
 > 별칭: 없음
 
 [웹팩<sup>Webpack</sup>](https://webpack.js.org/), [바벨<sup>Babel</sup>](https://babeljs.io/), [ESBuild](https://esbuild.github.io/)를 사용하여, `bananass` 폴더에 존재하는 문제 풀이 파일들을 `.bananass` 폴더에 번들링하여 빌드합니다.
 
-#### 사용 예시 {#build-example}
+### 사용 예시 {#build-example}
 
 ```sh
 npx bananass build [options] <problems...>
 ```
 
-#### 인자 `<problems...>` {#build-args}
+### 인자 `<problems...>` {#build-args}
 
 ::: warning :bulb:개선 예정입니다!:bulb:
 
@@ -95,9 +99,9 @@ npx bananass build [options] <problems...>
 
 :::
 
-`<problems...>` 인자로 문제 풀이 파일 번호를 입력합니다. 예를 들어, 백준 1000번 문제는 `1000`으로, 1001번 문제는 `1001`로 입력합니다.
+`<problems...>` 인자로 문제 풀이 파일 번호를 입력합니다. 예를 들어, 백준 1000번 문제는 `1000`으로, 1001번 문제는 `1001`로 입력합니다. `npx bananass build 1000 1001`과 같이 여러 개의 문제 풀이 파일 번호를 입력할 수도 있습니다.
 
-#### 옵션 `[options]` {#build-options}
+### 옵션 `[options]` {#build-options}
 
 | 옵션                    | 인자      | 기본값           | 설명                                                                                                                                                |
 | ----------------------- | -------- | ----------------| -------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -110,7 +114,7 @@ npx bananass build [options] <problems...>
 | `-t`, `--template-type` | `<type>` | `fs`            | 웹팩<sup>Webpack</sup>의 엔트리 파일로 사용할 템플릿 타입을 설정합니다. `fs`<sup>File System</sup> 혹은 `rl`<sup>Read Line</sup> 중 하나를 선택할 수 있습니다. |
 | `-h`, `--help`          | X        |                 | 사용 가능한 옵션과 도움말 정보를 표시합니다.                                                                                                             |
 
-### `discussion` {#discussion}
+## `discussion` {#discussion}
 
 > 별칭: `discussions`, `discuss`, `disc`, `question`, `questions`
 
@@ -118,13 +122,13 @@ npx bananass build [options] <problems...>
 
 바나나 프레임워크와 관련된 질문, 답변, 토론 등을 남기고 싶을 때 유용하게 사용할 수 있습니다!
 
-#### 사용 예시 {#discussion-example}
+### 사용 예시 {#discussion-example}
 
 ```sh
 npx bananass discussion [options]
 ```
 
-#### 옵션 `[options]` {#discussion-options}
+### 옵션 `[options]` {#discussion-options}
 
 | 옵션                    | 인자         | 기본값     | 설명                                                                                        |
 | ----------------------- | ----------- | --------- | ------------------------------------------------------------------------------------------ |
@@ -134,42 +138,131 @@ npx bananass discussion [options]
 | `-q`, `--quiet`         | X           | `false`   | 출력 로그를 최소화하는 조용한 모드를 실행합니다.                                                  |
 | `-h`, `--help`          | X           |           | 사용 가능한 옵션과 도움말 정보를 표시합니다.                                                     |
 
-### `home` {#home}
+## `home` {#home}
 
 > 별칭: 없음
 
-<!-- @include: @/shared/wip.ko.md -->
+브라우저에서 [바나나 프레임워크 공식 문서](https://bananass.lumir.page) 웹 페이지를 열어줍니다.
 
-### `info` {#info}
+### 사용 예시 {#home-example}
 
-> 별칭: 없음
+```sh
+npx bananass home [options]
+```
 
-<!-- @include: @/shared/wip.ko.md -->
+### 옵션 `[options]` {#home-options}
 
-### `open` {#open}
+| 옵션                    | 인자         | 기본값     | 설명                                                                                        |
+| ----------------------- | ----------- | --------- | ------------------------------------------------------------------------------------------ |
+| `-b`, `--browser`       | `<browser>` | `default` | 브라우저를 설정합니다. `chrome`, `edge`, `firefox`, `default` 중 하나를 인자로 전달할 수 있습니다. |
+| `-s`, `--secret-mode`   | X           | `false`   | 브라우저의 시크릿 모드를 활성화합니다.                                                          |
+| `-d`, `--debug`         | X           | `false`   | 디버그 모드를 활성화하여 추가 정보를 출력합니다.                                                  |
+| `-q`, `--quiet`         | X           | `false`   | 출력 로그를 최소화하는 조용한 모드를 실행합니다.                                                  |
+| `-h`, `--help`          | X           |           | 사용 가능한 옵션과 도움말 정보를 표시합니다.                                                     |
 
-> 별칭: 없음
-
-<!-- @include: @/shared/wip.ko.md -->
-
-### `repo` {#repo}
-
-> 별칭: 없음
-
-<!-- @include: @/shared/wip.ko.md -->
-
-### `run` {#run}
+## `info` {#info}
 
 > 별칭: 없음
 
-<!-- @include: @/shared/wip.ko.md -->
+버그를 보고할 때 사용할 수 있는 현재 시스템에 대한 세부 정보를 출력합니다.
 
-### `help` {#help}
+### 사용 예시 {#info-example}
+
+```sh
+npx bananass info [options]
+```
+
+### 옵션 `[options]` {#info-options}
+
+| 옵션                    | 인자         | 기본값     | 설명                                                                                        |
+| ----------------------- | ----------- | --------- | ------------------------------------------------------------------------------------------ |
+| `-d`, `--debug`         | X           | `false`   | 디버그 모드를 활성화하여 추가 정보를 출력합니다.                                                  |
+| `-q`, `--quiet`         | X           | `false`   | 출력 로그를 최소화하는 조용한 모드를 실행합니다.                                                  |
+| `-a`, `--all`           | X           | `false`   | `not found`를 포함한 모든 정보를 출력합니다.                                                    |
+| `-h`, `--help`          | X           |           | 사용 가능한 옵션과 도움말 정보를 표시합니다.                                                     |
+
+## `open` {#open}
 
 > 별칭: 없음
 
-<!-- @include: @/shared/wip.ko.md -->
+브라우저에서 백준 문제 번호에 해당하는 웹 페이지를 열어줍니다.
 
-## `create-bananass` {#create-bananass}
+### 사용 예시 {#open-example}
 
-<!-- @include: @/shared/wip.ko.md -->
+```sh
+npx bananass open [options] <problems...>
+```
+
+### 인자 `<problems...>` {#open-args}
+
+`<problems...>` 인자로 문제 풀이 파일 번호를 입력합니다. 예를 들어, 백준 1000번 문제는 `1000`으로, 1001번 문제는 `1001`로 입력합니다. `npx bananass open 1000 1001`과 같이 여러 개의 문제 풀이 파일 번호를 입력할 수도 있습니다.
+
+### 옵션 `[options]` {#open-options}
+
+| 옵션                    | 인자         | 기본값     | 설명                                                                                        |
+| ----------------------- | ----------- | --------- | ------------------------------------------------------------------------------------------ |
+| `-b`, `--browser`       | `<browser>` | `default` | 브라우저를 설정합니다. `chrome`, `edge`, `firefox`, `default` 중 하나를 인자로 전달할 수 있습니다. |
+| `-s`, `--secret-mode`   | X           | `false`   | 브라우저의 시크릿 모드를 활성화합니다.                                                          |
+| `-d`, `--debug`         | X           | `false`   | 디버그 모드를 활성화하여 추가 정보를 출력합니다.                                                  |
+| `-q`, `--quiet`         | X           | `false`   | 출력 로그를 최소화하는 조용한 모드를 실행합니다.                                                  |
+| `-h`, `--help`          | X           |           | 사용 가능한 옵션과 도움말 정보를 표시합니다.                                                     |
+
+## `repo` {#repo}
+
+> 별칭: 없음
+
+브라우저에서 [바나나 프레임워크 깃허브 리포지토리](https://github.com/lumirlumir/npm-bananass) 웹 페이지를 열어줍니다.
+
+### 사용 예시 {#repo-example}
+
+```sh
+npx bananass repo [options]
+```
+
+### 옵션 `[options]` {#repo-options}
+
+| 옵션                    | 인자         | 기본값     | 설명                                                                                        |
+| ----------------------- | ----------- | --------- | ------------------------------------------------------------------------------------------ |
+| `-b`, `--browser`       | `<browser>` | `default` | 브라우저를 설정합니다. `chrome`, `edge`, `firefox`, `default` 중 하나를 인자로 전달할 수 있습니다. |
+| `-s`, `--secret-mode`   | X           | `false`   | 브라우저의 시크릿 모드를 활성화합니다.                                                          |
+| `-d`, `--debug`         | X           | `false`   | 디버그 모드를 활성화하여 추가 정보를 출력합니다.                                                  |
+| `-q`, `--quiet`         | X           | `false`   | 출력 로그를 최소화하는 조용한 모드를 실행합니다.                                                  |
+| `-h`, `--help`          | X           |           | 사용 가능한 옵션과 도움말 정보를 표시합니다.                                                     |
+
+## `run` {#run}
+
+> 별칭: 없음
+
+[문제 풀이 파일의 테스트 케이스](writing-test-cases.md)를 실행하고 예상 출력값과 비교합니다.
+
+### 사용 예시 {#run-example}
+
+```sh
+npx bananass run [options] <problems...>
+```
+
+### 인자 `<problems...>` {#run-args}
+
+`<problems...>` 인자로 문제 풀이 파일 번호를 입력합니다. 예를 들어, 백준 1000번 문제는 `1000`으로, 1001번 문제는 `1001`로 입력합니다. `npx bananass run 1000 1001`과 같이 여러 개의 문제 풀이 파일 번호를 입력할 수도 있습니다.
+
+### 옵션 `[options]` {#run-options}
+
+| 옵션                    | 인자         | 기본값           | 설명                                             |
+| ----------------------- | ----------- | --------------- | ----------------------------------------------- |
+| `-c`, `--cwd`           | `<dir>`     | `findRootDir()` | 명령어를 실행할 현재 작업 디렉토리를 설정합니다.       |
+| `-e`, `--entry-dir`     | `<dir>`     | `bananass`      | 문제 풀이 파일들이 위치할 엔트리 디렉토리를 설정합니다. |
+| `-d`, `--debug`         | X           | `false`         | 디버그 모드를 활성화하여 추가 정보를 출력합니다.       |
+| `-q`, `--quiet`         | X           | `false`         | 출력 로그를 최소화하는 조용한 모드를 실행합니다.       |
+| `-h`, `--help`          | X           |                 | 사용 가능한 옵션과 도움말 정보를 표시합니다.          |
+
+## `help` {#help}
+
+> 별칭: 없음
+
+바나나 프레임워크의 CLI 명령어에 대한 도움말을 출력합니다.
+
+### 사용 예시 {#help-example}
+
+```sh
+npx bananass help [command]
+```

--- a/websites/vitepress/ko/learn/writing-bananass-config-file.md
+++ b/websites/vitepress/ko/learn/writing-bananass-config-file.md
@@ -2,6 +2,16 @@
 
 <!-- @include: @/shared/wip.ko.md -->
 
+::: warning CLI 명령어와 `bananass.config.*` 중 어떤 옵션이 우선시되나요?
+
+옵션의 우선순위는 아래와 같습니다!
+
+1. CLI 명령어에 입력한 옵션 (가장 높은 우선순위)
+1. `bananass.config.*` 파일에 설정한 옵션
+1. 바나나 프레임워크의 기본 옵션 (가장 낮은 우선순위)
+
+:::
+
 ::: code-group
 
 ```js [bananass.config.mjs]


### PR DESCRIPTION
This pull request enhances the Korean documentation for the Banana Framework by adding detailed explanations of CLI commands, their options, and usage examples. It also introduces a new section to clarify the priority of configuration options between CLI commands and `bananass.config.*` files.

### Additions to CLI Command Documentation:

* **Expanded CLI Command Descriptions**: Added detailed descriptions, usage examples, and option tables for multiple CLI commands, including `build`, `run`, `open`, `home`, `repo`, and more. These updates make it easier for users to understand how to use each command effectively. [[1]](diffhunk://#diff-91f4adf76df66a2d7ca53d94359d33cc81580d4aaad1940b255c00c63d6711d9R5-R24) [[2]](diffhunk://#diff-91f4adf76df66a2d7ca53d94359d33cc81580d4aaad1940b255c00c63d6711d9L76-R92) [[3]](diffhunk://#diff-91f4adf76df66a2d7ca53d94359d33cc81580d4aaad1940b255c00c63d6711d9L137-R268)

* **New Commands and Options**: Introduced new commands like `home` and `info`, along with their respective options, such as setting a browser or enabling secret mode.

### Configuration Option Priority:

* **Priority Clarification**: Added a section explaining the precedence of configuration options, with CLI command options taking the highest priority, followed by `bananass.config.*` settings, and default framework options. This clarification is included in both the CLI documentation and the configuration file documentation. [[1]](diffhunk://#diff-91f4adf76df66a2d7ca53d94359d33cc81580d4aaad1940b255c00c63d6711d9L27-R70) [[2]](diffhunk://#diff-ac7d70829e275fe46729c82d2c99b2a628f58891d0f080e2ea04432712f74c71R5-R14)

### Structural Improvements:

* **Improved Formatting**: Adjusted headings and formatting for better readability and consistency, such as changing subheadings to proper levels and reformatting option tables.

These updates significantly improve the usability and clarity of the Banana Framework's Korean documentation.