### PR TITLE
fix(eslint-config-bananass): add missing wildcard pattern to `jsonc` files

### DIFF
--- a/packages/eslint-config-bananass/src/files.js
+++ b/packages/eslint-config-bananass/src/files.js
@@ -20,7 +20,9 @@ export const jsonc = /** @type {const} */ ([
   '**/*.jsonc',
   '**/.vscode/*.json',
   '**/jsconfig.json',
+  '**/jsconfig.*.json',
   '**/tsconfig.json',
+  '**/tsconfig.*.json',
 ]);
 
 export const json5 = /** @type {const} */ (['**/*.json5']);


### PR DESCRIPTION
This pull request expands the file matching patterns for configuration files in the ESLint config package to ensure broader coverage for various project setups.

Configuration file pattern updates:

* Added support for matching all variants of `jsconfig` files (e.g., `jsconfig.*.json`) in `files.js`.
* Added support for matching all variants of `tsconfig` files (e.g., `tsconfig.*.json`) in `files.js`.