### PR TITLE
chore(*): enable more precise markdown linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,23 +34,44 @@ export default defineConfig([
     },
   },
 
+  // md
   {
     name: 'md/global',
     files: ['**/*.md'],
     rules: {
-      'md/allow-link-url': [
+      'md/allow-image-url': ['error', { disallowUrls: [/^\.\//, /^http:\/\//i] }],
+      'md/allow-link-url': ['error', { disallowUrls: [/^\.\//, /^http:\/\//i] }],
+      'md/code-lang-shorthand': 'error',
+      'md/consistent-code-style': [
         'error',
-        {
-          disallowUrls: [/^\.\//],
-        },
+        { style: 'fence-backtick', blankLineAbove: 1, blankLineBelow: 1 },
       ],
+      'md/consistent-delete-style': ['error', { style: '~' }],
+      'md/consistent-emphasis-style': ['error', { style: '*' }],
+      'md/consistent-inline-code-style': 'error',
+      'md/consistent-strong-style': ['error', { style: '*' }],
+      'md/consistent-thematic-break-style': ['error', { style: '---' }],
+      'md/consistent-unordered-list-style': ['error', { style: '-' }],
+      'md/no-control-character': 'error',
+      'md/no-curly-quote': 'error',
+      'md/no-double-punctuation': 'off', // Too tight.
+      'md/no-double-space': 'error',
+      'md/no-emoji': 'off',
+      'md/no-git-conflict-marker': 'error',
+      'md/no-irregular-dash': 'error',
+      'md/no-irregular-whitespace': 'error',
+      'md/no-tab': 'error',
+      'md/no-url-trailing-slash': 'off', // Too tight.
+      'md/require-heading-id': 'off',
+      'md/require-image-title': 'off', // Too tight.
+      'md/require-link-title': 'off', // Too tight.
     },
   },
   {
     name: 'md/websites-vitepress/global',
     files: ['websites/vitepress/**/*.md'],
     rules: {
-      // 'md/heading-id': 'error', // TODO
+      'md/require-heading-id': 'error',
       'md/no-emoji': 'error',
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.7.0",
-        "eslint-markdown": "^0.9.1",
+        "eslint-markdown": "^0.10.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "markdownlint-cli": "^0.48.0",
@@ -6455,9 +6455,9 @@
       }
     },
     "node_modules/eslint-markdown": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/eslint-markdown/-/eslint-markdown-0.9.1.tgz",
-      "integrity": "sha512-7M6121fM5Mh/CWTFgykMzlPZSHRLiP9SAVAxeIbc6+Z3bv06Q5UdtGsD35I1Z3UQYVJvfxfw1aQio0dLagKfbw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-markdown/-/eslint-markdown-0.10.0.tgz",
+      "integrity": "sha512-eiglpEe4F9PdDaJDEDqDGWuMIWKQKivfzAyehSRzC6X0VbEUEtANHxVolmx68R7vEgQWE/T8NEjKVVMc0E721Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.7.0",
-    "eslint-markdown": "^0.9.1",
+    "eslint-markdown": "^0.10.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "markdownlint-cli": "^0.48.0",


### PR DESCRIPTION
This pull request updates our Markdown linting configuration and dependencies to enforce stricter and more consistent Markdown style rules across the project. The main focus is on improving code style consistency and upgrading the `eslint-markdown` dependency.

Markdown linting improvements:

* Expanded the set of Markdown linting rules in `eslint.config.js` to enforce consistent styles for code blocks, emphasis, strong text, unordered lists, thematic breaks, and more. Also added new rules to disallow certain URL patterns in images and links, and enabled stricter whitespace and character checks.
* Enabled the `md/require-heading-id` rule specifically for Markdown files in the `websites/vitepress` directory to ensure all headings have IDs.

Dependency updates:

* Upgraded the `eslint-markdown` package from version `0.9.1` to `0.10.0` in `package.json` to support the new and updated Markdown linting rules.