### PR TITLE
fix(bananass-utils-console): update parameter types from `any` to `unknown` for better type safety

### DIFF
--- a/packages/bananass-utils-console/src/icons/icons.js
+++ b/packages/bananass-utils-console/src/icons/icons.js
@@ -24,9 +24,10 @@ import isUnicodeSupported from '../is-unicode-supported/index.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @param {string | string[]} unicode Used when Unicode is supported.
- * @param {string | string[]} ascii Used when Unicode is not supported.
- * @returns {any}
+ * @template {string | string[]} T
+ * @param {T} unicode Used when Unicode is supported.
+ * @param {T} ascii Used when Unicode is not supported.
+ * @returns {T}
  */
 const choose = (unicode, ascii) => (isUnicodeSupported() ? unicode : ascii);
 

--- a/packages/bananass-utils-console/src/logger/logger.js
+++ b/packages/bananass-utils-console/src/logger/logger.js
@@ -69,7 +69,7 @@ class Logger {
    * - `quiet === true`: output X
    * - `quiet === false`: output O
    *
-   * @param {...any} params
+   * @param {...unknown} params
    * @returns {Logger}
    */
   log(...params) {
@@ -111,7 +111,7 @@ class Logger {
    * - `quiet === false && debug === true`: output O
    * - `quiet === false && debug === false`: output X
    *
-   * @param {...any} params
+   * @param {...unknown} params
    * @returns {Logger}
    */
   debug(...params) {
@@ -172,7 +172,6 @@ class Logger {
 
   /**
    * Get the last method called.
-   *
    * @returns {'log' | 'debug'}
    */
   get lastMethodCalled() {


### PR DESCRIPTION
This pull request makes type improvements and documentation updates to the `bananass-utils-console` package, focusing on the `icons.js` and `logger.js` modules. The main changes enhance type safety and clarity in the codebase.

Type improvements:

* Updated the `choose` function in `icons.js` to use a generic type parameter, ensuring that the return type matches the input type and improving type inference.
* Changed the parameter types for the `log` and `debug` methods in the `Logger` class from `any` to `unknown` for better type safety and stricter type checking. [[1]](diffhunk://#diff-96f095019880b5226ba5e1a9a332538a581b23c29e901ecbdc1d5445c2381567L72-R72) [[2]](diffhunk://#diff-96f095019880b5226ba5e1a9a332538a581b23c29e901ecbdc1d5445c2381567L114-R114)

Documentation and clarity:

* Removed an unnecessary blank line in the JSDoc for the `lastMethodCalled` getter in the `Logger` class to improve documentation clarity.