### PR TITLE
build(create-bananass): update build script to include TypeScript compilation

### DIFF
--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "node ../../scripts/cp.mjs ../../LICENSE.md LICENSE.md ../../README.md README.md",
+    "build": "npx tsc --noEmit && node ../../scripts/cp.mjs ../../LICENSE.md LICENSE.md ../../README.md README.md",
     "test": "node --test",
     "dev": "node src/cli.js"
   },


### PR DESCRIPTION
This pull request includes a small update to the `build` script in the `packages/create-bananass/package.json` file. The change adds a TypeScript type-checking step (`npx tsc --noEmit`) before running the existing file copy commands.