### PR TITLE
refactor(prettier-config-bananass): migrate type declarations to use `@import` syntax

### DIFF
--- a/packages/prettier-config-bananass/src/index.js
+++ b/packages/prettier-config-bananass/src/index.js
@@ -1,13 +1,21 @@
 /**
  * @fileoverview Entry file for the `prettier-config-bananass` package.
- * All default values are based on `prettier@3`. {@link https://prettier.io/docs/en/options}
+ * All default values are based on `prettier@3`. (https://prettier.io/docs/en/options)
+ */
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @import { Config } from 'prettier';
  */
 
 // --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
-/** @type {import("prettier").Config} */
+/** @type {Config} */
 export default {
   printWidth: 90,
   tabWidth: 2, // Default.


### PR DESCRIPTION
This pull request includes a small change to the `packages/prettier-config-bananass/src/index.js` file. The change updates the documentation comment to remove the `@link` tag and adjusts the type import for `Config` from `prettier`.