### PR TITLE
chore(release): bump package versions from `v0.1.1` to `v0.1.2` (`patch`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.1"
+    "bananass": "^0.1.2"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.1"
+    "bananass": "^0.1.2"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.1"
+    "bananass": "^0.1.2"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.1"
+    "bananass": "^0.1.2"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.1.0",
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.28.0",
-        "eslint-config-bananass": "^0.1.1",
+        "eslint-config-bananass": "^0.1.2",
         "eslint-plugin-mark": "^0.1.0-canary.5",
         "husky": "^9.1.7",
         "lerna": "^8.2.2",
         "lint-staged": "^16.1.0",
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.1",
+        "prettier-config-bananass": "^0.1.2",
         "shx": "^0.4.0",
         "textlint": "^14.7.2",
         "textlint-rule-allowed-uris": "^1.1.1",
@@ -40,7 +40,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -52,30 +52,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1"
+        "bananass": "^0.1.2"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1"
+        "bananass": "^0.1.2"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1"
+        "bananass": "^0.1.2"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1"
+        "bananass": "^0.1.2"
       }
     },
     "examples/solutions-readline": {
@@ -85,7 +85,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -94,7 +94,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -22387,14 +22387,14 @@
       }
     },
     "packages/bananass": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/preset-env": "^7.27.2",
         "@babel/preset-typescript": "^7.27.1",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.1.1",
+        "bananass-utils-console": "^0.1.2",
         "c12": "^3.0.4",
         "chalk": "^5.4.1",
         "commander": "^14.0.0",
@@ -22429,7 +22429,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -22477,7 +22477,7 @@
       }
     },
     "packages/bananass-utils-vitepress": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT"
     },
     "packages/bananass/node_modules/chalk": {
@@ -22505,10 +22505,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.1.1",
+        "bananass-utils-console": "^0.1.2",
         "commander": "^14.0.0",
         "consola": "^3.4.2",
         "is-interactive": "^2.0.0"
@@ -22549,13 +22549,13 @@
     },
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1",
+        "bananass": "^0.1.2",
         "eslint": "^9.28.0",
-        "eslint-config-bananass": "^0.1.1",
+        "eslint-config-bananass": "^0.1.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.1"
+        "prettier-config-bananass": "^0.1.2"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22563,13 +22563,13 @@
     },
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1",
+        "bananass": "^0.1.2",
         "eslint": "^9.28.0",
-        "eslint-config-bananass": "^0.1.1",
+        "eslint-config-bananass": "^0.1.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.1"
+        "prettier-config-bananass": "^0.1.2"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22593,14 +22593,14 @@
     },
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1",
+        "bananass": "^0.1.2",
         "eslint": "^9.28.0",
-        "eslint-config-bananass": "^0.1.1",
+        "eslint-config-bananass": "^0.1.2",
         "jiti": "^2.4.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.1",
+        "prettier-config-bananass": "^0.1.2",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -22609,14 +22609,14 @@
     },
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1",
+        "bananass": "^0.1.2",
         "eslint": "^9.28.0",
-        "eslint-config-bananass": "^0.1.1",
+        "eslint-config-bananass": "^0.1.2",
         "jiti": "^2.4.2",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.1.1",
+        "prettier-config-bananass": "^0.1.2",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -22632,7 +22632,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.3.3",
@@ -22686,7 +22686,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -22694,18 +22694,18 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1"
+        "bananass": "^0.1.2"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
-        "bananass": "^0.1.1",
-        "bananass-utils-console": "^0.1.1",
-        "create-bananass": "^0.1.1"
+        "bananass": "^0.1.2",
+        "bananass-utils-console": "^0.1.2",
+        "create-bananass": "^0.1.2"
       }
     },
     "website": {
@@ -22778,10 +22778,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@eslint/config-inspector": "^1.0.2",
-        "eslint-config-bananass": "^0.1.1"
+        "eslint-config-bananass": "^0.1.2"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -22795,11 +22795,11 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
-        "bananass": "^0.1.1",
-        "bananass-utils-vitepress": "^0.1.1",
+        "bananass": "^0.1.2",
+        "bananass-utils-vitepress": "^0.1.2",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -70,14 +70,14 @@
     "concurrently": "^9.1.0",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.28.0",
-    "eslint-config-bananass": "^0.1.1",
+    "eslint-config-bananass": "^0.1.2",
     "eslint-plugin-mark": "^0.1.0-canary.5",
     "husky": "^9.1.7",
     "lerna": "^8.2.2",
     "lint-staged": "^16.1.0",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.1",
+    "prettier-config-bananass": "^0.1.2",
     "shx": "^0.4.0",
     "textlint": "^14.7.2",
     "textlint-rule-allowed-uris": "^1.1.1",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass-utils-vitepress/package.json
+++ b/packages/bananass-utils-vitepress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-vitepress",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "VitePress Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -96,7 +96,7 @@
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-typescript": "^7.27.1",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.1.1",
+    "bananass-utils-console": "^0.1.2",
     "c12": "^3.0.4",
     "chalk": "^5.4.1",
     "commander": "^14.0.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -56,7 +56,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.1.1",
+    "bananass-utils-console": "^0.1.2",
     "commander": "^14.0.0",
     "consola": "^3.4.2",
     "is-interactive": "^2.0.0"

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-cjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.1.1",
+    "bananass": "^0.1.2",
     "eslint": "^9.28.0",
-    "eslint-config-bananass": "^0.1.1",
+    "eslint-config-bananass": "^0.1.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.1"
+    "prettier-config-bananass": "^0.1.2"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-esm",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.1.1",
+    "bananass": "^0.1.2",
     "eslint": "^9.28.0",
-    "eslint-config-bananass": "^0.1.1",
+    "eslint-config-bananass": "^0.1.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.1"
+    "prettier-config-bananass": "^0.1.2"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-cjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.1.1",
+    "bananass": "^0.1.2",
     "eslint": "^9.28.0",
-    "eslint-config-bananass": "^0.1.1",
+    "eslint-config-bananass": "^0.1.2",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.1",
+    "prettier-config-bananass": "^0.1.2",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-esm",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.1.1",
+    "bananass": "^0.1.2",
     "eslint": "^9.28.0",
-    "eslint-config-bananass": "^0.1.1",
+    "eslint-config-bananass": "^0.1.2",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.1.1",
+    "prettier-config-bananass": "^0.1.2",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.1"
+    "bananass": "^0.1.2"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.1",
-    "bananass-utils-console": "^0.1.1",
-    "create-bananass": "^0.1.1"
+    "bananass": "^0.1.2",
+    "bananass-utils-console": "^0.1.2",
+    "create-bananass": "^0.1.2"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.0.2",
-    "eslint-config-bananass": "^0.1.1"
+    "eslint-config-bananass": "^0.1.2"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
-    "bananass": "^0.1.1",
-    "bananass-utils-vitepress": "^0.1.1",
+    "bananass": "^0.1.2",
+    "bananass-utils-vitepress": "^0.1.2",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.2`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.1.1` to `v0.1.2` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/15485197325) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 0a7118a       |
| Old Version | `v0.1.1`  |
| New Version | `v0.1.2`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :toolbox: Chores
* chore(*): update ESLint config and dependabot by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/479
### :memo: Documentation
* docs(websites-vitepress): complete `editor-setup.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/475
* docs(websites-vitepress): update `other-useful-cli-commands.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/476
* docs(websites-vitepress): complete `other-useful-cli-commands.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/482
### :recycle: Code Refactoring
* refactor(bananass): streamline command options with new groups for better organization by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/474
### :arrow_up: Dependency Updates
* chore(deps-dev): bump textlint from 14.7.1 to 14.7.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/471
* chore(deps): bump webpack from 5.99.7 to 5.99.9 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/470
* chore(deps-dev): bump @types/node from 22.15.19 to 22.15.21 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/472
* chore(deps-dev): bump @codecov/vite-plugin from 1.9.0 to 1.9.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/477
* chore(deps): bump globals from 16.1.0 to 16.2.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/480
* chore(deps): bump the babel group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/483
* chore(deps-dev): bump @types/node from 22.15.21 to 22.15.24 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/485
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/486
* chore(deps-dev): bump lint-staged from 16.0.0 to 16.1.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/487
* chore(deps): bump the babel group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/489
* chore(deps-dev): bump @types/node from 22.15.24 to 22.15.29 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/490
* chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/492
* chore(deps): bump eslint-plugin-n from 17.18.0 to 17.19.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/491
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.5.5 to 1.6.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/498
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.1.0 to 1.1.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/500


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.1.1...v0.1.2