### PR TITLE
chore(release): bump package versions from `v0.6.0` to `v0.6.1` (`patch`)

### DIFF
--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -7,6 +7,6 @@
     "test": "node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.6.0"
+    "bananass": "^0.6.1"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -7,6 +7,6 @@
     "test": "tsc --noEmit && node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.6.0"
+    "bananass": "^0.6.1"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -8,6 +8,6 @@
     "test": "node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.6.0"
+    "bananass": "^0.6.1"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -8,6 +8,6 @@
     "test": "tsc --noEmit && node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.6.0"
+    "bananass": "^0.6.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "workspaces": [
         ".",
         "examples/*",
@@ -20,7 +20,7 @@
         "c8": "^11.0.0",
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.0",
+        "eslint-config-bananass": "^0.6.1",
         "eslint-markdown": "^0.1.0-canary.12",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.3",
@@ -39,25 +39,25 @@
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
       "devDependencies": {
-        "bananass": "^0.6.0"
+        "bananass": "^0.6.1"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
       "devDependencies": {
-        "bananass": "^0.6.0"
+        "bananass": "^0.6.1"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
       "devDependencies": {
-        "bananass": "^0.6.0"
+        "bananass": "^0.6.1"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
       "devDependencies": {
-        "bananass": "^0.6.0"
+        "bananass": "^0.6.1"
       }
     },
     "examples/solutions-readline-cjs": {
@@ -13718,7 +13718,7 @@
       }
     },
     "packages/bananass": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.29.0",
@@ -13726,7 +13726,7 @@
         "@babel/plugin-transform-typescript": "^7.28.6",
         "@babel/preset-env": "^7.29.2",
         "babel-loader": "^10.1.1",
-        "bananass-utils-console": "^0.6.0",
+        "bananass-utils-console": "^0.6.1",
         "commander": "^14.0.3",
         "defu": "^6.1.6",
         "enhanced-resolve": "^5.20.1",
@@ -13752,7 +13752,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -13762,10 +13762,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.6.0",
+        "bananass-utils-console": "^0.6.1",
         "commander": "^14.0.3",
         "consola": "^3.4.2"
       },
@@ -13782,9 +13782,9 @@
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
       "devDependencies": {
-        "bananass": "^0.6.0",
+        "bananass": "^0.6.1",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.0",
+        "eslint-config-bananass": "^0.6.1",
         "prettier": "^3.8.1"
       },
       "engines": {
@@ -13794,9 +13794,9 @@
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
       "devDependencies": {
-        "bananass": "^0.6.0",
+        "bananass": "^0.6.1",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.0",
+        "eslint-config-bananass": "^0.6.1",
         "prettier": "^3.8.1"
       },
       "engines": {
@@ -13806,9 +13806,9 @@
     "packages/create-bananass/templates/typescript-cjs": {
       "name": "create-bananass-typescript-cjs",
       "devDependencies": {
-        "bananass": "^0.6.0",
+        "bananass": "^0.6.1",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.0",
+        "eslint-config-bananass": "^0.6.1",
         "jiti": "^2.6.1",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3"
@@ -13820,9 +13820,9 @@
     "packages/create-bananass/templates/typescript-esm": {
       "name": "create-bananass-typescript-esm",
       "devDependencies": {
-        "bananass": "^0.6.0",
+        "bananass": "^0.6.1",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.0",
+        "eslint-config-bananass": "^0.6.1",
         "jiti": "^2.6.1",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3"
@@ -13832,7 +13832,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/json": "^0.14.0",
@@ -13878,24 +13878,24 @@
     },
     "tests": {
       "devDependencies": {
-        "bananass": "^0.6.0",
-        "bananass-utils-console": "^0.6.0",
-        "create-bananass": "^0.6.0",
-        "eslint-config-bananass": "^0.6.0"
+        "bananass": "^0.6.1",
+        "bananass-utils-console": "^0.6.1",
+        "create-bananass": "^0.6.1",
+        "eslint-config-bananass": "^0.6.1"
       }
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
       "devDependencies": {
         "@eslint/config-inspector": "^1.5.0",
-        "eslint-config-bananass": "^0.6.0"
+        "eslint-config-bananass": "^0.6.1"
       }
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
-        "bananass": "^0.6.0",
+        "bananass": "^0.6.1",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "^2.0.0-alpha.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "packageManager": "npm@11.11.0",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -65,7 +65,7 @@
     "c8": "^11.0.0",
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.0",
+    "eslint-config-bananass": "^0.6.1",
     "eslint-markdown": "^0.1.0-canary.12",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.3",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -93,7 +93,7 @@
     "@babel/plugin-transform-typescript": "^7.28.6",
     "@babel/preset-env": "^7.29.2",
     "babel-loader": "^10.1.1",
-    "bananass-utils-console": "^0.6.0",
+    "bananass-utils-console": "^0.6.1",
     "commander": "^14.0.3",
     "defu": "^6.1.6",
     "enhanced-resolve": "^5.20.1",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -57,7 +57,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.6.0",
+    "bananass-utils-console": "^0.6.1",
     "commander": "^14.0.3",
     "consola": "^3.4.2"
   }

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -21,9 +21,9 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.6.0",
+    "bananass": "^0.6.1",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.0",
+    "eslint-config-bananass": "^0.6.1",
     "prettier": "^3.8.1"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -21,9 +21,9 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.6.0",
+    "bananass": "^0.6.1",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.0",
+    "eslint-config-bananass": "^0.6.1",
     "prettier": "^3.8.1"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -22,9 +22,9 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.6.0",
+    "bananass": "^0.6.1",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.0",
+    "eslint-config-bananass": "^0.6.1",
     "jiti": "^2.6.1",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3"

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -22,9 +22,9 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "bananass": "^0.6.0",
+    "bananass": "^0.6.1",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.0",
+    "eslint-config-bananass": "^0.6.1",
     "jiti": "^2.6.1",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3"

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,9 +6,9 @@
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.6.0",
-    "bananass-utils-console": "^0.6.0",
-    "create-bananass": "^0.6.0",
-    "eslint-config-bananass": "^0.6.0"
+    "bananass": "^0.6.1",
+    "bananass-utils-console": "^0.6.1",
+    "create-bananass": "^0.6.1",
+    "eslint-config-bananass": "^0.6.1"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.5.0",
-    "eslint-config-bananass": "^0.6.0"
+    "eslint-config-bananass": "^0.6.1"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
-    "bananass": "^0.6.0",
+    "bananass": "^0.6.1",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^2.0.0-alpha.15",


### PR DESCRIPTION
## Release Information: `v0.6.1`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.6.0` to `v0.6.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/23976281074) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 4bf657b       |
| Old Version | `v0.6.0`  |
| New Version | `v0.6.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(eslint-config-bananass): add `vitest` configuration to `import/no-extraneous-dependencies` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/913
* fix(eslint-config-bananass): update dependencies by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/967
* fix(bananass): update dependencies by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/968
### :toolbox: Chores
* chore(*): add `funding` field to `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/917
* chore(sync-server): simplify coverage CI script and update `.markdownlint.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/919
* chore(*): flatten `tests` directory by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/921
* chore(sync-server): update configurations, github actions, and pin to Node.js 22.22.0 by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/959
### :memo: Documentation
* docs(*): add `copilot-instructions.md` for enhanced GitHub Copilot support by @Copilot in https://github.com/lumirlumir/npm-bananass/pull/766
### :recycle: Code Refactoring
* refactor(*): simplify `package.json` import by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/929
### :test_tube: Tests
* test(*): move `e2e` tests under `bananass-build` and refactor test structures by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/918
* test(*): replace shell script with Node.js test files to make example tests twice as fast by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/922
* test(tests): add test for `exports` field order in `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/928
### :arrow_up: Dependency Updates
* chore(deps): bump eslint-plugin-n from 17.23.2 to 17.24.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/904
* chore(deps): bump commander from 14.0.2 to 14.0.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/905
* chore(deps): bump webpack from 5.105.1 to 5.105.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/909
* chore(deps): bump zod from 4.3.5 to 4.3.6 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/914
* chore(deps): update enhanced-resolve requirement from ^5.18.3 to ^5.19.0 in /packages/bananass by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/916
* chore(deps): bump ajv from 6.12.6 to 6.14.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/920
* chore(deps-dev): bump eslint from 9.39.2 to 9.39.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/923
* chore(deps-dev): bump c8 from 10.1.3 to 11.0.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/930
* chore(deps): bump webpack from 5.105.2 to 5.105.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/932
* chore(deps-dev): bump @types/node from 24.10.13 to 24.10.15 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/931
* chore(deps-dev): bump lint-staged from 16.2.7 to 16.3.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/935
* chore(deps-dev): bump @types/node from 24.10.15 to 24.11.0 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/934
* chore(deps-dev): bump markdownlint-cli from 0.47.0 to 0.48.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/937
* chore(deps-dev): bump minimatch from 3.1.2 to 3.1.5 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/938
* chore(deps-dev): bump @types/node from 24.11.0 to 24.11.2 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/936
* chore(deps-dev): update dependencies across multiple packages by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/939
* chore(deps): bump babel-loader from 10.0.0 to 10.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/943
* chore(deps): bump babel-loader from 10.1.0 to 10.1.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/948
* chore(deps-dev): bump lint-staged from 16.3.2 to 16.3.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/950
* chore(deps): bump enhanced-resolve from 5.19.0 to 5.20.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/951
* chore(deps): bump flatted from 3.3.3 to 3.4.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/953
* chore(deps-dev): bump @eslint/config-inspector from 1.4.2 to 1.5.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/956
* chore(deps): bump the babel group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/958


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.6.0...v0.6.1