### PR TITLE
fix(eslint-config-bananass): support `mjs` and `cjs` extensions for `import/no-extraneous-dependencies`

### DIFF
--- a/packages/eslint-config-bananass/src/rules/import/import-helpful-warnings.js
+++ b/packages/eslint-config-bananass/src/rules/import/import-helpful-warnings.js
@@ -59,8 +59,8 @@ export default {
         '**/jest.config.js', // jest config
         '**/jest.setup.js', // jest setup
         '**/vue.config.js', // vue-cli config
-        '**/webpack.config.js', // webpack config
-        '**/webpack.config.*.js', // webpack config
+        '**/webpack.config.{js,mjs,cjs}', // webpack config
+        '**/webpack.config.*.{js,mjs,cjs}', // webpack config
         '**/rollup.config.js', // rollup config
         '**/rollup.config.*.js', // rollup config
         '**/gulpfile.js', // gulp config


### PR DESCRIPTION
This pull request updates the ESLint configuration to enhance compatibility with different module formats in Webpack configuration files.

### ESLint configuration updates:

* [`packages/eslint-config-bananass/src/rules/import/import-helpful-warnings.js`](diffhunk://#diff-7c38ccec1938f29a081e55a03c2c7857543c24f815351ea839ed9aa58a76be5dL62-R63): Modified the patterns for matching Webpack configuration files to include `mjs` and `cjs` module formats, ensuring broader support for modern JavaScript module types.