### PR TITLE
chore(release): bump package versions from `v0.6.1` to `v0.7.0` (`minor`)

### DIFF
--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -7,6 +7,6 @@
     "test": "node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.6.1"
+    "bananass": "^0.7.0"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -7,6 +7,6 @@
     "test": "tsc --noEmit && node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.6.1"
+    "bananass": "^0.7.0"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -8,6 +8,6 @@
     "test": "node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.6.1"
+    "bananass": "^0.7.0"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -8,6 +8,6 @@
     "test": "tsc --noEmit && node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.6.1"
+    "bananass": "^0.7.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "workspaces": [
         ".",
         "examples/*",
@@ -20,7 +20,7 @@
         "c8": "^11.0.0",
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.1",
+        "eslint-config-bananass": "^0.7.0",
         "eslint-markdown": "^0.9.1",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
@@ -39,25 +39,25 @@
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
       "devDependencies": {
-        "bananass": "^0.6.1"
+        "bananass": "^0.7.0"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
       "devDependencies": {
-        "bananass": "^0.6.1"
+        "bananass": "^0.7.0"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
       "devDependencies": {
-        "bananass": "^0.6.1"
+        "bananass": "^0.7.0"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
       "devDependencies": {
-        "bananass": "^0.6.1"
+        "bananass": "^0.7.0"
       }
     },
     "examples/solutions-readline-cjs": {
@@ -13742,7 +13742,7 @@
       }
     },
     "packages/bananass": {
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.29.7",
@@ -13750,7 +13750,7 @@
         "@babel/plugin-transform-typescript": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "babel-loader": "^10.1.1",
-        "bananass-utils-console": "^0.6.1",
+        "bananass-utils-console": "^0.7.0",
         "commander": "^14.0.3",
         "defu": "^6.1.7",
         "enhanced-resolve": "^5.21.0",
@@ -13776,7 +13776,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -13786,10 +13786,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.6.1",
+        "bananass-utils-console": "^0.7.0",
         "commander": "^14.0.3",
         "consola": "^3.4.2"
       },
@@ -13806,9 +13806,9 @@
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
       "devDependencies": {
-        "bananass": "^0.6.1",
+        "bananass": "^0.7.0",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.1",
+        "eslint-config-bananass": "^0.7.0",
         "prettier": "^3.8.3"
       },
       "engines": {
@@ -13818,9 +13818,9 @@
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
       "devDependencies": {
-        "bananass": "^0.6.1",
+        "bananass": "^0.7.0",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.1",
+        "eslint-config-bananass": "^0.7.0",
         "prettier": "^3.8.3"
       },
       "engines": {
@@ -13831,9 +13831,9 @@
       "name": "create-bananass-typescript-cjs",
       "devDependencies": {
         "@types/node": "^20.19.41",
-        "bananass": "^0.6.1",
+        "bananass": "^0.7.0",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.1",
+        "eslint-config-bananass": "^0.7.0",
         "jiti": "^2.7.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3"
@@ -13846,9 +13846,9 @@
       "name": "create-bananass-typescript-esm",
       "devDependencies": {
         "@types/node": "^20.19.41",
-        "bananass": "^0.6.1",
+        "bananass": "^0.7.0",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.6.1",
+        "eslint-config-bananass": "^0.7.0",
         "jiti": "^2.7.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3"
@@ -13858,7 +13858,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/json": "^0.14.0",
@@ -13904,24 +13904,24 @@
     },
     "tests": {
       "devDependencies": {
-        "bananass": "^0.6.1",
-        "bananass-utils-console": "^0.6.1",
-        "create-bananass": "^0.6.1",
-        "eslint-config-bananass": "^0.6.1"
+        "bananass": "^0.7.0",
+        "bananass-utils-console": "^0.7.0",
+        "create-bananass": "^0.7.0",
+        "eslint-config-bananass": "^0.7.0"
       }
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
       "devDependencies": {
         "@eslint/config-inspector": "^3.0.4",
-        "eslint-config-bananass": "^0.6.1"
+        "eslint-config-bananass": "^0.7.0"
       }
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
       "devDependencies": {
         "@codecov/vite-plugin": "^2.0.1",
-        "bananass": "^0.6.1",
+        "bananass": "^0.7.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "2.0.0-alpha.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {
@@ -78,7 +78,7 @@
     "c8": "^11.0.0",
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.1",
+    "eslint-config-bananass": "^0.7.0",
     "eslint-markdown": "^0.9.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -93,7 +93,7 @@
     "@babel/plugin-transform-typescript": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "babel-loader": "^10.1.1",
-    "bananass-utils-console": "^0.6.1",
+    "bananass-utils-console": "^0.7.0",
     "commander": "^14.0.3",
     "defu": "^6.1.7",
     "enhanced-resolve": "^5.21.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -57,7 +57,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.6.1",
+    "bananass-utils-console": "^0.7.0",
     "commander": "^14.0.3",
     "consola": "^3.4.2"
   }

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -21,9 +21,9 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.6.1",
+    "bananass": "^0.7.0",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.1",
+    "eslint-config-bananass": "^0.7.0",
     "prettier": "^3.8.3"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -21,9 +21,9 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.6.1",
+    "bananass": "^0.7.0",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.1",
+    "eslint-config-bananass": "^0.7.0",
     "prettier": "^3.8.3"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -23,9 +23,9 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.41",
-    "bananass": "^0.6.1",
+    "bananass": "^0.7.0",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.1",
+    "eslint-config-bananass": "^0.7.0",
     "jiti": "^2.7.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3"

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -23,9 +23,9 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.41",
-    "bananass": "^0.6.1",
+    "bananass": "^0.7.0",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.6.1",
+    "eslint-config-bananass": "^0.7.0",
     "jiti": "^2.7.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3"

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,9 +6,9 @@
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.6.1",
-    "bananass-utils-console": "^0.6.1",
-    "create-bananass": "^0.6.1",
-    "eslint-config-bananass": "^0.6.1"
+    "bananass": "^0.7.0",
+    "bananass-utils-console": "^0.7.0",
+    "create-bananass": "^0.7.0",
+    "eslint-config-bananass": "^0.7.0"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^3.0.4",
-    "eslint-config-bananass": "^0.6.1"
+    "eslint-config-bananass": "^0.7.0"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^2.0.1",
-    "bananass": "^0.6.1",
+    "bananass": "^0.7.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "2.0.0-alpha.17",


### PR DESCRIPTION
## Release Information: `v0.7.0`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.6.1` to `v0.7.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/26652436787) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | da02dc3       |
| Old Version | `v0.6.1`  |
| New Version | `v0.7.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-config-bananass): support subpath import and intial loading performance optimization by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1030
### :bug: Bug Fixes
* fix(bananass): bump defu from 6.1.6 to 6.1.7 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/983
* fix(create-bananass): use subpath import in eslint config template by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1031
* fix(bananass): correct `typesVersions` subpath mappings by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1033
### :toolbox: Chores
* chore(sync-server): update ignore files by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/971
* chore(*): update `eslint.config.mjs` to include `**/.vitepress/.temp/` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/974
* chore(*): use shared tsconfig base and TypeScript v6 by @Copilot in https://github.com/lumirlumir/npm-bananass/pull/981
* chore(sync-server): update CI files and rename config files to use `.js` extensions by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/994
* chore(*): rename GitHub actions workflow by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/998
* chore(*): rename username to `lumir` by @Copilot in https://github.com/lumirlumir/npm-bananass/pull/1013
* chore(sync-server): add `devEngines` field, update configs and CI by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1019
### :arrows_counterclockwise: Continuous Integrations
* ci(sync-server): reestablish cache strategy in CI for a faster speed by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/980
* ci(*): (perf) remove unnecessary `npx` prefixes by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/993
* ci(sync-server): merge lint and test workflow configs into ci by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/995
### :memo: Documentation
* docs(*): move copilot instructions to root `AGENTS.md` by @Copilot in https://github.com/lumirlumir/npm-bananass/pull/985
### :test_tube: Tests
* test(create-bananass): remove Node.js version pinning workaround by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/986
### :arrow_up: Dependency Updates
* chore(eslint-config-bananass): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/972
* chore(deps): bump webpack from 5.105.4 to 5.106.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/977
* chore(deps-dev): bump brace-expansion from 1.1.12 to 1.1.14 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/979
* chore(deps-dev): bump the dev-dependencies group across 6 directories with 4 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/982
* chore(deps-dev): bump the dev-dependencies group across 6 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/987
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/989
* chore(deps): bump the next group across 2 directories with 1 update  by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/988
* chore(deps): bump webpack from 5.106.1 to 5.106.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/991
* chore(deps-dev): bump the dev-dependencies group across 4 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/990
* chore(deps): bump eslint-plugin-react-hooks from 7.0.1 to 7.1.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/996
* chore(deps-dev): bump h3 from 1.15.6 to 1.15.11 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/999
* chore(deps-dev): bump rollup from 4.53.3 to 4.60.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1000
* chore(deps): bump enhanced-resolve from 5.20.1 to 5.21.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1001
* chore(deps): bump zod from 4.3.6 to 4.4.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1003
* chore(deps-dev): bump postcss from 8.5.6 to 8.5.12 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1005
* chore(deps): bump the babel group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1006
* chore(deps): bump zod from 4.4.1 to 4.4.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1007
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1010
* chore(deps): bump fast-uri from 3.1.0 to 3.1.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1011
* chore(deps): bump the babel group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1009
* chore(deps-dev): bump brace-expansion from 1.1.14 to 5.0.6 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1018
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1015
* chore(deps): bump webpack from 5.106.2 to 5.107.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1021
* chore(deps): bump the babel group across 2 directories with 4 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1024
* chore(deps): bump eslint-plugin-n from 17.24.0 to 18.0.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1026
* chore(deps-dev): bump the dev-dependencies group across 4 directories with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1029


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.6.1...v0.7.0