### PR TITLE
chore(*): update `eslint.config.mjs` to include `**/.vitepress/.temp/`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,13 @@ import md from 'eslint-markdown';
 /** @type {import("eslint").Linter.Config[]} */
 export default defineConfig([
   globalIgnores(
-    ['**/build/', '**/coverage/', '**/.vitepress/cache/', '**/.bananass/'],
+    [
+      '**/build/',
+      '**/coverage/',
+      '**/.vitepress/.temp/',
+      '**/.vitepress/cache/',
+      '**/.bananass/',
+    ],
     'global/ignores',
   ),
 


### PR DESCRIPTION
This pull request updates the ESLint configuration to improve the ignored paths for linting. The main change is the addition of the `.vitepress/.temp/` directory to the list of globally ignored paths.

**ESLint configuration improvements:**

* Added `.vitepress/.temp/` to the global ignore list in `eslint.config.mjs` to prevent ESLint from processing temporary VitePress files.