### PR TITLE
fix(bananass): correct `typesVersions` subpath mappings

### DIFF
--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -29,13 +29,13 @@
       ".": [
         "./build/core/types/index.d.ts"
       ],
-      "./commands": [
+      "commands": [
         "./build/commands/index.d.ts"
       ],
-      "./core/constants": [
+      "core/constants": [
         "./build/core/constants.d.ts"
       ],
-      "./core/types": [
+      "core/types": [
         "./build/core/types/index.d.ts"
       ]
     }

--- a/packages/bananass/src/index.test.js
+++ b/packages/bananass/src/index.test.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Test for `index.js`.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+import packageJson from '../package.json' with { type: 'json' };
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('index', () => {
+  describe('package.json', () => {
+    it('should not have `typesVersions` keys that start with `./`', () => {
+      const typesVersionKeys = Object.keys(packageJson.typesVersions['*']);
+
+      strictEqual(typesVersionKeys.filter(key => key.startsWith('./')).length, 0);
+    });
+  });
+});


### PR DESCRIPTION
## summary
- Correct `bananass` `typesVersions` subpath keys so TypeScript matches consumer imports without a leading `./`.
- Add a package test that guards against leading `./` keys in `typesVersions`.

## scope
- `packages/bananass/package.json`
- `packages/bananass/src/index.test.js`

## validation
- `node --experimental-test-module-mocks --test packages/bananass/src/index.test.js`
- `npm run test -w packages/bananass`

## notes
- Opened as ready for review, not draft.