### PR TITLE
fix(bananass): drop `esbuild-loader` and reduce package size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -791,21 +791,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
@@ -1580,12 +1565,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
-      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-create-class-features-plugin": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
@@ -1768,25 +1753,6 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/preset-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
-      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-        "@babel/plugin-transform-typescript": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -1946,6 +1912,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1962,6 +1929,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1978,6 +1946,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1994,6 +1963,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2010,6 +1980,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2026,6 +1997,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2042,6 +2014,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2058,6 +2031,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2074,6 +2048,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2090,6 +2065,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2106,6 +2082,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2122,6 +2099,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2138,6 +2116,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2154,6 +2133,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2170,6 +2150,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2186,6 +2167,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2202,6 +2184,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2218,6 +2201,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2234,6 +2218,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2250,6 +2235,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2266,6 +2252,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2282,6 +2269,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2298,6 +2286,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2314,6 +2303,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2330,6 +2320,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2346,6 +2337,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6846,15 +6838,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/bin-links": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-4.0.4.tgz",
@@ -8822,15 +8805,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -9164,6 +9138,7 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
       "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9199,34 +9174,6 @@
         "@esbuild/win32-arm64": "0.25.8",
         "@esbuild/win32-ia32": "0.25.8",
         "@esbuild/win32-x64": "0.25.8"
-      }
-    },
-    "node_modules/esbuild-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esbuild-loader/-/esbuild-loader-4.3.0.tgz",
-      "integrity": "sha512-D7HeJNdkDKKMarPQO/3dlJT6RwN2YJO7ENU6RPlpOz5YxSHnUNi2yvW41Bckvi1EVwctIaLzlb0ni5ag2GINYA==",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "get-tsconfig": "^4.7.0",
-        "loader-utils": "^2.0.4",
-        "webpack-sources": "^1.4.3"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/esbuild-loader?sponsor=1"
-      },
-      "peerDependencies": {
-        "webpack": "^4.40.0 || ^5.0.0"
-      }
-    },
-    "node_modules/esbuild-loader/node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/escalade": {
@@ -13234,20 +13181,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
-      }
-    },
-    "node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/local-pkg": {
@@ -18554,12 +18487,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/source-list-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-      "license": "MIT"
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -21456,8 +21383,9 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.0",
         "@babel/preset-env": "^7.28.0",
-        "@babel/preset-typescript": "^7.27.1",
         "babel-loader": "^10.0.0",
         "bananass-utils-console": "^0.3.0",
         "chalk": "^5.4.1",
@@ -21465,7 +21393,6 @@
         "defu": "^6.1.4",
         "enhanced-resolve": "^5.18.2",
         "envinfo": "^7.14.0",
-        "esbuild-loader": "^4.3.0",
         "jiti": "^2.5.1",
         "open": "^10.2.0",
         "superstruct": "^2.0.2",

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -93,8 +93,9 @@
   },
   "dependencies": {
     "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+    "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
-    "@babel/preset-typescript": "^7.27.1",
     "babel-loader": "^10.0.0",
     "bananass-utils-console": "^0.3.0",
     "chalk": "^5.4.1",
@@ -102,7 +103,6 @@
     "defu": "^6.1.4",
     "enhanced-resolve": "^5.18.2",
     "envinfo": "^7.14.0",
-    "esbuild-loader": "^4.3.0",
     "jiti": "^2.5.1",
     "open": "^10.2.0",
     "superstruct": "^2.0.2",

--- a/packages/bananass/src/core/cli/descriptions.js
+++ b/packages/bananass/src/core/cli/descriptions.js
@@ -15,7 +15,7 @@ import { defaultConfigObject as dco } from '../conf/index.js';
 /** @type {string} */
 export const bug = 'open the github issues in a browser';
 /** @type {string} */
-export const build = `build and create bundled files using webpack, babel and esbuild from the \`${dco.entryDir}\` directory and outputs them to the \`${dco.outDir}\` directory`;
+export const build = `build and create bundled files using webpack and babel from the \`${dco.entryDir}\` directory and outputs them to the \`${dco.outDir}\` directory`;
 /** @type {string} */
 export const discussion = 'open the github discussions in a browser';
 /** @type {string} */

--- a/websites/vitepress/ko/learn/other-useful-cli-commands.md
+++ b/websites/vitepress/ko/learn/other-useful-cli-commands.md
@@ -81,7 +81,7 @@ npx bananass bug [options]
 
 > 별칭: 없음
 
-[웹팩<sup>Webpack</sup>](https://webpack.js.org/), [바벨<sup>Babel</sup>](https://babeljs.io/)을 사용하여, `bananass` 폴더에 존재하는 문제 풀이 파일들을 `.bananass` 폴더에 번들링하여 빌드합니다.
+[웹팩<sup>Webpack</sup>](https://webpack.js.org/) 및 [바벨<sup>Babel</sup>](https://babeljs.io/)을 사용하여, `bananass` 폴더에 존재하는 문제 풀이 파일들을 `.bananass` 폴더에 번들링하여 빌드합니다.
 
 ### 사용 예시 {#build-example}
 

--- a/websites/vitepress/ko/learn/other-useful-cli-commands.md
+++ b/websites/vitepress/ko/learn/other-useful-cli-commands.md
@@ -81,7 +81,7 @@ npx bananass bug [options]
 
 > 별칭: 없음
 
-[웹팩<sup>Webpack</sup>](https://webpack.js.org/), [바벨<sup>Babel</sup>](https://babeljs.io/), [ESBuild](https://esbuild.github.io/)를 사용하여, `bananass` 폴더에 존재하는 문제 풀이 파일들을 `.bananass` 폴더에 번들링하여 빌드합니다.
+[웹팩<sup>Webpack</sup>](https://webpack.js.org/), [바벨<sup>Babel</sup>](https://babeljs.io/)을 사용하여, `bananass` 폴더에 존재하는 문제 풀이 파일들을 `.bananass` 폴더에 번들링하여 빌드합니다.
 
 ### 사용 예시 {#build-example}
 


### PR DESCRIPTION
This pull request updates the build process for the `bananass` package by removing `esbuild` and refining Babel configurations. The changes primarily focus on transitioning TypeScript transpilation to Babel plugins, improving compatibility with CommonJS modules, and updating documentation and descriptions to reflect these modifications.

### Build process updates:

* [`packages/bananass/package.json`](diffhunk://#diff-e74f46a7c449d500fc71c84c894fd8e911cf9fe4e54157b741ff6f9cbf357432R96-L105): Removed `esbuild-loader` and replaced `@babel/preset-typescript` with `@babel/plugin-transform-typescript` and `@babel/plugin-transform-modules-commonjs` for more granular control over TypeScript transpilation.
* [`packages/bananass/src/commands/bananass-build/build.js`](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4L49-R53): Updated the `babelLoaderConfig` function to accept `babelPlugins` and `sourceType`, removed `babelPresets` parameter, and added detailed comments explaining the motivation behind TypeScript setups. [[1]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4L49-R53) [[2]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4L64-R76) [[3]](diffhunk://#diff-5b3f690c580caae1e82d3789dd6e78d9b694ac24acc51e672b297b524521fda4R184-R229)

### Documentation updates:

* [`packages/bananass/src/core/cli/descriptions.js`](diffhunk://#diff-4779ca37913f14f5aec15ce530617d866fc03de73d6a32a61264fbc8bdef8a77L18-R18): Updated the `build` command description to remove references to `esbuild`.
* [`websites/vitepress/ko/learn/other-useful-cli-commands.md`](diffhunk://#diff-91f4adf76df66a2d7ca53d94359d33cc81580d4aaad1940b255c00c63d6711d9L84-R84): Revised the CLI documentation to reflect the removal of `esbuild` from the build process.