### PR TITLE
ci(*): update node version matrix in `test-cross-platform` workflow

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -24,8 +24,10 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 24.0.0
+          - 24.x
+          - 22.x
           - 22.3.0
+          - 20.x
           - 20.18.0
 
     runs-on: ${{ matrix.runner-image }}


### PR DESCRIPTION
This pull request updates the Node.js versions tested in the cross-platform workflow to ensure compatibility with a broader range of versions.

* [`.github/workflows/test-cross-platform.yml`](diffhunk://#diff-290907d9a4bcf13181105b134bd1645da5a3ef27c54f148ad5823e6b77e88426L27-R30): Modified the `node-version` matrix to include version ranges (`24.x`, `22.x`, `20.x`) instead of specific patch versions, providing better coverage for testing against multiple Node.js versions.