### PR TITLE
fix(bananass-utils-console): update type to allow `undefined` in `options`

### DIFF
--- a/packages/bananass-utils-console/src/logger/logger.js
+++ b/packages/bananass-utils-console/src/logger/logger.js
@@ -15,9 +15,9 @@ import { styleText } from 'node:util';
 
 /**
  * @typedef {object} Options Logger options.
- * @property {boolean} [debug] Enable debug mode.
- * @property {boolean} [quiet] Enable quiet mode.
- * @property {string | boolean} [textPrefix] Text prefix.
+ * @property {boolean | undefined} [debug] Enable debug mode.
+ * @property {boolean | undefined} [quiet] Enable quiet mode.
+ * @property {string | boolean | undefined} [textPrefix] Text prefix.
  */
 
 // --------------------------------------------------------------------------------

--- a/packages/bananass-utils-console/src/spinner/spinner.js
+++ b/packages/bananass-utils-console/src/spinner/spinner.js
@@ -34,11 +34,11 @@ import {
 
 /**
  * @typedef {object} Options Spinner options.
- * @property {string} [text] Text to display next to the spinner. (default: `''`)
- * @property {ForegroundColors} [color] The color of the spinner. (default: `'yellow'`)
- * @property {NodeJS.WriteStream} [stream] The stream to which the spinner is written. (default: `process.stderr`)
- * @property {boolean} [isInteractive] Whether the spinner should be interactive. (default: Auto-detected)
- * @property {SpinnerStyle} [spinner]
+ * @property {string | undefined} [text] Text to display next to the spinner. (default: `''`)
+ * @property {ForegroundColors | undefined} [color] The color of the spinner. (default: `'yellow'`)
+ * @property {NodeJS.WriteStream | undefined} [stream] The stream to which the spinner is written. (default: `process.stderr`)
+ * @property {boolean | undefined} [isInteractive] Whether the spinner should be interactive. (default: Auto-detected)
+ * @property {SpinnerStyle | undefined} [spinner]
  * Customize the spinner animation with a custom set of frames and interval.
  *
  * ```

--- a/packages/bananass-utils-console/src/theme/theme.js
+++ b/packages/bananass-utils-console/src/theme/theme.js
@@ -40,7 +40,7 @@ const format = (str, showIcon, color, icon) =>
  * Returns a green-colored success message prefixed with an icon.
  *
  * @param {string} str The success message to format.
- * @param {boolean} showIcon Whether to show the icon. Defaults to `false`.
+ * @param {boolean} [showIcon] Whether to show the icon. Defaults to `false`.
  * @returns {string} Returns a green-colored success message prefixed with an icon.
  *
  * @example
@@ -55,7 +55,7 @@ export function success(str, showIcon = false) {
  * Returns a red-colored error message prefixed with an icon.
  *
  * @param {string} str The error message to format.
- * @param {boolean} showIcon Whether to show the icon. Defaults to `false`.
+ * @param {boolean} [showIcon] Whether to show the icon. Defaults to `false`.
  * @returns {string} Returns a red-colored error message prefixed with an icon.
  *
  * @example
@@ -70,7 +70,7 @@ export function error(str, showIcon = false) {
  * Returns a yellow-colored warning message prefixed with an icon.
  *
  * @param {string} str The warning message to format.
- * @param {boolean} showIcon Whether to show the icon. Defaults to `false`.
+ * @param {boolean} [showIcon] Whether to show the icon. Defaults to `false`.
  * @returns {string} Returns a yellow-colored warning message prefixed with an icon.
  *
  * @example
@@ -85,7 +85,7 @@ export function warning(str, showIcon = false) {
  * Returns a blue-colored info message prefixed with an icon.
  *
  * @param {string} str The info message to format.
- * @param {boolean} showIcon Whether to show the icon. Defaults to `false`.
+ * @param {boolean} [showIcon] Whether to show the icon. Defaults to `false`.
  * @returns {string} Returns a blue-colored info message prefixed with an icon.
  *
  * @example
@@ -100,7 +100,7 @@ export function info(str, showIcon = false) {
  * Returns a yellow-colored error message prefixed with an icon.
  *
  * @param {string} str The bananass message to format.
- * @param {boolean} showIcon Whether to show the icon. Defaults to `false`.
+ * @param {boolean} [showIcon] Whether to show the icon. Defaults to `false`.
  * @returns Returns a yellow-colored error message prefixed with an icon.
  *
  * @example


### PR DESCRIPTION
This pull request updates several JSDoc type definitions across the `bananass-utils-console` package to improve type safety and clarity. The main change is making several options explicitly allow `undefined`, which better reflects how these options are used in practice. This helps prevent type errors and makes the documentation more accurate for consumers of these utilities.

Type definition improvements:

* Updated the `Options` typedef in `logger.js` to allow `debug`, `quiet`, and `textPrefix` to be `undefined` as well as their original types.
* Updated the `Options` typedef in `spinner.js` to allow `text`, `color`, `stream`, `isInteractive`, and `spinner` to be `undefined` as well as their original types.

Theme function parameter documentation:

* Updated the JSDoc comments for the `showIcon` parameter in the `success`, `error`, `warning`, and `info` functions in `theme.js` to indicate that `showIcon` is optional (`[showIcon]`). [[1]](diffhunk://#diff-5bcd4abce62d40cbfa05b160f76d0acccd1a063ed0729098bed2751050d67049L43-R43) [[2]](diffhunk://#diff-5bcd4abce62d40cbfa05b160f76d0acccd1a063ed0729098bed2751050d67049L58-R58) [[3]](diffhunk://#diff-5bcd4abce62d40cbfa05b160f76d0acccd1a063ed0729098bed2751050d67049L73-R73) [[4]](diffhunk://#diff-5bcd4abce62d40cbfa05b160f76d0acccd1a063ed0729098bed2751050d67049L88-R88) [[5]](diffhunk://#diff-5bcd4abce62d40cbfa05b160f76d0acccd1a063ed0729098bed2751050d67049L103-R103)