### PR TITLE
fix(bananass-utils-console): internalize `is-unicode-supported` to reduce dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3610,11 +3610,14 @@
       }
     },
     "node_modules/@lerna/create/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -12841,11 +12844,14 @@
       }
     },
     "node_modules/lerna/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -19500,11 +19506,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -20435,12 +20444,15 @@
       }
     },
     "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -20527,11 +20539,14 @@
       }
     },
     "node_modules/vitepress/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -20555,9 +20570,9 @@
       }
     },
     "node_modules/vitepress/node_modules/vite": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.1.tgz",
-      "integrity": "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.2.tgz",
+      "integrity": "sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21321,23 +21336,10 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.5.0",
-        "is-unicode-supported": "^2.1.0"
+        "chalk": "^5.5.0"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
-      }
-    },
-    "packages/bananass-utils-console/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/bananass/node_modules/envinfo": {

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -12,6 +12,10 @@
       "types": "./build/is-interactive/index.d.ts",
       "default": "./src/is-interactive/index.js"
     },
+    "./is-unicode-supported": {
+      "types": "./build/is-unicode-supported/index.d.ts",
+      "default": "./src/is-unicode-supported/index.js"
+    },
     "./logger": {
       "types": "./build/logger/index.d.ts",
       "default": "./src/logger/index.js"
@@ -36,6 +40,9 @@
       ],
       "is-interactive": [
         "./build/is-interactive/index.d.ts"
+      ],
+      "is-unicode-supported": [
+        "./build/is-unicode-supported/index.d.ts"
       ],
       "logger": [
         "./build/logger/index.d.ts"
@@ -92,7 +99,6 @@
     "test": "node --test"
   },
   "dependencies": {
-    "chalk": "^5.5.0",
-    "is-unicode-supported": "^2.1.0"
+    "chalk": "^5.5.0"
   }
 }

--- a/packages/bananass-utils-console/src/icons/icons.js
+++ b/packages/bananass-utils-console/src/icons/icons.js
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import c from 'chalk';
-import isUnicodeSupported from 'is-unicode-supported';
+import isUnicodeSupported from '../is-unicode-supported/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedef

--- a/packages/bananass-utils-console/src/is-unicode-supported/index.js
+++ b/packages/bananass-utils-console/src/is-unicode-supported/index.js
@@ -1,0 +1,3 @@
+import isUnicodeSupported from './is-unicode-supported.js';
+
+export default isUnicodeSupported;

--- a/packages/bananass-utils-console/src/is-unicode-supported/is-unicode-supported.js
+++ b/packages/bananass-utils-console/src/is-unicode-supported/is-unicode-supported.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Detect whether the terminal supports Unicode.
+ * @module bananass-utils-console/is-unicode-supported
+ * @license MIT Portions of this code were borrowed from [`is-unicode-supported`](https://github.com/sindresorhus/is-unicode-supported).
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import process from 'node:process';
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Detect whether the terminal supports Unicode.
+ *
+ * This can be useful to decide whether to use Unicode characters or
+ * fallback ASCII characters in command-line output.
+ *
+ * Note that the check is quite naive.
+ * It just assumes all non-Windows terminals support Unicode and hard-codes
+ * which Windows terminals that do support Unicode.
+ * However, I have been using this logic in some popular packages for years without problems.
+ *
+ * @returns {boolean} Returns a `boolean` for whether the terminal supports Unicode.
+ * @example
+ * ```
+ * import isUnicodeSupported from 'bananass-utils-console/is-unicode-supported';
+ *
+ * isUnicodeSupported(); // true
+ * ```
+ */
+export default function isUnicodeSupported() {
+  const { env } = process;
+  const { TERM, TERM_PROGRAM } = env;
+
+  if (process.platform !== 'win32') {
+    return TERM !== 'linux'; // Linux console (kernel)
+  }
+
+  return (
+    Boolean(env.WT_SESSION) || // Windows Terminal
+    Boolean(env.TERMINUS_SUBLIME) || // Terminus (<0.2.27)
+    env.ConEmuTask === '{cmd::Cmder}' || // ConEmu and cmder
+    TERM_PROGRAM === 'Terminus-Sublime' ||
+    TERM_PROGRAM === 'vscode' ||
+    TERM === 'xterm-256color' ||
+    TERM === 'alacritty' ||
+    TERM === 'rxvt-unicode' ||
+    TERM === 'rxvt-unicode-256color' ||
+    env.TERMINAL_EMULATOR === 'JetBrains-JediTerm'
+  );
+}

--- a/packages/bananass-utils-console/src/is-unicode-supported/is-unicode-supported.test.js
+++ b/packages/bananass-utils-console/src/is-unicode-supported/is-unicode-supported.test.js
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Test for `is-unicode-supported.js`.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import process from 'node:process';
+import { describe, it } from 'node:test';
+import { ok } from 'node:assert';
+
+import isUnicodeSupported from './is-unicode-supported.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('is-unicode-supported', () => {
+  it('main', () => {
+    ok(isUnicodeSupported());
+  });
+
+  it('windows', () => {
+    delete process.env.CI;
+    delete process.env.TERM;
+    delete process.env.TERM_PROGRAM;
+    delete process.env.WT_SESSION;
+    delete process.env.TERMINUS_SUBLIME;
+
+    const originalPlatform = process.platform;
+
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    ok(!isUnicodeSupported());
+    process.env.WT_SESSION = '1';
+    ok(isUnicodeSupported());
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+});


### PR DESCRIPTION
This pull request refactors the `is-unicode-supported` utility in the `bananass-utils-console` package by replacing the external `is-unicode-supported` dependency with a local implementation. It updates all relevant imports, adjusts the package exports, and adds a basic test for the new implementation.

**Dependency and Implementation Refactor:**

* Removed the external `is-unicode-supported` package from dependencies in `package.json` and replaced it with a local implementation in `src/is-unicode-supported/is-unicode-supported.js`. (`[[1]](diffhunk://#diff-14dc0ab8d918f740c0f0d225fcfbbfdbf6620ab25f1e833d884d3878b35a9a0eL95-R102)`, `[[2]](diffhunk://#diff-8a14a4e86f6bdb638df2b6fde2ae01e42be0ef682e9191100fd87dca030c0f15R1-R56)`)
* Updated all imports of `is-unicode-supported` within the package to reference the new local module. (`[[1]](diffhunk://#diff-d3f16eb3ff3fa7e044b861f681f7554eca8a0d838ebe6ef5e26e2adcdb008683L10-R10)`, `[[2]](diffhunk://#diff-4a1f065d01668a094705847be53ea2422e7db7cf1a07abc9520f99a3f0ec5f36R1-R3)`)

**Package Exports and Types:**

* Added export mappings for the new `is-unicode-supported` module in `package.json`, including type definitions. (`[[1]](diffhunk://#diff-14dc0ab8d918f740c0f0d225fcfbbfdbf6620ab25f1e833d884d3878b35a9a0eR15-R18)`, `[[2]](diffhunk://#diff-14dc0ab8d918f740c0f0d225fcfbbfdbf6620ab25f1e833d884d3878b35a9a0eR44-R46)`)

**Testing:**

* Added a new test file `is-unicode-supported.test.js` to verify the correctness of the local implementation, including platform-specific checks. (`[packages/bananass-utils-console/src/is-unicode-supported/is-unicode-supported.test.jsR1-R40](diffhunk://#diff-3dca12329fc4ee3cccbfc8b09c796f180fe629aa87ba41bd7a0a78861e9a4494R1-R40)`)