### PR TITLE
chore(*): enforce allowed solution headings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,34 +79,36 @@ export default defineConfig([
     name: 'md/websites-vitepress/solutions/ko',
     files: ['websites/vitepress/ko/solutions/**/*.md'],
     rules: {
-      /*
       'md/allow-heading': [
         'error',
         {
-          h2: ['문제 풀이 {#solutions}', '해설 {#explanation}', '기여자 {#contributors}'],
+          h2: {
+            allow: [
+              /## 문제 풀이 {#solutions}/,
+              /## 해설 {#explanation}/,
+              /## 기여자 {#contributors}/,
+            ],
+          },
         },
       ],
-      */
-      // TODO
     },
   },
   {
     name: 'md/websites-vitepress/solutions/en',
     files: ['websites/vitepress/en/solutions/**/*.md'],
     rules: {
-      /*
       'md/allow-heading': [
         'error',
         {
-          h2: [
-            'Solutions {#solutions}',
-            'Explanation {#explanation}',
-            'Contributors {#contributors}',
-          ],
+          h2: {
+            allow: [
+              /## Solutions {#solutions}/,
+              /## Explanation {#explanation}/,
+              /## Contributors {#contributors}/,
+            ],
+          },
         },
       ],
-      */
-      // TODO
     },
   },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.7.0",
-        "eslint-markdown": "^0.11.1",
+        "eslint-markdown": "^0.12.1",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
         "markdownlint-cli": "^0.49.0",
@@ -6448,9 +6448,9 @@
       }
     },
     "node_modules/eslint-markdown": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/eslint-markdown/-/eslint-markdown-0.11.1.tgz",
-      "integrity": "sha512-BKk85Gxf+/b+oE85xphLZUq3CqW0Ja4KpIMDG00Ue2Xdd7vrVG9pRNUGE1bH+3ub1f0zXtcKqbKwpqVDGq/mkw==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-markdown/-/eslint-markdown-0.12.1.tgz",
+      "integrity": "sha512-zQ2pnYdZtLLDW2QeeJ0szqYy7yD+ntwBe1mAibeWSo5tZaUrhPpfXqsSf6q09K9OArl9OP4/sxgSlDgZ5cQliA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.7.0",
-    "eslint-markdown": "^0.11.1",
+    "eslint-markdown": "^0.12.1",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "markdownlint-cli": "^0.49.0",


### PR DESCRIPTION
This pull request updates markdown heading lint rules for the VitePress solutions documentation and upgrades the `eslint-markdown` dependency version. The main changes are:

### Lint rule improvements for markdown headings

* Updated the `md/allow-heading` rule in `eslint.config.js` for both Korean (`websites/vitepress/ko/solutions/**/*.md`) and English (`websites/vitepress/en/solutions/**/*.md`) solution docs to use regular expressions for allowed H2 headings, improving flexibility and accuracy.

### Dependency updates

* Upgraded the `eslint-markdown` package from version `0.11.1` to `0.12.1` in `package.json` to ensure compatibility and access to the latest features and fixes.