### PR TITLE
feat(eslint-config-bananass): update ES version from 2025 to 2026 in globals

### DIFF
--- a/packages/eslint-config-bananass/src/language-options.js
+++ b/packages/eslint-config-bananass/src/language-options.js
@@ -16,7 +16,7 @@ import typescriptParser from '@typescript-eslint/parser';
 export const globals = {
   ...globalsModule.browser,
   ...globalsModule.builtin,
-  ...globalsModule.es2025,
+  ...globalsModule.es2026,
   ...globalsModule.node,
   ...globalsModule.jest,
   ...globalsModule.vitest,


### PR DESCRIPTION
This pull request updates the ESLint configuration to use the latest ECMAScript version for global variables.

* [`packages/eslint-config-bananass/src/language-options.js`](diffhunk://#diff-d379aabef12bca9dbfb6a19560c38b4e14a8ab77fee9878dca8eefde57b447eaL19-R19): Updated the globals configuration to replace `es2025` with `es2026`, ensuring compatibility with the latest ECMAScript standards.