### PR TITLE
chore(release): bump package versions from `v0.7.0` to `v0.8.0` (`minor`)

### DIFF
--- a/examples/solutions-bananass-cjs/package.json
+++ b/examples/solutions-bananass-cjs/package.json
@@ -7,6 +7,6 @@
     "test": "node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.7.0"
+    "bananass": "^0.8.0"
   }
 }

--- a/examples/solutions-bananass-cts/package.json
+++ b/examples/solutions-bananass-cts/package.json
@@ -7,6 +7,6 @@
     "test": "tsc --noEmit && node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.7.0"
+    "bananass": "^0.8.0"
   }
 }

--- a/examples/solutions-bananass-mjs/package.json
+++ b/examples/solutions-bananass-mjs/package.json
@@ -8,6 +8,6 @@
     "test": "node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.7.0"
+    "bananass": "^0.8.0"
   }
 }

--- a/examples/solutions-bananass-mts/package.json
+++ b/examples/solutions-bananass-mts/package.json
@@ -8,6 +8,6 @@
     "test": "tsc --noEmit && node solutions.test.mjs"
   },
   "devDependencies": {
-    "bananass": "^0.7.0"
+    "bananass": "^0.8.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-bananass",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-bananass",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "workspaces": [
         ".",
         "examples/*",
@@ -20,7 +20,7 @@
         "c8": "^11.0.0",
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.7.0",
+        "eslint-config-bananass": "^0.8.0",
         "eslint-markdown": "^0.12.1",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
@@ -39,25 +39,25 @@
     "examples/solutions-bananass-cjs": {
       "name": "examples-solutions-bananass-cjs",
       "devDependencies": {
-        "bananass": "^0.7.0"
+        "bananass": "^0.8.0"
       }
     },
     "examples/solutions-bananass-cts": {
       "name": "examples-solutions-bananass-cts",
       "devDependencies": {
-        "bananass": "^0.7.0"
+        "bananass": "^0.8.0"
       }
     },
     "examples/solutions-bananass-mjs": {
       "name": "examples-solutions-bananass-mjs",
       "devDependencies": {
-        "bananass": "^0.7.0"
+        "bananass": "^0.8.0"
       }
     },
     "examples/solutions-bananass-mts": {
       "name": "examples-solutions-bananass-mts",
       "devDependencies": {
-        "bananass": "^0.7.0"
+        "bananass": "^0.8.0"
       }
     },
     "examples/solutions-readline-cjs": {
@@ -13727,7 +13727,7 @@
       }
     },
     "packages/bananass": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.29.7",
@@ -13735,7 +13735,7 @@
         "@babel/plugin-transform-typescript": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "babel-loader": "^10.1.1",
-        "bananass-utils-console": "^0.7.0",
+        "bananass-utils-console": "^0.8.0",
         "commander": "^15.0.0",
         "defu": "^6.1.7",
         "enhanced-resolve": "^5.24.0",
@@ -13761,7 +13761,7 @@
       }
     },
     "packages/bananass-utils-console": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "engines": {
         "node": "^22.23.0 || ^24.15.0 || >=26.0.0"
@@ -13771,10 +13771,10 @@
       }
     },
     "packages/create-bananass": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "bananass-utils-console": "^0.7.0",
+        "bananass-utils-console": "^0.8.0",
         "commander": "^15.0.0",
         "consola": "^3.4.2"
       },
@@ -13791,9 +13791,9 @@
     "packages/create-bananass/templates/javascript-cjs": {
       "name": "create-bananass-javascript-cjs",
       "devDependencies": {
-        "bananass": "^0.7.0",
+        "bananass": "^0.8.0",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.7.0",
+        "eslint-config-bananass": "^0.8.0",
         "prettier": "^3.9.4"
       },
       "engines": {
@@ -13803,9 +13803,9 @@
     "packages/create-bananass/templates/javascript-esm": {
       "name": "create-bananass-javascript-esm",
       "devDependencies": {
-        "bananass": "^0.7.0",
+        "bananass": "^0.8.0",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.7.0",
+        "eslint-config-bananass": "^0.8.0",
         "prettier": "^3.9.4"
       },
       "engines": {
@@ -13816,9 +13816,9 @@
       "name": "create-bananass-typescript-cjs",
       "devDependencies": {
         "@types/node": "^22.20.0",
-        "bananass": "^0.7.0",
+        "bananass": "^0.8.0",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.7.0",
+        "eslint-config-bananass": "^0.8.0",
         "jiti": "^2.7.0",
         "prettier": "^3.9.4",
         "typescript": "^6.0.3"
@@ -13831,9 +13831,9 @@
       "name": "create-bananass-typescript-esm",
       "devDependencies": {
         "@types/node": "^22.20.0",
-        "bananass": "^0.7.0",
+        "bananass": "^0.8.0",
         "eslint": "^9.39.4",
-        "eslint-config-bananass": "^0.7.0",
+        "eslint-config-bananass": "^0.8.0",
         "jiti": "^2.7.0",
         "prettier": "^3.9.4",
         "typescript": "^6.0.3"
@@ -13843,7 +13843,7 @@
       }
     },
     "packages/eslint-config-bananass": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/json": "^0.14.0",
@@ -13889,24 +13889,24 @@
     },
     "tests": {
       "devDependencies": {
-        "bananass": "^0.7.0",
-        "bananass-utils-console": "^0.7.0",
-        "create-bananass": "^0.7.0",
-        "eslint-config-bananass": "^0.7.0"
+        "bananass": "^0.8.0",
+        "bananass-utils-console": "^0.8.0",
+        "create-bananass": "^0.8.0",
+        "eslint-config-bananass": "^0.8.0"
       }
     },
     "websites/eslint-config-bananass": {
       "name": "websites-eslint-config-bananass",
       "devDependencies": {
         "@eslint/config-inspector": "^3.0.4",
-        "eslint-config-bananass": "^0.7.0"
+        "eslint-config-bananass": "^0.8.0"
       }
     },
     "websites/vitepress": {
       "name": "websites-vitepress",
       "devDependencies": {
         "@codecov/vite-plugin": "^2.0.1",
-        "bananass": "^0.7.0",
+        "bananass": "^0.8.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "vitepress": "2.0.0-alpha.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-bananass",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "packageManager": "npm@10.9.8",
   "engines": {
@@ -78,7 +78,7 @@
     "c8": "^11.0.0",
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.7.0",
+    "eslint-config-bananass": "^0.8.0",
     "eslint-markdown": "^0.12.1",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",

--- a/packages/bananass-utils-console/package.json
+++ b/packages/bananass-utils-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass-utils-console",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Console Utilities for Bananass Framework.🍌",
   "exports": {

--- a/packages/bananass/package.json
+++ b/packages/bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bananass",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Baekjoon Framework for JavaScript.🍌",
   "exports": {
@@ -93,7 +93,7 @@
     "@babel/plugin-transform-typescript": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "babel-loader": "^10.1.1",
-    "bananass-utils-console": "^0.7.0",
+    "bananass-utils-console": "^0.8.0",
     "commander": "^15.0.0",
     "defu": "^6.1.7",
     "enhanced-resolve": "^5.24.0",

--- a/packages/create-bananass/package.json
+++ b/packages/create-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bananass",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Create a Bananass framework project for solving Baekjoon problems with JavaScript/TypeScript.🍌",
   "exports": {
@@ -57,7 +57,7 @@
     "dev": "node src/cli.js"
   },
   "dependencies": {
-    "bananass-utils-console": "^0.7.0",
+    "bananass-utils-console": "^0.8.0",
     "commander": "^15.0.0",
     "consola": "^3.4.2"
   }

--- a/packages/create-bananass/templates/javascript-cjs/package.json
+++ b/packages/create-bananass/templates/javascript-cjs/package.json
@@ -21,9 +21,9 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.7.0",
+    "bananass": "^0.8.0",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.7.0",
+    "eslint-config-bananass": "^0.8.0",
     "prettier": "^3.9.4"
   }
 }

--- a/packages/create-bananass/templates/javascript-esm/package.json
+++ b/packages/create-bananass/templates/javascript-esm/package.json
@@ -21,9 +21,9 @@
     "prettier:fix": "prettier . --write --ignore-unknown"
   },
   "devDependencies": {
-    "bananass": "^0.7.0",
+    "bananass": "^0.8.0",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.7.0",
+    "eslint-config-bananass": "^0.8.0",
     "prettier": "^3.9.4"
   }
 }

--- a/packages/create-bananass/templates/typescript-cjs/package.json
+++ b/packages/create-bananass/templates/typescript-cjs/package.json
@@ -23,9 +23,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.20.0",
-    "bananass": "^0.7.0",
+    "bananass": "^0.8.0",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.7.0",
+    "eslint-config-bananass": "^0.8.0",
     "jiti": "^2.7.0",
     "prettier": "^3.9.4",
     "typescript": "^6.0.3"

--- a/packages/create-bananass/templates/typescript-esm/package.json
+++ b/packages/create-bananass/templates/typescript-esm/package.json
@@ -23,9 +23,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.20.0",
-    "bananass": "^0.7.0",
+    "bananass": "^0.8.0",
     "eslint": "^9.39.4",
-    "eslint-config-bananass": "^0.7.0",
+    "eslint-config-bananass": "^0.8.0",
     "jiti": "^2.7.0",
     "prettier": "^3.9.4",
     "typescript": "^6.0.3"

--- a/packages/eslint-config-bananass/package.json
+++ b/packages/eslint-config-bananass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bananass",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "ESLint Config for Bananass Framework.🍌",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,9 +6,9 @@
     "test": "node --test"
   },
   "devDependencies": {
-    "bananass": "^0.7.0",
-    "bananass-utils-console": "^0.7.0",
-    "create-bananass": "^0.7.0",
-    "eslint-config-bananass": "^0.7.0"
+    "bananass": "^0.8.0",
+    "bananass-utils-console": "^0.8.0",
+    "create-bananass": "^0.8.0",
+    "eslint-config-bananass": "^0.8.0"
   }
 }

--- a/websites/eslint-config-bananass/package.json
+++ b/websites/eslint-config-bananass/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^3.0.4",
-    "eslint-config-bananass": "^0.7.0"
+    "eslint-config-bananass": "^0.8.0"
   }
 }

--- a/websites/vitepress/package.json
+++ b/websites/vitepress/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^2.0.1",
-    "bananass": "^0.7.0",
+    "bananass": "^0.8.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "2.0.0-alpha.17",


### PR DESCRIPTION
## Release Information: `v0.8.0`

New release of `lumirlumir/npm-bananass` has arrived! :tada:

This PR bumps the package versions from `v0.7.0` to `v0.8.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-bananass/actions/runs/29672881213) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-bananass` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | 1a6bc58       |
| Old Version | `v0.7.0`  |
| New Version | `v0.8.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* feat(*)!: require Node.js `^22.23.0 || ^24.15.0 || >=26.0.0` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1068
### :bug: Bug Fixes
* fix(eslint-config-bananass): bump the typescript-eslint group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1035
* fix(deps): bump enhanced-resolve from 5.22.1 to 5.22.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1040
* fix(deps): bump enhanced-resolve from 5.23.0 to 5.24.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1052
* fix(*): update `commander` to v15 by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1070
### :toolbox: Chores
* chore(*): enable more precise markdown linting by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1042
* chore(sync-server): update `actions/checkout` and `.nvmrc` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1066
* chore(sync-server): update `actions/checkout` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1067
* chore(*): update `devDependencies` by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1069
* chore(*): enforce allowed solution headings by @lumirlumir in https://github.com/lumirlumir/npm-bananass/pull/1071
### :arrow_up: Dependency Updates
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1039
* chore(deps): bump enhanced-resolve from 5.22.2 to 5.23.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1045
* chore(deps-dev): bump the dev-dependencies group across 3 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1044
* chore(deps): bump codecov/codecov-action from 6 to 7 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1043
* chore(deps-dev): bump the dev-dependencies group across 5 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1048
* chore(deps): bump the next group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1047
* chore(deps-dev): bump the dev-dependencies group across 3 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1049
* chore(deps): bump eslint-plugin-n from 18.0.1 to 18.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1053
* chore(deps-dev): bump undici from 6.26.0 to 6.27.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1065
* chore(deps): bump actions/checkout from 6 to 7 by @dependabot[bot] in https://github.com/lumirlumir/npm-bananass/pull/1062


**Full Changelog**: https://github.com/lumirlumir/npm-bananass/compare/v0.7.0...v0.8.0