### PR TITLE
chore(release): bump package versions from `v0.4.1` to `v0.5.0` (`minor`)

### DIFF
--- a/examples/readline/package.json
+++ b/examples/readline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-readline",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "scripts": {
     "start": "node ."
   }

--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cjs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.4.1"
+    "bananass": "^0.5.0"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-cts",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "scripts": {
     "build": "bananass build",
     "run": "bananass run",
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.4.1"
+    "bananass": "^0.5.0"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mjs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.4.1"
+    "bananass": "^0.5.0"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-bananass-mts",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "build": "bananass build",
@@ -9,6 +9,6 @@
     "test": "npx tsc --noEmit && bash ../../scripts/examples-solutions-bananass-test.sh"
   },
   "devDependencies": {
-    "bananass": "^0.4.1"
+    "bananass": "^0.5.0"
   }
 }

--- a/examples/solutions-readline-cjs/package.json
+++ b/examples/solutions-readline-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-cjs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "scripts": {
     "start:1000": "node src/1000",
     "start:1001": "node src/1001",

--- a/examples/solutions-readline-mjs/package.json
+++ b/examples/solutions-readline-mjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-solutions-readline-mjs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "start:1000": "node src/1000"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.4.1"
+  "version": "0.5.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "workspaces": [
         ".",
         "examples/*",
@@ -21,14 +21,14 @@
         "concurrently": "^9.2.1",
         "editorconfig-checker": "^6.1.0",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.1",
+        "eslint-config-bananass": "^0.5.0",
         "eslint-plugin-mark": "^0.1.0-canary.7",
         "husky": "^9.1.7",
         "lerna": "^8.2.4",
         "lint-staged": "^16.2.3",
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.1",
+        "prettier-config-bananass": "^0.5.0",
         "textlint": "14.7.2",
         "textlint-rule-allowed-uris": "^2.0.1",
         "typescript": "^5.9.2"
@@ -39,43 +39,43 @@
     },
     "examples/readline": {
       "name": "examples-readline",
-      "version": "0.4.1"
+      "version": "0.5.0"
     },
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1"
+        "bananass": "^0.5.0"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1"
+        "bananass": "^0.5.0"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1"
+        "bananass": "^0.5.0"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1"
+        "bananass": "^0.5.0"
       }
     },
     "examples/solutions-readline-cjs": {
       "name": "examples-solutions-readline-cjs",
-      "version": "0.4.1"
+      "version": "0.5.0"
     },
     "examples/solutions-readline-mjs": {
       "name": "examples-solutions-readline-mjs",
-      "version": "0.4.1"
+      "version": "0.5.0"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
@@ -21301,7 +21301,7 @@
       }
     },
     "packages/bananass": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.4",
@@ -21309,7 +21309,7 @@
         "@babel/plugin-transform-typescript": "^7.28.0",
         "@babel/preset-env": "^7.28.3",
         "babel-loader": "^10.0.0",
-        "bananass-utils-console": "^0.4.1",
+        "bananass-utils-console": "^0.5.0",
         "commander": "^14.0.1",
         "defu": "^6.1.4",
         "enhanced-resolve": "^5.18.3",
@@ -21332,7 +21332,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -21360,10 +21360,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.4.1",
+        "bananass-utils-console": "^0.5.0",
         "commander": "^14.0.1",
         "consola": "^3.4.2"
       },
@@ -21376,13 +21376,13 @@
     },
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1",
+        "bananass": "^0.5.0",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.1",
+        "eslint-config-bananass": "^0.5.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.1"
+        "prettier-config-bananass": "^0.5.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -21390,13 +21390,13 @@
     },
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1",
+        "bananass": "^0.5.0",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.1",
+        "eslint-config-bananass": "^0.5.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.1"
+        "prettier-config-bananass": "^0.5.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -21404,14 +21404,14 @@
     },
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1",
+        "bananass": "^0.5.0",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.1",
+        "eslint-config-bananass": "^0.5.0",
         "jiti": "^2.5.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.1",
+        "prettier-config-bananass": "^0.5.0",
         "typescript": "^5.9.2"
       },
       "engines": {
@@ -21420,14 +21420,14 @@
     },
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1",
+        "bananass": "^0.5.0",
         "eslint": "^9.35.0",
-        "eslint-config-bananass": "^0.4.1",
+        "eslint-config-bananass": "^0.5.0",
         "jiti": "^2.5.1",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.1",
+        "prettier-config-bananass": "^0.5.0",
         "typescript": "^5.9.2"
       },
       "engines": {
@@ -21435,7 +21435,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/json": "^0.13.2",
@@ -21458,7 +21458,7 @@
       }
     },
     "packages/prettier-config-bananass": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -21466,34 +21466,34 @@
     },
     "tests/e2e": {
       "name": "tests-e2e",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1"
+        "bananass": "^0.5.0"
       }
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
-        "bananass": "^0.4.1",
-        "bananass-utils-console": "^0.4.1",
-        "create-bananass": "^0.4.1"
+        "bananass": "^0.5.0",
+        "bananass-utils-console": "^0.5.0",
+        "create-bananass": "^0.5.0"
       }
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
         "@eslint/config-inspector": "^1.3.0",
-        "eslint-config-bananass": "^0.4.1"
+        "eslint-config-bananass": "^0.5.0"
       }
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
-        "bananass": "^0.4.1",
+        "bananass": "^0.5.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^2.0.0-alpha.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -68,14 +68,14 @@
     "concurrently": "^9.2.1",
     "editorconfig-checker": "^6.1.0",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.1",
+    "eslint-config-bananass": "^0.5.0",
     "eslint-plugin-mark": "^0.1.0-canary.7",
     "husky": "^9.1.7",
     "lerna": "^8.2.4",
     "lint-staged": "^16.2.3",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.1",
+    "prettier-config-bananass": "^0.5.0",
     "textlint": "14.7.2",
     "textlint-rule-allowed-uris": "^2.0.1",
     "typescript": "^5.9.2"

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -92,7 +92,7 @@
     "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/preset-env": "^7.28.3",
     "babel-loader": "^10.0.0",
-    "bananass-utils-console": "^0.4.1",
+    "bananass-utils-console": "^0.5.0",
     "commander": "^14.0.1",
     "defu": "^6.1.4",
     "enhanced-resolve": "^5.18.3",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -56,7 +56,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.4.1",
+    "bananass-utils-console": "^0.5.0",
     "commander": "^14.0.1",
     "consola": "^3.4.2"
   }

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-cjs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "commonjs",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.4.1",
+    "bananass": "^0.5.0",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.1",
+    "eslint-config-bananass": "^0.5.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.1"
+    "prettier-config-bananass": "^0.5.0"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-javascript-esm",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -22,10 +22,10 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.4.1",
+    "bananass": "^0.5.0",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.1",
+    "eslint-config-bananass": "^0.5.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.1"
+    "prettier-config-bananass": "^0.5.0"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-cjs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "commonjs",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.4.1",
+    "bananass": "^0.5.0",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.1",
+    "eslint-config-bananass": "^0.5.0",
     "jiti": "^2.5.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.1",
+    "prettier-config-bananass": "^0.5.0",
     "typescript": "^5.9.2"
   }
 }

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "create-bananass-typescript-esm",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -23,12 +23,12 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.4.1",
+    "bananass": "^0.5.0",
     "eslint": "^9.35.0",
-    "eslint-config-bananass": "^0.4.1",
+    "eslint-config-bananass": "^0.5.0",
     "jiti": "^2.5.1",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.1",
+    "prettier-config-bananass": "^0.5.0",
     "typescript": "^5.9.2"
   }
 }

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/packages/prettier-config-bananass/package.json
+++ b/packages/prettier-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-bananass",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "Prettier Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-e2e",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.4.1"
+    "bananass": "^0.5.0"
   }
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.4.1",
-    "bananass-utils-console": "^0.4.1",
-    "create-bananass": "^0.4.1"
+    "bananass": "^0.5.0",
+    "bananass-utils-console": "^0.5.0",
+    "create-bananass": "^0.5.0"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-eslint-config-bananass",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "build": "npx @eslint/config-inspector build --config ./config.js --outDir ./build",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.3.0",
-    "eslint-config-bananass": "^0.4.1"
+    "eslint-config-bananass": "^0.5.0"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "websites-vitepress",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
-    "bananass": "^0.4.1",
+    "bananass": "^0.5.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^2.0.0-alpha.11",


### PR DESCRIPTION
## Release Information: `v0.5.0`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.4.1` to `v0.5.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/18270236564) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | a22c44b       |
| Old Version | `v0.4.1`  |
| New Version | `v0.5.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* fix(bananass)!: remove `bananass/core/structs` export by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/723
* fix(bananass)!: remove `SolutionWithTestcases` type by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/724
* feat(*)!: require Node.js `^20.19.0 || ^22.13.0 || >=24.0.0` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/737
### :sparkles: Features
* feat(eslint-config-bananass): add support for `json`, `jsonc`, and `json5` configs by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/717
### :bug: Bug Fixes
* fix(*): enable strict type-checking and correct types in `bananass-utils-console` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/701
* fix(bananass-utils-console): update type to allow `undefined` in `options` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/720
* fix(eslint-config-bananass): add additional JSON config ignores for `jsconfig` and `tsconfig` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/721
* fix(bananass): migrate to Zod and tighten types by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/637
### :toolbox: Chores
* chore(*): simplify `package.json` import and minor style formatting by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/711
* chore(sync-server): add `cooldown` option to `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/714
* chore(sync-server): update `.vscode/settings.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/715
* chore(*): remove `cooldown` in dependabot (buggy) by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/731
### :memo: Documentation
* docs(*): centralize `CODE_OF_CONDUCT` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/725
### :recycle: Code Refactoring
* refactor(bananass): partial migration to zod and drop `Problems` and `ConfigObject` struct by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/722
### :arrow_up: Dependency Updates
* chore(deps): bump eslint-plugin-n from 17.21.3 to 17.23.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/705
* chore(deps-dev): bump @types/node from 24.3.1 to 24.5.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/706
* chore(deps-dev): bump lerna from 8.2.3 to 8.2.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/709
* chore(deps-dev): bump @types/node from 24.5.0 to 24.5.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/708
* chore(deps): bump eslint-plugin-n from 17.23.0 to 17.23.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/712
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/732
* chore(deps-dev): bump @eslint/config-inspector from 1.2.0 to 1.3.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/733
* chore(deps-dev): bump @types/node from 24.5.1 to 24.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/735
* chore(deps-dev): bump lint-staged from 16.1.6 to 16.2.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/739
* chore(deps-dev): bump @types/node from 24.6.0 to 24.6.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/742
* chore(deps-dev): bump @types/eslint-plugin-jsx-a11y from 6.10.0 to 6.10.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/743


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.4.1...v0.5.0