### PR TITLE
chore(release): bump package versions from `v0.4.0` to `v0.4.1` (`patch`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.4.0"
+    "bananass": "^0.4.1"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.4.0"
+    "bananass": "^0.4.1"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.4.0"
+    "bananass": "^0.4.1"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.4.0"
+    "bananass": "^0.4.1"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.2.1",
         "editorconfig-checker": "^6.1.0",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.0",
+        "eslint-config-bananass": "^0.4.1",
         "eslint-plugin-mark": "^0.1.0-canary.7",
         "husky": "^9.1.7",
         "lerna": "^8.2.3",
         "lint-staged": "^16.1.6",
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.0",
+        "prettier-config-bananass": "^0.4.1",
         "textlint": "14.7.2",
         "textlint-rule-allowed-uris": "^2.0.1",
         "typescript": "^5.9.2"
@@ -39,7 +39,7 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     "examples/solutions-bananass": {
       "name": "examples-solutions-bananass",
@@ -51,30 +51,30 @@
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0"
+        "bananass": "^0.4.1"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0"
+        "bananass": "^0.4.1"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0"
+        "bananass": "^0.4.1"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0"
+        "bananass": "^0.4.1"
       }
     },
     "examples/solutions-readline": {
@@ -84,7 +84,7 @@
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     "examples/solutions-readline-esm": {
       "name": "examples-solutions-readline-esm",
@@ -93,7 +93,7 @@
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -21324,7 +21324,7 @@
       }
     },
     "packages/bananass": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.4",
@@ -21332,7 +21332,7 @@
         "@babel/plugin-transform-typescript": "^7.28.0",
         "@babel/preset-env": "^7.28.3",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.4.0",
+        "bananass-utils-console": "^0.4.1",
         "commander": "^14.0.1",
         "defu": "^6.1.4",
         "enhanced-resolve": "^5.18.3",
@@ -21366,7 +21366,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -21385,10 +21385,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.4.0",
+        "bananass-utils-console": "^0.4.1",
         "commander": "^14.0.1",
         "consola": "^3.4.2"
       },
@@ -21416,13 +21416,13 @@
     },
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0",
+        "bananass": "^0.4.1",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.0",
+        "eslint-config-bananass": "^0.4.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.0"
+        "prettier-config-bananass": "^0.4.1"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -21430,13 +21430,13 @@
     },
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0",
+        "bananass": "^0.4.1",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.0",
+        "eslint-config-bananass": "^0.4.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.0"
+        "prettier-config-bananass": "^0.4.1"
       },
       "engines": {
         "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -21460,14 +21460,14 @@
     },
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0",
+        "bananass": "^0.4.1",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.0",
+        "eslint-config-bananass": "^0.4.1",
         "jiti": "^2.5.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.0",
+        "prettier-config-bananass": "^0.4.1",
         "typescript": "^5.9.2"
       },
       "engines": {
@@ -21476,14 +21476,14 @@
     },
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0",
+        "bananass": "^0.4.1",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.0",
+        "eslint-config-bananass": "^0.4.1",
         "jiti": "^2.5.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.0",
+        "prettier-config-bananass": "^0.4.1",
         "typescript": "^5.9.2"
       },
       "engines": {
@@ -21499,7 +21499,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^15.5.3",
@@ -21536,7 +21536,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -21544,18 +21544,18 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0"
+        "bananass": "^0.4.1"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
-        "bananass": "^0.4.0",
-        "bananass-utils-console": "^0.4.0",
-        "create-bananass": "^0.4.0"
+        "bananass": "^0.4.1",
+        "bananass-utils-console": "^0.4.1",
+        "create-bananass": "^0.4.1"
       }
     },
     "website": {
@@ -21628,10 +21628,10 @@
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
         "@eslint/config-inspector": "^1.2.0",
-        "eslint-config-bananass": "^0.4.0"
+        "eslint-config-bananass": "^0.4.1"
       }
     },
     "websites/eslint-config-bananass-react": {
@@ -21645,10 +21645,10 @@
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
-        "bananass": "^0.4.0",
+        "bananass": "^0.4.1",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^2.0.0-alpha.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -68,14 +68,14 @@
     "concurrently": "^9.2.1",
     "editorconfig-checker": "^6.1.0",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.0",
+    "eslint-config-bananass": "^0.4.1",
     "eslint-plugin-mark": "^0.1.0-canary.7",
     "husky": "^9.1.7",
     "lerna": "^8.2.3",
     "lint-staged": "^16.1.6",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.0",
+    "prettier-config-bananass": "^0.4.1",
     "textlint": "14.7.2",
     "textlint-rule-allowed-uris": "^2.0.1",
     "typescript": "^5.9.2"

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -97,7 +97,7 @@
     "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/preset-env": "^7.28.3",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.4.0",
+    "bananass-utils-console": "^0.4.1",
     "commander": "^14.0.1",
     "defu": "^6.1.4",
     "enhanced-resolve": "^5.18.3",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -56,7 +56,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.4.0",
+    "bananass-utils-console": "^0.4.1",
     "commander": "^14.0.1",
     "consola": "^3.4.2"
   }

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-cjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.4.0",
+    "bananass": "^0.4.1",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.0",
+    "eslint-config-bananass": "^0.4.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.0"
+    "prettier-config-bananass": "^0.4.1"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-esm",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.4.0",
+    "bananass": "^0.4.1",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.0",
+    "eslint-config-bananass": "^0.4.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.0"
+    "prettier-config-bananass": "^0.4.1"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-cjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "commonjs",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.4.0",
+    "bananass": "^0.4.1",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.0",
+    "eslint-config-bananass": "^0.4.1",
     "jiti": "^2.5.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.0",
+    "prettier-config-bananass": "^0.4.1",
     "typescript": "^5.9.2"
   }
 }

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-esm",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "engines": {
     "node": "^20.18.0 || ^22.3.0 || >= 24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.4.0",
+    "bananass": "^0.4.1",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.0",
+    "eslint-config-bananass": "^0.4.1",
     "jiti": "^2.5.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.0",
+    "prettier-config-bananass": "^0.4.1",
     "typescript": "^5.9.2"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.4.0"
+    "bananass": "^0.4.1"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.4.0",
-    "bananass-utils-console": "^0.4.0",
-    "create-bananass": "^0.4.0"
+    "bananass": "^0.4.1",
+    "bananass-utils-console": "^0.4.1",
+    "create-bananass": "^0.4.1"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.2.0",
-    "eslint-config-bananass": "^0.4.0"
+    "eslint-config-bananass": "^0.4.1"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
-    "bananass": "^0.4.0",
+    "bananass": "^0.4.1",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^2.0.0-alpha.11",


### PR DESCRIPTION
## Release Information: `v0.4.1`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.4.0` to `v0.4.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/17675367692) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | cf40541       |
| Old Version | `v0.4.0`  |
| New Version | `v0.4.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(bananass): narrow types in `constants` and internals by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/696
* fix(bananass-utils-console): update parameter types from `any` to `unknown` for better type safety by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/697
### :toolbox: Chores
* chore(sync-server): bump GitHub Actions version by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/663
* chore(*): bump dependencies including `typescript` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/664
* chore(sync-server): bump GitHub Actions versions by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/692
### :memo: Documentation
* docs(websites-vitepress): create `community` section by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/657
### :recycle: Code Refactoring
* refactor(*): add explicit type when importing `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/665
* refactor(eslint-config-bananass): remove supported Web Speech API globals using `globals` package by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/698
### :arrow_up: Dependency Updates
* chore(deps): bump webpack from 5.101.0 to 5.101.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/658
* chore(deps): bump the babel group across 2 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/659
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.6.2 to 1.6.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/666
* chore(deps-dev): bump @eslint/config-inspector from 1.1.0 to 1.2.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/669
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/668
* chore(deps-dev): bump eslint from 9.33.0 to 9.34.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/675
* chore(deps-dev): bump concurrently from 9.2.0 to 9.2.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/678
* chore(deps): bump eslint-plugin-react-hooks from 6.0.0-rc.1 to 6.0.0-rc.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/680
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/679
* chore(deps-dev): bump lint-staged from 16.1.5 to 16.1.6 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/682
* chore(deps-dev): bump @types/node from 24.3.0 to 24.3.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/683
* chore(deps-dev): bump eslint from 9.34.0 to 9.35.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/687
* chore(deps): bump the babel group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/686
* chore(deps): bump actions/setup-node from 4 to 5 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/685
* chore(deps): bump globals from 16.3.0 to 16.4.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/693
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/695
* chore(deps): bump dependencies by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/699


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.4.0...v0.4.1