### PR TITLE
docs(websites-vitepress): create `community` section

### DIFF
--- a/websites/vitepress/.vitepress/config/en.js
+++ b/websites/vitepress/.vitepress/config/en.js
@@ -283,6 +283,37 @@ export default defineConfig({
             },
           ],
         },
+        {
+          base: '/en/community',
+          text: 'Community',
+          collapsed: true,
+          items: [
+            {
+              text: 'Code of Conduct',
+              link: '/code-of-conduct',
+            },
+            {
+              text: 'Contributing',
+              link: '/contributing',
+            },
+            {
+              text: 'Change Log',
+              link: '/change-log',
+            },
+            {
+              text: 'Versioning',
+              link: '/versioning',
+            },
+            {
+              text: 'Security',
+              link: '/security',
+            },
+            {
+              text: 'License',
+              link: '/license',
+            },
+          ],
+        },
       ],
     },
 

--- a/websites/vitepress/.vitepress/config/ko.js
+++ b/websites/vitepress/.vitepress/config/ko.js
@@ -283,6 +283,37 @@ export default defineConfig({
             },
           ],
         },
+        {
+          base: '/community',
+          text: '커뮤니티',
+          collapsed: true,
+          items: [
+            {
+              text: '기여자 행동 강령 규약',
+              link: '/code-of-conduct',
+            },
+            {
+              text: '기여하기',
+              link: '/contributing',
+            },
+            {
+              text: '변경 사항',
+              link: '/change-log',
+            },
+            {
+              text: '버전 정책',
+              link: '/versioning',
+            },
+            {
+              text: '보안',
+              link: '/security',
+            },
+            {
+              text: '라이선스',
+              link: '/license',
+            },
+          ],
+        },
       ],
     },
 

--- a/websites/vitepress/en/community/change-log.md
+++ b/websites/vitepress/en/community/change-log.md
@@ -1,0 +1,1 @@
+<!-- @include: ../../../../CHANGELOG.md -->

--- a/websites/vitepress/en/community/code-of-conduct.md
+++ b/websites/vitepress/en/community/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Code of Conduct {#code-of-conduct}
+
+Please read our [Code of Conduct](https://github.com/lumirlumir/.github/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct).

--- a/websites/vitepress/en/community/contributing.md
+++ b/websites/vitepress/en/community/contributing.md
@@ -1,0 +1,1 @@
+<!-- @include: ../../../../CONTRIBUTING.en.md -->

--- a/websites/vitepress/en/community/license.md
+++ b/websites/vitepress/en/community/license.md
@@ -1,0 +1,1 @@
+<!-- @include: ../../../../LICENSE.md -->

--- a/websites/vitepress/en/community/security.md
+++ b/websites/vitepress/en/community/security.md
@@ -1,0 +1,3 @@
+# Security {#security}
+
+Please read our [Security Policy](https://github.com/lumirlumir/.github/blob/main/SECURITY.md#security).

--- a/websites/vitepress/en/community/versioning.md
+++ b/websites/vitepress/en/community/versioning.md
@@ -1,0 +1,7 @@
+---
+description: "This project adheres to Semantic Versioning."
+---
+
+# Versioning {#versioning}
+
+This project adheres to [Semantic Versioning](https://semver.org/).

--- a/websites/vitepress/ko/community/change-log.md
+++ b/websites/vitepress/ko/community/change-log.md
@@ -1,0 +1,1 @@
+<!-- @include: ../../../../CHANGELOG.md -->

--- a/websites/vitepress/ko/community/code-of-conduct.md
+++ b/websites/vitepress/ko/community/code-of-conduct.md
@@ -1,0 +1,3 @@
+# 기여자 행동 강령 규약 {#code-of-conduct}
+
+[기여자 행동 강령 규약](https://github.com/lumirlumir/.github/blob/main/CODE_OF_CONDUCT_KO.md#%EA%B8%B0%EC%97%AC%EC%9E%90-%ED%96%89%EB%8F%99-%EA%B0%95%EB%A0%B9-%EA%B7%9C%EC%95%BD)을 읽어주세요.

--- a/websites/vitepress/ko/community/contributing.md
+++ b/websites/vitepress/ko/community/contributing.md
@@ -1,0 +1,1 @@
+<!-- @include: ../../../../CONTRIBUTING.md -->

--- a/websites/vitepress/ko/community/license.md
+++ b/websites/vitepress/ko/community/license.md
@@ -1,0 +1,1 @@
+<!-- @include: ../../../../LICENSE.md -->

--- a/websites/vitepress/ko/community/security.md
+++ b/websites/vitepress/ko/community/security.md
@@ -1,0 +1,3 @@
+# 보안 {#security}
+
+[보안 정책](https://github.com/lumirlumir/.github/blob/main/SECURITY_KO.md#%EB%B3%B4%EC%95%88)을 읽어주세요.

--- a/websites/vitepress/ko/community/versioning.md
+++ b/websites/vitepress/ko/community/versioning.md
@@ -1,0 +1,7 @@
+---
+description: "이 프로젝트는 유의적 버전 정책을 준수합니다."
+---
+
+# 버전 정책 {#versioning}
+
+이 프로젝트는 [유의적 버전<sup>Semantic Versioning</sup> 정책](https://semver.org/lang/ko/)을 준수합니다.


### PR DESCRIPTION
This pull request adds new "Community" sections to both the English and Korean VitePress documentation sites. These sections provide important project documents such as the Code of Conduct, Contributing guidelines, Change Log, Versioning policy, Security policy, and License, making them more accessible to users in both languages.

**Navigation and Structure Updates:**

* Added a "Community" group to the sidebar navigation in both the English (`config/en.js`) and Korean (`config/ko.js`) documentation, each linking to the relevant community documents. [[1]](diffhunk://#diff-e8c9834d429fe2a2ab737c4d4792e53b5b37662b8a6ca63da5d0436b5f1231beR286-R316) [[2]](diffhunk://#diff-5f7efba08157e85cfd217cddfc20d73024f20fa0f48b6f230844d9328fb31f57R286-R316)

**English Community Documentation:**

* Created new markdown files in `en/community/` for Code of Conduct, Contributing, Change Log, Versioning, Security, and License, each linking to or including the respective project documents. [[1]](diffhunk://#diff-83ae165028403bc99b4edd1428d34eab74f6a71f7ef88349f63e69eea6b0d057R1-R3) [[2]](diffhunk://#diff-19118eaf29f1efc551a521eaaf48e51b3638ee6787cc90cbfba4f6c0293ffb27R1) [[3]](diffhunk://#diff-026af389407ed5d4458a007941ab719185076492c56c904bcfbf1a62f17486f1R1) [[4]](diffhunk://#diff-baefa4058a2c234b3414cd2d8045307b2212382e7ac58299a267985ab227c45bR1-R7) [[5]](diffhunk://#diff-c8cc35713af380e05ed96918fe17ba22f32fd830f829621eb602205726c0210dR1-R3) [[6]](diffhunk://#diff-eb8298d1ab0924accc127f0a5e6a8bdce0deff819a0a13901ac110845d8cd3b6R1)

**Korean Community Documentation:**

* Created new markdown files in `ko/community/` for the Korean versions of Code of Conduct, Contributing, Change Log, Versioning, Security, and License, each linking to or including the respective translated documents. [[1]](diffhunk://#diff-8edcf86292e2c1e23e5819ba531bf4e58d78523449400559d97f0c7daa04cfd3R1-R3) [[2]](diffhunk://#diff-cb1afb2c8ac7560ad492aede7f40e02e958f4b1610ff0b135d7271080b07f4a2R1) [[3]](diffhunk://#diff-026af389407ed5d4458a007941ab719185076492c56c904bcfbf1a62f17486f1R1) [[4]](diffhunk://#diff-1e943a17204ad031e8376d987b421f8b3b0765819e43dd54fe5f009c24b0e1e4R1-R7) [[5]](diffhunk://#diff-9a7e925c267a5676743289a64259bec6f58b136ca51397323b4ed5621b79b2a8R1-R3) [[6]](diffhunk://#diff-eb8298d1ab0924accc127f0a5e6a8bdce0deff819a0a13901ac110845d8cd3b6R1)