### PR TITLE
chore(release): bump package versions from `v0.1.2` to `v0.2.0` (`minor`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.2"
+    "bananass": "^0.2.0"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.2"
+    "bananass": "^0.2.0"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.2"
+    "bananass": "^0.2.0"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.1.2"
+    "bananass": "^0.2.0"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.2"
+  "version": "0.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.2.0",
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.30.1",
-        "eslint-config-bananass": "^0.1.2",
+        "eslint-config-bananass": "^0.2.0",
         "eslint-plugin-mark": "^0.1.0-canary.5",
         "husky": "^9.1.7",
         "lerna": "^8.2.3",
         "lint-staged": "^16.1.2",
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.1.2",
+        "prettier-config-bananass": "^0.2.0",
         "textlint": "^14.7.2",
         "textlint-rule-allowed-uris": "^1.1.1",
         "typescript": "^5.8.3"
@@ -39,7 +39,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.1.2"
+      "version": "0.2.0"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -51,30 +51,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2"
+        "bananass": "^0.2.0"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2"
+        "bananass": "^0.2.0"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2"
+        "bananass": "^0.2.0"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2"
+        "bananass": "^0.2.0"
       }
     },
     "examples/solutions-readline": {
@@ -84,7 +84,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.1.2"
+      "version": "0.2.0"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -93,7 +93,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.1.2"
+      "version": "0.2.0"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -22232,14 +22232,14 @@
       }
     },
     "packages/bananass": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-typescript": "^7.27.1",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.1.2",
+        "bananass-utils-console": "^0.2.0",
         "c12": "^3.0.4",
         "chalk": "^5.4.1",
         "commander": "^14.0.0",
@@ -22274,7 +22274,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -22346,10 +22346,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.1.2",
+        "bananass-utils-console": "^0.2.0",
         "commander": "^14.0.0",
         "consola": "^3.4.2",
         "is-interactive": "^2.0.0"
@@ -22390,13 +22390,13 @@
     },
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2",
+        "bananass": "^0.2.0",
         "eslint": "^9.30.1",
-        "eslint-config-bananass": "^0.1.2",
+        "eslint-config-bananass": "^0.2.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.1.2"
+        "prettier-config-bananass": "^0.2.0"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22404,13 +22404,13 @@
     },
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2",
+        "bananass": "^0.2.0",
         "eslint": "^9.30.1",
-        "eslint-config-bananass": "^0.1.2",
+        "eslint-config-bananass": "^0.2.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.1.2"
+        "prettier-config-bananass": "^0.2.0"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22434,14 +22434,14 @@
     },
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2",
+        "bananass": "^0.2.0",
         "eslint": "^9.30.1",
-        "eslint-config-bananass": "^0.1.2",
+        "eslint-config-bananass": "^0.2.0",
         "jiti": "^2.4.2",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.1.2",
+        "prettier-config-bananass": "^0.2.0",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -22450,14 +22450,14 @@
     },
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2",
+        "bananass": "^0.2.0",
         "eslint": "^9.30.1",
-        "eslint-config-bananass": "^0.1.2",
+        "eslint-config-bananass": "^0.2.0",
         "jiti": "^2.4.2",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.1.2",
+        "prettier-config-bananass": "^0.2.0",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -22473,7 +22473,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.3.5",
@@ -22527,7 +22527,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -22535,18 +22535,18 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2"
+        "bananass": "^0.2.0"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
-        "bananass": "^0.1.2",
-        "bananass-utils-console": "^0.1.2",
-        "create-bananass": "^0.1.2"
+        "bananass": "^0.2.0",
+        "bananass-utils-console": "^0.2.0",
+        "create-bananass": "^0.2.0"
       }
     },
     "website": {
@@ -22619,10 +22619,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
         "@eslint/config-inspector": "^1.1.0",
-        "eslint-config-bananass": "^0.1.2"
+        "eslint-config-bananass": "^0.2.0"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -22636,10 +22636,10 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
-        "bananass": "^0.1.2",
+        "bananass": "^0.2.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -68,14 +68,14 @@
     "concurrently": "^9.2.0",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.30.1",
-    "eslint-config-bananass": "^0.1.2",
+    "eslint-config-bananass": "^0.2.0",
     "eslint-plugin-mark": "^0.1.0-canary.5",
     "husky": "^9.1.7",
     "lerna": "^8.2.3",
     "lint-staged": "^16.1.2",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.1.2",
+    "prettier-config-bananass": "^0.2.0",
     "textlint": "^14.7.2",
     "textlint-rule-allowed-uris": "^1.1.1",
     "typescript": "^5.8.3"

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -96,7 +96,7 @@
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-typescript": "^7.27.1",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.1.2",
+    "bananass-utils-console": "^0.2.0",
     "c12": "^3.0.4",
     "chalk": "^5.4.1",
     "commander": "^14.0.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -56,7 +56,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.1.2",
+    "bananass-utils-console": "^0.2.0",
     "commander": "^14.0.0",
     "consola": "^3.4.2",
     "is-interactive": "^2.0.0"

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-cjs",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.1.2",
+    "bananass": "^0.2.0",
     "eslint": "^9.30.1",
-    "eslint-config-bananass": "^0.1.2",
+    "eslint-config-bananass": "^0.2.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.1.2"
+    "prettier-config-bananass": "^0.2.0"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-esm",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.1.2",
+    "bananass": "^0.2.0",
     "eslint": "^9.30.1",
-    "eslint-config-bananass": "^0.1.2",
+    "eslint-config-bananass": "^0.2.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.1.2"
+    "prettier-config-bananass": "^0.2.0"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-cjs",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.1.2",
+    "bananass": "^0.2.0",
     "eslint": "^9.30.1",
-    "eslint-config-bananass": "^0.1.2",
+    "eslint-config-bananass": "^0.2.0",
     "jiti": "^2.4.2",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.1.2",
+    "prettier-config-bananass": "^0.2.0",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-esm",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.1.2",
+    "bananass": "^0.2.0",
     "eslint": "^9.30.1",
-    "eslint-config-bananass": "^0.1.2",
+    "eslint-config-bananass": "^0.2.0",
     "jiti": "^2.4.2",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.1.2",
+    "prettier-config-bananass": "^0.2.0",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.2"
+    "bananass": "^0.2.0"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.1.2",
-    "bananass-utils-console": "^0.1.2",
-    "create-bananass": "^0.1.2"
+    "bananass": "^0.2.0",
+    "bananass-utils-console": "^0.2.0",
+    "create-bananass": "^0.2.0"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.1.0",
-    "eslint-config-bananass": "^0.1.2"
+    "eslint-config-bananass": "^0.2.0"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
-    "bananass": "^0.1.2",
+    "bananass": "^0.2.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.2.0`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.1.2` to `v0.2.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/16164614874) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | 92a01a0       |
| Old Version | `v0.1.2`  |
| New Version | `v0.2.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* refactor(bananass)!: rename `secretMode` option to `secret` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/507
* refactor(*)!: remove `bananass-utils-vitepress` package by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/555
### :sparkles: Features
* feat(eslint-config-bananass): update ES version from 2025 to 2026 in globals by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/567
### :hammer_and_wrench: Builds
* build(*): create `cp.mjs` script for file copying and drop `shx` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/503
### :toolbox: Chores
* chore(*): run `npm dedupe` for cleanup by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/504
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/539
* chore(*): move `FUNDING.yml` to `.github` repository by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/568
### :memo: Documentation
* docs(websites-vitepress): complete `writing-bananass-config-file.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/488
### :recycle: Code Refactoring
* refactor(bananass): migrate type decalrations to use `@import` syntax by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/556
* refactor(prettier-config-bananass): migrate type declarations to use `@import` syntax by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/564
### :arrow_up: Dependency Updates
* chore(deps-dev): bump @eslint/config-inspector from 1.0.2 to 1.1.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/505
* chore(deps-dev): bump @types/node from 22.15.29 to 24.0.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/509
* chore(deps): bump eslint-plugin-n from 17.19.0 to 17.20.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/512
* chore(deps-dev): bump @types/node from 24.0.0 to 24.0.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/511
* chore(deps-dev): bump eslint from 9.28.0 to 9.29.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/515
* chore(deps-dev): bump lint-staged from 16.1.0 to 16.1.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/514
* chore(deps-dev): bump @types/node from 24.0.1 to 24.0.3 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/520
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/521
* chore(deps-dev): bump concurrently from 9.1.2 to 9.2.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/522
* chore(deps): bump eslint-plugin-import from 2.31.0 to 2.32.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/523
* chore(deps-dev): bump prettier from 3.5.3 to 3.6.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/525
* chore(deps): bump enhanced-resolve from 5.18.1 to 5.18.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/530
* chore(deps-dev): bump prettier from 3.6.0 to 3.6.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/533
* chore(deps): bump the babel group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/538
* chore(deps-dev): bump eslint from 9.29.0 to 9.30.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/540
* chore(deps-dev): bump @types/node from 24.0.3 to 24.0.7 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/541
* chore(deps-dev): bump lerna from 8.2.2 to 8.2.3 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/547
* chore(deps-dev): bump prettier from 3.6.1 to 3.6.2 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/546
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.6.0 to 1.6.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/552
* chore(deps): bump globals from 16.2.0 to 16.3.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/558
* chore(deps-dev): bump eslint from 9.30.0 to 9.30.1 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/557
* chore(deps): bump the babel group across 2 directories with 2 updates by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/565
* chore(deps-dev): bump @types/node from 24.0.7 to 24.0.10 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/566
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/570
* chore(deps): bump eslint-plugin-n from 17.20.0 to 17.21.0 by @dependabot in https://github.com/lumirlumir/npm-bananass/pull/569


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.1.2...v0.2.0