### PR TITLE
test(create-bananass): remove Node.js version pinning workaround

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -24,8 +24,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 24.13.0 # TODO: Work around a bug in Node 24.13.1, the latest version as of February 20, 2026.
-          - 22.22.0 # TODO: Work around a bug in Node 22.22.1, the latest version as of March 05, 2026.
+          - 24.x
+          - 22.x
           - 22.13.0
           - 20.x
           - 20.19.0

--- a/packages/create-bananass/src/cli.test.js
+++ b/packages/create-bananass/src/cli.test.js
@@ -12,13 +12,13 @@ import { stripVTControlCharacters } from 'node:util';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 
 // --------------------------------------------------------------------------------
 // Helper
 // --------------------------------------------------------------------------------
 
-const outDir = mkdtempSync(join(tmpdir(), 'create-bananass-'));
+const outDir = join(tmpdir(), 'create-bananass');
 const successMessage = /Successfully created a new Bananass framework project!/;
 
 /**


### PR DESCRIPTION
This PR fixes a test failure workaround in recent Node.js versions caused by https://github.com/nodejs/node/issues/58947.

Thanks @Han5991 for the hints!

Co-authored-by: sangwook <rewq5991@gmail.com>