### PR TITLE
build(*): exclude root from workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "npm-bananass",
       "version": "0.8.0",
       "workspaces": [
-        ".",
         "examples/*",
         "packages/*",
         "packages/create-bananass/templates/*",
@@ -20,7 +19,7 @@
         "c8": "^12.0.0",
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.5",
-        "eslint-config-bananass": "^0.8.0",
+        "eslint-config-bananass": "file:packages/eslint-config-bananass",
         "eslint-markdown": "^0.12.1",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
@@ -9657,10 +9656,6 @@
       "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/npm-bananass": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     }
   },
   "workspaces": [
-    ".",
     "examples/*",
     "packages/*",
     "packages/create-bananass/templates/*",
@@ -81,7 +80,7 @@
     "c8": "^12.0.0",
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.5",
-    "eslint-config-bananass": "^0.8.0",
+    "eslint-config-bananass": "file:packages/eslint-config-bananass",
     "eslint-markdown": "^0.12.1",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",


### PR DESCRIPTION
This pull request makes two key changes to the `package.json` file to improve workspace management and dependency resolution. The most important updates are:

Workspace configuration:

* Removed the `"."` entry from the `workspaces` array, so the root directory is no longer treated as a workspace.

Dependency management:

* Updated the `eslint-config-bananass` dependency to use a local file reference (`"file:packages/eslint-config-bananass"`) instead of a version from the npm registry, ensuring the local package is used during development.