### PR TITLE
fix(*): update `commander` to v15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5560,12 +5560,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -8856,16 +8856,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.12.0"
       }
     },
     "node_modules/markdownlint-cli/node_modules/ignore": {
@@ -13746,7 +13736,7 @@
         "@babel/preset-env": "^7.29.7",
         "babel-loader": "^10.1.1",
         "bananass-utils-console": "^0.7.0",
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "defu": "^6.1.7",
         "enhanced-resolve": "^5.24.0",
         "envinfo": "^7.21.0",
@@ -13785,7 +13775,7 @@
       "license": "MIT",
       "dependencies": {
         "bananass-utils-console": "^0.7.0",
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "consola": "^3.4.2"
       },
       "bin": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -94,7 +94,7 @@
     "@babel/preset-env": "^7.29.7",
     "babel-loader": "^10.1.1",
     "bananass-utils-console": "^0.7.0",
-    "commander": "^14.0.3",
+    "commander": "^15.0.0",
     "defu": "^6.1.7",
     "enhanced-resolve": "^5.24.0",
     "envinfo": "^7.21.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "bananass-utils-console": "^0.7.0",
-    "commander": "^14.0.3",
+    "commander": "^15.0.0",
     "consola": "^3.4.2"
   }
 }


### PR DESCRIPTION
This pull request updates the `commander` dependency to version 15.0.0 in both the `bananass` and `create-bananass` packages. This ensures both packages use the latest major version of the CLI framework.

Dependency updates:

* Updated `commander` to `^15.0.0` in `packages/bananass/package.json`
* Updated `commander` to `^15.0.0` in `packages/create-bananass/package.json`