### PR TITLE
feat(eslint-config-bananass): add globals for Web Speech API

### DIFF
--- a/packages/eslint-config-bananass/src/language-options.js
+++ b/packages/eslint-config-bananass/src/language-options.js
@@ -21,6 +21,21 @@ export const globals = {
   ...globalsModule.jest,
   ...globalsModule.vitest,
   ...globalsModule.mocha,
+  // Browser Web Speech APIs: https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
+  SpeechGrammar: false,
+  SpeechGrammarList: false,
+  SpeechRecognition: false,
+  SpeechRecognitionAlternative: false,
+  SpeechRecognitionErrorEvent: false,
+  SpeechRecognitionEvent: false,
+  SpeechRecognitionResult: false,
+  SpeechRecognitionResultList: false,
+  speechSynthesis: false,
+  SpeechSynthesis: false,
+  SpeechSynthesisErrorEvent: false,
+  SpeechSynthesisEvent: false,
+  SpeechSynthesisUtterance: false,
+  SpeechSynthesisVoice: false,
 };
 
 export const parser = typescriptParser;

--- a/packages/eslint-config-bananass/src/language-options.js
+++ b/packages/eslint-config-bananass/src/language-options.js
@@ -24,6 +24,7 @@ export const globals = {
   // Browser Web Speech APIs: https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
   SpeechGrammar: false,
   SpeechGrammarList: false,
+  webkitSpeechRecognition: false,
   SpeechRecognition: false,
   SpeechRecognitionAlternative: false,
   SpeechRecognitionErrorEvent: false,


### PR DESCRIPTION
This pull request adds support for browser Web Speech API globals to the ESLint configuration. This ensures that references to these APIs in code will not be flagged as undefined by ESLint.

**ESLint configuration updates:**

* Added the following Web Speech API globals to the `globals` object in `language-options.js`: `SpeechGrammar`, `SpeechGrammarList`, `SpeechRecognition`, `SpeechRecognitionAlternative`, `SpeechRecognitionErrorEvent`, `SpeechRecognitionEvent`, `SpeechRecognitionResult`, `SpeechRecognitionResultList`, `speechSynthesis`, `SpeechSynthesis`, `SpeechSynthesisErrorEvent`, `SpeechSynthesisEvent`, `SpeechSynthesisUtterance`, and `SpeechSynthesisVoice`.