### PR TITLE
chore(release): bump package versions from `v0.3.0` to `v0.3.1` (`patch`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.3.0"
+    "bananass": "^0.3.1"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.3.0"
+    "bananass": "^0.3.1"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.3.0"
+    "bananass": "^0.3.1"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.3.0"
+    "bananass": "^0.3.1"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.3.0"
+  "version": "0.3.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.2.0",
         "editorconfig-checker": "^6.1.0",
         "eslint": "^9.32.0",
-        "eslint-config-bananass": "^0.3.0",
+        "eslint-config-bananass": "^0.3.1",
         "eslint-plugin-mark": "^0.1.0-canary.5",
         "husky": "^9.1.7",
         "lerna": "^8.2.3",
         "lint-staged": "^16.1.2",
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.3.0",
+        "prettier-config-bananass": "^0.3.1",
         "textlint": "^14.7.2",
         "textlint-rule-allowed-uris": "^2.0.0",
         "typescript": "^5.8.3"
@@ -39,7 +39,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -51,30 +51,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0"
+        "bananass": "^0.3.1"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0"
+        "bananass": "^0.3.1"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0"
+        "bananass": "^0.3.1"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0"
+        "bananass": "^0.3.1"
       }
     },
     "examples/solutions-readline": {
@@ -84,7 +84,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -93,7 +93,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -21379,7 +21379,7 @@
       }
     },
     "packages/bananass": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -21387,7 +21387,7 @@
         "@babel/plugin-transform-typescript": "^7.28.0",
         "@babel/preset-env": "^7.28.0",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.3.0",
+        "bananass-utils-console": "^0.3.1",
         "chalk": "^5.4.1",
         "commander": "^14.0.0",
         "defu": "^6.1.4",
@@ -21422,7 +21422,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -21481,10 +21481,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.3.0",
+        "bananass-utils-console": "^0.3.1",
         "commander": "^14.0.0",
         "consola": "^3.4.2"
       },
@@ -21512,13 +21512,13 @@
     },
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0",
+        "bananass": "^0.3.1",
         "eslint": "^9.32.0",
-        "eslint-config-bananass": "^0.3.0",
+        "eslint-config-bananass": "^0.3.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.3.0"
+        "prettier-config-bananass": "^0.3.1"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -21526,13 +21526,13 @@
     },
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0",
+        "bananass": "^0.3.1",
         "eslint": "^9.32.0",
-        "eslint-config-bananass": "^0.3.0",
+        "eslint-config-bananass": "^0.3.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.3.0"
+        "prettier-config-bananass": "^0.3.1"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -21556,14 +21556,14 @@
     },
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0",
+        "bananass": "^0.3.1",
         "eslint": "^9.32.0",
-        "eslint-config-bananass": "^0.3.0",
+        "eslint-config-bananass": "^0.3.1",
         "jiti": "^2.5.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.3.0",
+        "prettier-config-bananass": "^0.3.1",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -21572,14 +21572,14 @@
     },
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0",
+        "bananass": "^0.3.1",
         "eslint": "^9.32.0",
-        "eslint-config-bananass": "^0.3.0",
+        "eslint-config-bananass": "^0.3.1",
         "jiti": "^2.5.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.3.0",
+        "prettier-config-bananass": "^0.3.1",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -21595,7 +21595,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.4.5",
@@ -21652,7 +21652,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -21660,18 +21660,18 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0"
+        "bananass": "^0.3.1"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
-        "bananass": "^0.3.0",
-        "bananass-utils-console": "^0.3.0",
-        "create-bananass": "^0.3.0"
+        "bananass": "^0.3.1",
+        "bananass-utils-console": "^0.3.1",
+        "create-bananass": "^0.3.1"
       }
     },
     "website": {
@@ -21744,10 +21744,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@eslint/config-inspector": "^1.1.0",
-        "eslint-config-bananass": "^0.3.0"
+        "eslint-config-bananass": "^0.3.1"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -21761,10 +21761,10 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
-        "bananass": "^0.3.0",
+        "bananass": "^0.3.1",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^2.0.0-alpha.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -68,14 +68,14 @@
     "concurrently": "^9.2.0",
     "editorconfig-checker": "^6.1.0",
     "eslint": "^9.32.0",
-    "eslint-config-bananass": "^0.3.0",
+    "eslint-config-bananass": "^0.3.1",
     "eslint-plugin-mark": "^0.1.0-canary.5",
     "husky": "^9.1.7",
     "lerna": "^8.2.3",
     "lint-staged": "^16.1.2",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.3.0",
+    "prettier-config-bananass": "^0.3.1",
     "textlint": "^14.7.2",
     "textlint-rule-allowed-uris": "^2.0.0",
     "typescript": "^5.8.3"

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -97,7 +97,7 @@
     "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.3.0",
+    "bananass-utils-console": "^0.3.1",
     "chalk": "^5.4.1",
     "commander": "^14.0.0",
     "defu": "^6.1.4",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -56,7 +56,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.3.0",
+    "bananass-utils-console": "^0.3.1",
     "commander": "^14.0.0",
     "consola": "^3.4.2"
   }

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-cjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.3.0",
+    "bananass": "^0.3.1",
     "eslint": "^9.32.0",
-    "eslint-config-bananass": "^0.3.0",
+    "eslint-config-bananass": "^0.3.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.3.0"
+    "prettier-config-bananass": "^0.3.1"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-esm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.3.0",
+    "bananass": "^0.3.1",
     "eslint": "^9.32.0",
-    "eslint-config-bananass": "^0.3.0",
+    "eslint-config-bananass": "^0.3.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.3.0"
+    "prettier-config-bananass": "^0.3.1"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-cjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.3.0",
+    "bananass": "^0.3.1",
     "eslint": "^9.32.0",
-    "eslint-config-bananass": "^0.3.0",
+    "eslint-config-bananass": "^0.3.1",
     "jiti": "^2.5.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.3.0",
+    "prettier-config-bananass": "^0.3.1",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-esm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.3.0",
+    "bananass": "^0.3.1",
     "eslint": "^9.32.0",
-    "eslint-config-bananass": "^0.3.0",
+    "eslint-config-bananass": "^0.3.1",
     "jiti": "^2.5.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.3.0",
+    "prettier-config-bananass": "^0.3.1",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.3.0"
+    "bananass": "^0.3.1"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.3.0",
-    "bananass-utils-console": "^0.3.0",
-    "create-bananass": "^0.3.0"
+    "bananass": "^0.3.1",
+    "bananass-utils-console": "^0.3.1",
+    "create-bananass": "^0.3.1"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.1.0",
-    "eslint-config-bananass": "^0.3.0"
+    "eslint-config-bananass": "^0.3.1"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
-    "bananass": "^0.3.0",
+    "bananass": "^0.3.1",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^2.0.0-alpha.9",


### PR DESCRIPTION
## Release Information: `v0.3.1`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.3.0` to `v0.3.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/16691723848) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 7c53c0f       |
| Old Version | `v0.3.0`  |
| New Version | `v0.3.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(bananass-utils-console): internalize `is-interactive` to reduce dependencies by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/630
* fix(bananass): drop `esbuild-loader` and reduce package size by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/631
### :toolbox: Chores
* chore(sync-server): update `tsconfig.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/612
* chore(*): bump `vitepress` and `textlint-rule-allowed-uris` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/619
* chore(*): remove `ISSUE_TEMPLATE` in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/626
### :arrows_counterclockwise: Continuous Integrations
* ci(*): update node version matrix in `test-cross-platform` workflow by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/620
### :arrow_up: Dependency Updates
* chore(deps): bump jiti from 2.5.0 to 2.5.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/608
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/607
* chore(deps-dev): bump eslint from 9.31.0 to 9.32.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/613
* chore(deps-dev): update eslint requirement from ^9.31.0 to ^9.32.0 in /packages/create-bananass/templates/javascript-esm by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/617
* chore(deps): bump eslint-plugin-n from 17.21.0 to 17.21.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/621
* chore(deps): bump webpack from 5.100.2 to 5.101.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/622
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/625


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.3.0...v0.3.1