### PR TITLE
fix(eslint-config-bananass): add additional JSON config ignores for `jsconfig` and `tsconfig`

### DIFF
--- a/packages/eslint-config-bananass/src/ignores.js
+++ b/packages/eslint-config-bananass/src/ignores.js
@@ -12,5 +12,7 @@ export const json = /** @type {const} */ ([
   'package-lock.json',
   '**/.vscode/*.json',
   '**/jsconfig.json',
+  '**/jsconfig.*.json',
   '**/tsconfig.json',
+  '**/tsconfig.*.json',
 ]);


### PR DESCRIPTION
This pull request adds support for ignoring additional configuration files in the ESLint ignore list, specifically files that match wildcard patterns for `jsconfig` and `tsconfig`. This will help ensure that all relevant configuration files are excluded from linting.

Configuration ignore pattern updates:

* Added `**/jsconfig.*.json` and `**/tsconfig.*.json` to the ignore list in `packages/eslint-config-bananass/src/ignores.js`, allowing ESLint to ignore all variants of these config files.