### PR TITLE
chore(release): bump package versions from `v0.2.0` to `v0.3.0` (`minor`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.2.0"
+    "bananass": "^0.3.0"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.2.0"
+    "bananass": "^0.3.0"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.2.0"
+    "bananass": "^0.3.0"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.2.0"
+    "bananass": "^0.3.0"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.2.0",
         "editorconfig-checker": "^6.1.0",
         "eslint": "^9.31.0",
-        "eslint-config-bananass": "^0.2.0",
+        "eslint-config-bananass": "^0.3.0",
         "eslint-plugin-mark": "^0.1.0-canary.5",
         "husky": "^9.1.7",
         "lerna": "^8.2.3",
         "lint-staged": "^16.1.2",
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.2.0",
+        "prettier-config-bananass": "^0.3.0",
         "textlint": "^14.7.2",
         "textlint-rule-allowed-uris": "^1.1.1",
         "typescript": "^5.8.3"
@@ -39,7 +39,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -51,30 +51,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0"
+        "bananass": "^0.3.0"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0"
+        "bananass": "^0.3.0"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0"
+        "bananass": "^0.3.0"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0"
+        "bananass": "^0.3.0"
       }
     },
     "examples/solutions-readline": {
@@ -84,7 +84,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -93,7 +93,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -22115,14 +22115,14 @@
       }
     },
     "packages/bananass": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-typescript": "^7.27.1",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.2.0",
+        "bananass-utils-console": "^0.3.0",
         "chalk": "^5.4.1",
         "commander": "^14.0.0",
         "defu": "^6.1.4",
@@ -22157,7 +22157,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -22229,10 +22229,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.2.0",
+        "bananass-utils-console": "^0.3.0",
         "commander": "^14.0.0",
         "consola": "^3.4.2",
         "is-interactive": "^2.0.0"
@@ -22273,13 +22273,13 @@
     },
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0",
+        "bananass": "^0.3.0",
         "eslint": "^9.31.0",
-        "eslint-config-bananass": "^0.2.0",
+        "eslint-config-bananass": "^0.3.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.2.0"
+        "prettier-config-bananass": "^0.3.0"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22287,13 +22287,13 @@
     },
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0",
+        "bananass": "^0.3.0",
         "eslint": "^9.31.0",
-        "eslint-config-bananass": "^0.2.0",
+        "eslint-config-bananass": "^0.3.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.2.0"
+        "prettier-config-bananass": "^0.3.0"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22317,14 +22317,14 @@
     },
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0",
+        "bananass": "^0.3.0",
         "eslint": "^9.31.0",
-        "eslint-config-bananass": "^0.2.0",
+        "eslint-config-bananass": "^0.3.0",
         "jiti": "^2.5.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.2.0",
+        "prettier-config-bananass": "^0.3.0",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -22333,14 +22333,14 @@
     },
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0",
+        "bananass": "^0.3.0",
         "eslint": "^9.31.0",
-        "eslint-config-bananass": "^0.2.0",
+        "eslint-config-bananass": "^0.3.0",
         "jiti": "^2.5.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.2.0",
+        "prettier-config-bananass": "^0.3.0",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -22356,7 +22356,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.4.3",
@@ -22410,7 +22410,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -22418,18 +22418,18 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0"
+        "bananass": "^0.3.0"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
-        "bananass": "^0.2.0",
-        "bananass-utils-console": "^0.2.0",
-        "create-bananass": "^0.2.0"
+        "bananass": "^0.3.0",
+        "bananass-utils-console": "^0.3.0",
+        "create-bananass": "^0.3.0"
       }
     },
     "website": {
@@ -22502,10 +22502,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@eslint/config-inspector": "^1.1.0",
-        "eslint-config-bananass": "^0.2.0"
+        "eslint-config-bananass": "^0.3.0"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -22519,10 +22519,10 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
-        "bananass": "^0.2.0",
+        "bananass": "^0.3.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -68,14 +68,14 @@
     "concurrently": "^9.2.0",
     "editorconfig-checker": "^6.1.0",
     "eslint": "^9.31.0",
-    "eslint-config-bananass": "^0.2.0",
+    "eslint-config-bananass": "^0.3.0",
     "eslint-plugin-mark": "^0.1.0-canary.5",
     "husky": "^9.1.7",
     "lerna": "^8.2.3",
     "lint-staged": "^16.1.2",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.2.0",
+    "prettier-config-bananass": "^0.3.0",
     "textlint": "^14.7.2",
     "textlint-rule-allowed-uris": "^1.1.1",
     "typescript": "^5.8.3"

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -96,7 +96,7 @@
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-typescript": "^7.27.1",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.2.0",
+    "bananass-utils-console": "^0.3.0",
     "chalk": "^5.4.1",
     "commander": "^14.0.0",
     "defu": "^6.1.4",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -56,7 +56,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.2.0",
+    "bananass-utils-console": "^0.3.0",
     "commander": "^14.0.0",
     "consola": "^3.4.2",
     "is-interactive": "^2.0.0"

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-cjs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.2.0",
+    "bananass": "^0.3.0",
     "eslint": "^9.31.0",
-    "eslint-config-bananass": "^0.2.0",
+    "eslint-config-bananass": "^0.3.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.2.0"
+    "prettier-config-bananass": "^0.3.0"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-esm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.2.0",
+    "bananass": "^0.3.0",
     "eslint": "^9.31.0",
-    "eslint-config-bananass": "^0.2.0",
+    "eslint-config-bananass": "^0.3.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.2.0"
+    "prettier-config-bananass": "^0.3.0"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-cjs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.2.0",
+    "bananass": "^0.3.0",
     "eslint": "^9.31.0",
-    "eslint-config-bananass": "^0.2.0",
+    "eslint-config-bananass": "^0.3.0",
     "jiti": "^2.5.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.2.0",
+    "prettier-config-bananass": "^0.3.0",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-esm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.2.0",
+    "bananass": "^0.3.0",
     "eslint": "^9.31.0",
-    "eslint-config-bananass": "^0.2.0",
+    "eslint-config-bananass": "^0.3.0",
     "jiti": "^2.5.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.2.0",
+    "prettier-config-bananass": "^0.3.0",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.2.0"
+    "bananass": "^0.3.0"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.2.0",
-    "bananass-utils-console": "^0.2.0",
-    "create-bananass": "^0.2.0"
+    "bananass": "^0.3.0",
+    "bananass-utils-console": "^0.3.0",
+    "create-bananass": "^0.3.0"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.1.0",
-    "eslint-config-bananass": "^0.2.0"
+    "eslint-config-bananass": "^0.3.0"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
-    "bananass": "^0.2.0",
+    "bananass": "^0.3.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.3.0`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.2.0` to `v0.3.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/16492674688) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | 69ed928       |
| Old Version | `v0.2.0`  |
| New Version | `v0.3.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(bananass): add support for `brave` browser to cli commands by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/589
### :bug: Bug Fixes
* fix(eslint-config-bananass): support `mjs` and `cjs` extensions for `import/no-extraneous-dependencies` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/600
### :hammer_and_wrench: Builds
* build(create-bananass): update build script to include TypeScript compilation by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/590
### :memo: Documentation
* docs(*): remove `PULL_REQUEST_TEMPLATE.md` in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/588
* docs(*): complete `project-structure.md` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/510
### :recycle: Code Refactoring
* refactor(bananass): reduce dependency by removing `c12` and migrating to `defu` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/593
* refactor(bananass): replace `import.meta.url` with `import.meta.dirname` for cleaner path resolution by @Copilot in https://github.com/lumirlumir/npm-bananass/pull/595
### :arrow_up: Dependency Updates
* chore(deps-dev): bump @types/node from 24.0.10 to 24.0.12 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/572
* chore(deps): bump webpack from 5.99.9 to 5.100.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/574
* chore(deps): bump c12 from 3.0.4 to 3.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/577
* chore(deps-dev): bump eslint from 9.30.1 to 9.31.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/578
* chore(deps): bump webpack from 5.100.0 to 5.100.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/585
* chore(deps): bump open from 10.1.2 to 10.2.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/586
* chore(deps): bump webpack from 5.100.1 to 5.100.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/591
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/594
* chore(deps-dev): bump editorconfig-checker from 6.0.1 to 6.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/596
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/599
* chore(deps-dev): bump form-data from 4.0.1 to 4.0.4 in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/598
* chore(deps): bump jiti from 2.4.2 to 2.5.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/602

## New Contributors
* @Copilot made their first contribution in https://github.com/lumirlumir/npm-bananass/pull/595

**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.2.0...v0.3.0