### PR TITLE
refactor(eslint-config-bananass): remove supported Web Speech API globals using `globals` package

### DIFF
--- a/packages/eslint-config-bananass/src/language-options.js
+++ b/packages/eslint-config-bananass/src/language-options.js
@@ -21,22 +21,11 @@ export const globals = {
   ...globalsModule.jest,
   ...globalsModule.vitest,
   ...globalsModule.mocha,
-  // Browser Web Speech APIs: https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
-  SpeechGrammar: false,
-  SpeechGrammarList: false,
+  // Browser Web Speech APIs which are not yet supported by `globals`: https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
   webkitSpeechRecognition: false,
-  SpeechRecognition: false,
   SpeechRecognitionAlternative: false,
-  SpeechRecognitionErrorEvent: false,
-  SpeechRecognitionEvent: false,
   SpeechRecognitionResult: false,
   SpeechRecognitionResultList: false,
-  speechSynthesis: false,
-  SpeechSynthesis: false,
-  SpeechSynthesisErrorEvent: false,
-  SpeechSynthesisEvent: false,
-  SpeechSynthesisUtterance: false,
-  SpeechSynthesisVoice: false,
 };
 
 export const parser = typescriptParser;


### PR DESCRIPTION
This pull request updates the global variables configuration for browser Web Speech APIs in the `language-options.js` file. The main change is the removal of several Web Speech API globals that were previously manually specified, leaving only those not yet supported by the `globals` package.

**Globals configuration update:**

* Removed manual definitions for most Web Speech API globals such as `SpeechGrammar`, `SpeechRecognition`, and `speechSynthesis`, relying more on the `globals` package for support.
* Retained only the unsupported Web Speech API globals like `webkitSpeechRecognition` and a few related result types, ensuring coverage for APIs not yet handled by the `globals` package.